### PR TITLE
Fix: Enable persistent browser sessions

### DIFF
--- a/backend/images/base.py
+++ b/backend/images/base.py
@@ -127,6 +127,7 @@ def get_base_image() -> modal.Image:
                 # Force image rebuild on deploy (change this value to trigger rebuild)
                 "IMAGE_BUILD_VERSION": "2026-02-09-v107-browser-timeout",
                 "AGENT_BROWSER_EXECUTABLE_PATH": "/usr/bin/chromium",
+                "AGENT_BROWSER_PROFILE": "/root/.agent-browser-profile",
             }
         )
     )


### PR DESCRIPTION
## Problem
Browser sessions were not persisting when closing and reopening the browser. This was caused by the `AGENT_BROWSER_PROFILE` environment variable never being set, which meant the browser always started with a fresh profile.

## Solution
Added the `AGENT_BROWSER_PROFILE` environment variable in `/backend/images/base.py` with the value `/root/.agent-browser-profile`. This ensures browser profiles are persisted to disk and restored when the browser is reopened.

## Changes
- Added `AGENT_BROWSER_PROFILE: /root/.agent-browser-profile` to the environment variables in the Modal base image definition

## Testing
After deploying this change, browser sessions should persist cookies, local storage, and session state across browser restarts.