### PR TITLE
Add Easter egg to README for the curious explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,3 +324,37 @@ Browser                   Worker (:8787)              GitHub/Google
 ## License
 
 MIT
+
+---
+
+<details>
+<summary>🎉 You found the Easter egg! Click to reveal...</summary>
+
+```
+    _______________
+   /               \
+  /  AGENT OPS HQ  \
+ /___________________\
+        |  |
+        |  |
+   _____|  |_____
+  |  __________  |
+  | |          | |
+  | | > █      | |    "I'm in."
+  | |__________| |
+  |   _______ ___|
+  |  |       |   |
+  |  | BEEP  |   |    *hacker voice*
+  |  | BOOP  |   |
+  |__|_______|___|
+
+Fun fact: This entire platform was bootstrapped 
+by an AI agent... running inside its own platform.
+We've achieved agent-ception. 🤖
+
+Built with ☕ and an unhealthy amount of Durable Objects.
+```
+
+**Achievement Unlocked**: *README Completionist*
+
+</details>


### PR DESCRIPTION
## Summary

Adds a hidden Easter egg at the bottom of the README for developers who read all the way to the end.

## What's New

- Hidden `<details>` tag at the end of README containing:
  - ASCII art of "Agent Ops HQ" (a computer terminal)
  - Meta joke about agent-ception (an AI agent bootstrapping its own platform)
  - Achievement unlock message for README completionists

## Why?

Every serious coding project needs a touch of whimsy. This Easter egg:
- ✅ Rewards curious developers who actually read documentation
- ✅ Stays collapsed by default (not intrusive)
- ✅ Maintains professional tone while adding personality
- ✅ Is actually kind of meta and true (the irony is delicious)

## Preview

The Easter egg is hidden behind a collapsible section and won't be visible unless someone clicks to reveal it. Perfect for those who appreciate the little details.

---

*No agents were harmed in the making of this pull request.*