### PR TITLE
Add programming joke to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A hosted background coding agent platform. Users interact with an AI coding agent through a web UI or Slack. Each session runs in an isolated Modal sandbox with a full dev environment — VS Code, browser via VNC, terminal, and an OpenCode agent.
 
+> **Why do programmers prefer dark mode?** Because light attracts bugs.
+
 ## Architecture
 
 ```mermaid


### PR DESCRIPTION
## Summary

Added a light-hearted programming joke about dark mode to the README to make it more engaging for developers.

## Changes

- Added joke after the project description: "Why do programmers prefer dark mode? Because light attracts bugs."

This is a classic developer joke that fits well with the project's technical nature and adds a bit of personality to the documentation.