### PR TITLE
fix(client): remove rehypeRaw from markdown pipeline to reduce XSS risk

### DIFF
--- a/packages/client/XSS-TEST-CASES.md
+++ b/packages/client/XSS-TEST-CASES.md
@@ -1,0 +1,159 @@
+# XSS Test Cases for Markdown Rendering
+
+## Overview
+This document outlines XSS attack vectors to verify that the markdown rendering pipeline (without `rehypeRaw`) properly prevents execution of malicious payloads.
+
+## Test Cases
+
+### 1. Script Tag Injection
+```markdown
+<script>alert('XSS')</script>
+```
+**Expected**: Script tags are not parsed/executed. Text rendered as literal markdown.
+
+### 2. IMG onerror Handler
+```markdown
+<img src="invalid" onerror="alert('XSS')">
+```
+**Expected**: HTML not parsed; rendered as text or stripped.
+
+### 3. SVG with Script
+```markdown
+<svg onload="alert('XSS')">
+```
+**Expected**: SVG not parsed/executed.
+
+### 4. JavaScript Protocol in Link
+```markdown
+[Click me](javascript:alert('XSS'))
+```
+**Expected**: Link href sanitized; javascript: protocol blocked.
+
+### 5. Data URI with Script
+```markdown
+<iframe src="data:text/html,<script>alert('XSS')</script>">
+```
+**Expected**: iframe not rendered.
+
+### 6. Style Injection
+```markdown
+<div style="background:url('javascript:alert(1)')">
+```
+**Expected**: Style attribute with javascript: blocked or not parsed.
+
+### 7. Object/Embed Tags
+```markdown
+<object data="javascript:alert('XSS')">
+<embed src="javascript:alert('XSS')">
+```
+**Expected**: Tags not parsed/executed.
+
+### 8. HTML Event Handlers
+```markdown
+<div onclick="alert('XSS')">Click me</div>
+<body onload="alert('XSS')">
+```
+**Expected**: Event handler attributes stripped or not parsed.
+
+## Legitimate Use Cases (Should Still Work)
+
+### 1. Safe Markdown Images
+```markdown
+![Alt text](https://example.com/image.png)
+```
+**Expected**: Image renders correctly via custom `MarkdownImage` component.
+
+### 2. Data URI Images (Base64)
+```markdown
+![Base64](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==)
+```
+**Expected**: Base64 images allowed per sanitize schema.
+
+### 3. Code Blocks
+```markdown
+\`\`\`javascript
+console.log('This is code, not execution');
+\`\`\`
+```
+**Expected**: Rendered in `CodeBlock` component with syntax highlighting.
+
+### 4. Mermaid Diagrams
+```markdown
+\`\`\`mermaid
+graph TD;
+    A-->B;
+\`\`\`
+```
+**Expected**: Rendered via `MermaidBlock` component.
+
+### 5. Safe Links
+```markdown
+[Safe link](https://example.com)
+```
+**Expected**: Link opens in new tab with `rel="noopener noreferrer"`.
+
+### 6. Inline Code
+```markdown
+This is `inline code` in a sentence.
+```
+**Expected**: Styled inline code span.
+
+### 7. Standard Markdown Formatting
+```markdown
+**Bold**, *italic*, ~~strikethrough~~
+
+- List item 1
+- List item 2
+
+> Blockquote
+```
+**Expected**: All standard markdown features work correctly.
+
+## Manual Verification Steps
+
+1. Start dev server: `pnpm dev` from root
+2. Navigate to a chat interface
+3. Send messages containing each test case above
+4. Verify:
+   - No JavaScript execution (no alert dialogs)
+   - No console errors related to XSS attempts
+   - Legitimate markdown renders correctly
+   - Malicious payloads are either stripped or rendered as plain text
+
+## Future Automated Testing
+
+To add automated tests, the client package needs:
+- Testing library setup (vitest + @testing-library/react)
+- jsdom or happy-dom environment
+- React component test utilities
+
+Test file location: `packages/client/src/components/chat/markdown/__tests__/markdown-content.test.tsx`
+
+Example test structure:
+```typescript
+import { render } from '@testing-library/react';
+import { MarkdownContent } from '../markdown-content';
+
+describe('MarkdownContent XSS Protection', () => {
+  it('should not execute script tags', () => {
+    const xssPayload = '<script>alert("XSS")</script>';
+    const { container } = render(<MarkdownContent content={xssPayload} />);
+    
+    // Verify no script tag in DOM
+    expect(container.querySelector('script')).toBeNull();
+  });
+  
+  // Additional test cases...
+});
+```
+
+## Sanitization Schema
+
+Current schema (in `markdown-content.tsx`):
+- Extends `defaultSchema` from `rehype-sanitize`
+- Allows `data:image/*` URIs on `img.src` for base64 screenshots
+- Allows `https?://` protocols on `img.src`
+
+The schema should be reviewed periodically against:
+- [OWASP XSS Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+- [rehype-sanitize documentation](https://github.com/rehypejs/rehype-sanitize)

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,7 +29,6 @@
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.5.2",
     "recharts": "^3.7.0",
-    "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^3.21.0",

--- a/packages/client/src/components/chat/markdown/markdown-content.tsx
+++ b/packages/client/src/components/chat/markdown/markdown-content.tsx
@@ -1,7 +1,6 @@
 import { memo, useMemo, createContext, useContext, type ComponentProps } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import type { Components } from 'react-markdown';
 import { CodeBlock } from './code-block';
@@ -24,7 +23,7 @@ const sanitizeSchema = {
 };
 
 const remarkPlugins = [remarkGfm];
-const rehypePlugins = [rehypeRaw, [rehypeSanitize, sanitizeSchema]] as ComponentProps<typeof ReactMarkdown>['rehypePlugins'];
+const rehypePlugins = [[rehypeSanitize, sanitizeSchema]] as ComponentProps<typeof ReactMarkdown>['rehypePlugins'];
 
 function MermaidOrPlaceholder({ code }: { code: string }) {
   const isStreaming = useContext(StreamingContext);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       recharts:
         specifier: ^3.7.0
         version: 3.7.0(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.4)(react@19.2.3)(redux@5.0.1)
-      rehype-raw:
-        specifier: ^7.0.0
-        version: 7.0.0
       rehype-sanitize:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2539,10 +2536,6 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  entities@6.0.1:
-    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
-    engines: {node: '>=0.12'}
-
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
@@ -2707,15 +2700,6 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hast-util-from-parse5@8.0.3:
-    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
-
-  hast-util-parse-selector@4.0.0:
-    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
-
-  hast-util-raw@9.1.0:
-    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
-
   hast-util-sanitize@5.0.2:
     resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
 
@@ -2725,14 +2709,8 @@ packages:
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
-  hast-util-to-parse5@8.0.1:
-    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
-
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
-
-  hastscript@9.0.1:
-    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
   heic-to@1.4.2:
     resolution: {integrity: sha512-y69thwxfNcEm2Vk8lbOD/cMabnvMJyOREfJYiCHcXCDqlfcPyJoBhyRc8+iDe1B95LRfpbTOpzxzY1xbRkdwBA==}
@@ -3129,9 +3107,6 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
-  parse5@7.3.0:
-    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
-
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
@@ -3355,9 +3330,6 @@ packages:
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
-
-  rehype-raw@7.0.0:
-    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
 
   rehype-sanitize@6.0.0:
     resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
@@ -3691,9 +3663,6 @@ packages:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
-  vfile-location@5.0.3:
-    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
-
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
@@ -3796,9 +3765,6 @@ packages:
 
   vscode-uri@3.0.8:
     resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
-
-  web-namespaces@2.0.1:
-    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -5850,8 +5816,6 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  entities@6.0.1: {}
-
   es-module-lexer@1.7.0: {}
 
   es-toolkit@1.44.0: {}
@@ -6077,37 +6041,6 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hast-util-from-parse5@8.0.3:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
-      devlop: 1.1.0
-      hastscript: 9.0.1
-      property-information: 7.1.0
-      vfile: 6.0.3
-      vfile-location: 5.0.3
-      web-namespaces: 2.0.1
-
-  hast-util-parse-selector@4.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-
-  hast-util-raw@9.1.0:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
-      '@ungap/structured-clone': 1.3.0
-      hast-util-from-parse5: 8.0.3
-      hast-util-to-parse5: 8.0.1
-      html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.2.1
-      parse5: 7.3.0
-      unist-util-position: 5.0.0
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-      web-namespaces: 2.0.1
-      zwitch: 2.0.4
-
   hast-util-sanitize@5.0.2:
     dependencies:
       '@types/hast': 3.0.4
@@ -6148,27 +6081,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  hast-util-to-parse5@8.0.1:
-    dependencies:
-      '@types/hast': 3.0.4
-      comma-separated-tokens: 2.0.3
-      devlop: 1.1.0
-      property-information: 7.1.0
-      space-separated-tokens: 2.0.2
-      web-namespaces: 2.0.1
-      zwitch: 2.0.4
-
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
-
-  hastscript@9.0.1:
-    dependencies:
-      '@types/hast': 3.0.4
-      comma-separated-tokens: 2.0.3
-      hast-util-parse-selector: 4.0.0
-      property-information: 7.1.0
-      space-separated-tokens: 2.0.2
 
   heic-to@1.4.2: {}
 
@@ -6762,10 +6677,6 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
-  parse5@7.3.0:
-    dependencies:
-      entities: 6.0.1
-
   path-data-parser@0.1.0: {}
 
   path-parse@1.0.7: {}
@@ -6997,12 +6908,6 @@ snapshots:
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
-
-  rehype-raw@7.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-      hast-util-raw: 9.1.0
-      vfile: 6.0.3
 
   rehype-sanitize@6.0.0:
     dependencies:
@@ -7448,11 +7353,6 @@ snapshots:
 
   uuid@11.1.0: {}
 
-  vfile-location@5.0.3:
-    dependencies:
-      '@types/unist': 3.0.3
-      vfile: 6.0.3
-
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -7547,8 +7447,6 @@ snapshots:
       vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.0.8: {}
-
-  web-namespaces@2.0.1: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
## Summary

Removes `rehypeRaw` from the markdown rendering pipeline to reduce XSS attack surface, per security issue #14.

## Changes

- ✅ Removed `rehypeRaw` import and plugin from `markdown-content.tsx`
- ✅ Removed `rehype-raw` dependency from `package.json`
- ✅ Updated `pnpm-lock.yaml`
- ✅ Added `XSS-TEST-CASES.md` with verification steps and test scenarios

## Security Rationale

Even with `rehype-sanitize` active, parsing raw HTML from model/user content:
- Increases complexity and maintenance burden
- Opens potential for sanitization bypass bugs
- Is unnecessary for legitimate markdown use cases

Standard markdown constructs (images, links, code blocks, mermaid diagrams) all work correctly through safe component rendering without needing raw HTML support.

## What Still Works

- ✅ Images via markdown syntax (including data URIs for base64)
- ✅ Links with proper `target="_blank"` and security attributes
- ✅ Code blocks with syntax highlighting
- ✅ Mermaid diagrams
- ✅ GFM features (tables, strikethrough, task lists)
- ✅ All standard markdown formatting

## Testing

Manual verification steps are documented in `packages/client/XSS-TEST-CASES.md`, covering:
- Common XSS vectors (script tags, onerror handlers, javascript: protocols, etc.)
- Legitimate use cases that should continue working
- Future automated test structure

## Next Steps

To add automated tests, the client package needs:
- Testing library setup (vitest + @testing-library/react)
- jsdom/happy-dom environment
- React component test utilities

This can be done in a follow-up PR to keep changes focused.

Closes #14