### PR TITLE
Add Supabase and Notion integration beans

### DIFF
--- a/.beans/agent-ops-not1--notion-integration.md
+++ b/.beans/agent-ops-not1--notion-integration.md
@@ -1,0 +1,37 @@
+---
+# agent-ops-not1
+title: Notion Integration
+status: todo
+type: task
+priority: high
+tags:
+    - phase4
+    - notion
+    - worker
+    - documentation
+created_at: 2026-02-12T18:00:00Z
+updated_at: 2026-02-12T18:00:00Z
+parent: null
+---
+
+Notion integration for documentation and knowledge management:
+- Notion OAuth flow (frontend + worker callback)
+- Store access token encrypted in D1
+- Sync Notion pages and databases relevant to projects
+- Index page content for semantic search
+- Extract technical documentation, specs, and meeting notes
+- Bidirectional sync: update Notion from agent sessions (optional)
+- Support for code blocks, databases, and relations
+
+**Why it's needed:**
+Teams use Notion as their single source of truth for documentation, specs, and project planning. Integrating Notion allows the AI agent to access critical context like API documentation, architecture decisions, and requirements without users manually copying content. This bridges the gap between planning/docs and implementation, enabling the agent to generate code that aligns with documented specifications and update documentation based on code changes.
+
+Acceptance criteria:
+- Notion OAuth install flow works
+- Access token stored encrypted in D1
+- API endpoints to list accessible pages and databases
+- Page content sync with structured block parsing
+- Full-text search across synced Notion content
+- Semantic indexing for context retrieval
+- Context injection into agent sessions based on relevance
+- Optional bidirectional updates (Notion ←→ agent sessions)

--- a/.beans/agent-ops-sup1--supabase-integration.md
+++ b/.beans/agent-ops-sup1--supabase-integration.md
@@ -1,0 +1,36 @@
+---
+# agent-ops-sup1
+title: Supabase Integration
+status: todo
+type: task
+priority: high
+tags:
+    - phase4
+    - supabase
+    - worker
+    - database
+created_at: 2026-02-12T18:00:00Z
+updated_at: 2026-02-12T18:00:00Z
+parent: null
+---
+
+Supabase integration for database management and authentication:
+- Supabase OAuth flow (frontend + worker callback)
+- Store access token encrypted in D1
+- Connect to user's Supabase projects via Management API
+- List databases, tables, and schemas for context injection
+- Execute read-only SQL queries for database exploration
+- Sync database schema snapshots for session context
+- Display database metrics (size, row counts, connection info)
+
+**Why it's needed:**
+Many users store their application data in Supabase. Integrating Supabase allows the AI agent to understand the database schema, query data for debugging, and suggest schema improvements. This enables richer context-aware coding assistance, especially for full-stack applications where database structure impacts code decisions.
+
+Acceptance criteria:
+- Supabase OAuth install flow works
+- Access token stored encrypted in D1
+- API endpoints to list user's Supabase projects
+- Database schema introspection and sync
+- Read-only SQL query execution (with safety limits)
+- Database context injectable into agent sessions
+- Webhook or polling for schema change detection


### PR DESCRIPTION
## Summary

Adds two new integration beans for Phase 4 integrations:

### Supabase Integration (agent-ops-sup1)
- OAuth flow for authentication
- Encrypted token storage in D1
- Database introspection and schema sync
- Read-only SQL query execution
- Context injection into agent sessions

**Why:** Enables AI agents to understand database schemas, query data for debugging, and provide context-aware coding assistance for full-stack applications.

### Notion Integration (agent-ops-not1)
- OAuth flow for authentication
- Encrypted token storage in D1
- Page/database sync with semantic indexing
- Full-text search across documentation
- Optional bidirectional sync

**Why:** Bridges the gap between planning/docs and implementation by giving agents access to specifications, API docs, and project requirements stored in Notion.

Both integrations follow the established pattern used by Linear (agent-ops-areq) and GitHub integrations.