### PR TITLE
docs: add Turnkey SSH signing design

### DIFF
--- a/.beans/valet-gs3k--git-commit-signing.md
+++ b/.beans/valet-gs3k--git-commit-signing.md
@@ -1,18 +1,28 @@
 ---
 # valet-gs3k
 title: Git Commit Signing
-status: exploratory
+status: planned
 type: design-brief
-priority: medium
+priority: high
 tags:
     - security
     - git
     - signing
+    - ssh
+    - turnkey
 created_at: 2026-03-05T00:00:00Z
-updated_at: 2026-03-05T00:00:00Z
+updated_at: 2026-03-06T00:00:00Z
 ---
 
 Some organizations require all commits (including merge commits) to be cryptographically signed, with signing keys custodied on hardware security devices (e.g. YubiKeys). Valet makes commits inside remote sandboxes where the user's hardware key is physically unreachable. We need a model that satisfies signed-commit policies without requiring users to abandon Valet or weaken their security posture.
+
+## Decision
+
+We will pursue SSH-based commit signing using Turnkey 2-of-2 co-signing with
+automated enrollment. See:
+
+- Bean: `.beans/valet-ssh2of2--enterprise-ssh-signing-architecture.md`
+- Design: `docs/plans/2026-03-06-ssh-2of2-commit-signing-design.md`
 
 ## Current State
 
@@ -162,8 +172,6 @@ Git supports three signing formats. The choice affects what key types work and h
 
 ## Recommendation
 
-No single approach is recommended yet. The decision depends on the security posture assessment. However, the approaches are not mutually exclusive — Valet could support a configurable signing backend per org:
-
-- **Default:** Approach 1 (platform-managed keys) for orgs that just need "Verified" badges
-- **Strict:** Approach 2 (Turnkey co-signing) for orgs with hardware-custody mandates
-- **Keyless:** Approach 3 (Sigstore) for orgs that accept OIDC-based identity attestation
+The chosen direction is **Approach 2 (Turnkey co-signing)** with SSH signing
+format and per-push approvals. Other approaches remain documented for future
+trade-offs, but current execution should follow the Turnkey architecture.

--- a/.beans/valet-ssh2of2--enterprise-ssh-signing-architecture.md
+++ b/.beans/valet-ssh2of2--enterprise-ssh-signing-architecture.md
@@ -1,0 +1,107 @@
+---
+# valet-ssh2of2
+title: Enterprise SSH Commit Signing (Turnkey 2-of-2)
+status: planned
+type: major-feature
+priority: critical
+tags:
+  - security
+  - enterprise
+  - git
+  - ssh
+  - turnkey
+  - compliance
+created_at: 2026-03-06T00:00:00Z
+updated_at: 2026-03-06T00:00:00Z
+---
+
+## Summary
+
+Implement SSH-based Git commit signing with Turnkey 2-of-2 co-signing.
+
+- Private key generated and stored inside Turnkey secure enclave
+- Signing requires both:
+  - Valet API key
+  - User WebAuthn passkey approval
+- GitHub verifies commits via SSH signing key registered on the user account
+- No private key material exists in sandboxes
+
+Formal design doc: `docs/plans/2026-03-06-ssh-2of2-commit-signing-design.md`.
+
+## Goals
+
+- All Valet commits are cryptographically signed
+- GitHub shows "Verified" for those commits
+- Hardware-backed custody and user approval
+- Automated enrollment (no manual Turnkey setup)
+- Per-push approval by default
+- Merge commits are signed
+
+## Non-Goals
+
+- OpenPGP signing
+- Sigstore/gitsign
+- Bot-account signing
+- Per-commit approval
+
+## Architecture Summary
+
+### Key Lifecycle (Automated)
+
+1. Valet creates a Turnkey sub-org for the user
+2. Configure 2-of-2 quorum: user passkey + Valet API key
+3. Generate ECDSA P-256 key
+4. Export public key and convert to SSH format
+5. Register SSH signing key with GitHub
+6. Persist key metadata in Valet DB
+
+### Signing Flow (Per-Push)
+
+1. Agent creates unsigned commits
+2. Push requested -> Runner detects unsigned commits
+3. Signing request sent to SessionAgent DO
+4. Frontend shows signing modal; user approves via WebAuthn
+5. Worker calls Turnkey `signRawPayload`
+6. Worker constructs SSH signature envelope
+7. Signature returned to sandbox; commit signed
+8. Push proceeds
+
+### Merge Commits
+
+When signing is enforced, merges must be performed locally in the sandbox
+so the merge commit can be signed via Turnkey.
+
+## Components
+
+- **Sandbox:** `gpg.format=ssh`, `commit.gpgsign=true`, `gpg.program=valet-sign`
+- **Worker:** Turnkey integration + signing relay + SSH envelope construction
+- **SessionAgent DO:** signing state machine and approval workflow
+- **Frontend:** signing modal + WebAuthn ceremony
+
+## Data Model
+
+New tables:
+
+- `user_signing_profiles` (turnkey ids, github key ids, status)
+- `signing_events` (audit trail, outcome, timing)
+
+## Security Properties
+
+- Private key never exists in sandbox or Valet infrastructure
+- Valet cannot sign without user approval
+- User cannot sign without Valet API key
+- Turnkey provides audit trail
+
+## Implementation Phases
+
+1. Turnkey integration + enrollment pipeline
+2. Signing relay + SSH envelope construction
+3. UI modal + DO state machine
+4. Org policy flags + merge commit enforcement
+
+## Success Criteria
+
+- GitHub "Verified" badge on signed commits
+- Branch protection rule "Require signed commits" passes
+- Signing failure blocks push
+- WebAuthn approval required for each push

--- a/docs/plans/2026-03-06-ssh-2of2-commit-signing-design.md
+++ b/docs/plans/2026-03-06-ssh-2of2-commit-signing-design.md
@@ -1,0 +1,132 @@
+# SSH 2-of-2 Commit Signing Design
+
+Date: 2026-03-06
+Status: Draft (Approved)
+Owner: Valet Platform
+
+## Problem & Goals
+
+Valet currently produces unsigned commits from sandbox environments. Enterprise
+policies often require cryptographically signed commits and hardware-backed key
+custody. Sandboxes are ephemeral and cannot safely hold private key material.
+
+Goals:
+
+- Ensure all Valet commits are signed and show GitHub "Verified".
+- Use hardware-backed custody with user approval.
+- Keep private keys out of sandboxes and Valet infrastructure.
+- Automate enrollment and key registration.
+- Default to per-push approval and sign merge commits.
+
+Non-goals:
+
+- OpenPGP signing.
+- Sigstore/gitsign.
+- Bot-account signing.
+- Per-commit approval.
+
+## Architecture & Key Lifecycle
+
+### Signing Format
+
+Use Git SSH signing:
+
+- `gpg.format=ssh`
+- `commit.gpgsign=true`
+- `gpg.program=valet-sign`
+
+SSH is chosen because Turnkey returns raw ECDSA signatures and GitHub natively
+verifies SSH signing keys.
+
+### Automated Enrollment
+
+Enrollment is fully automated by Valet:
+
+1. Create a Turnkey sub-organization for the user.
+2. Configure 2-of-2 quorum: user passkey + Valet API key.
+3. Generate an ECDSA P-256 key inside Turnkey.
+4. Export the public key, convert to SSH format.
+5. Register the SSH signing key with GitHub for the user.
+6. Persist key metadata in Valet DB.
+
+No private key material is ever exported to Valet or sandboxes.
+
+## Signing Flow & UX
+
+### Per-Push Signing (Default)
+
+1. Agent creates unsigned commits.
+2. User initiates push.
+3. Runner detects unsigned commits and creates a signing request.
+4. SessionAgent DO enters `awaiting_approval` and notifies the frontend.
+5. Frontend presents a signing modal with repo, branch, and commit list.
+6. User approves via WebAuthn passkey.
+7. Worker calls Turnkey `signRawPayload` and receives raw ECDSA signature.
+8. Worker constructs SSH signature envelope and returns it to the sandbox.
+9. Sandbox finalizes signatures and push continues.
+
+### Merge Commits
+
+When signing is enforced, merge commits must be created locally in the sandbox
+so they can be signed via Turnkey. GitHub API merges are not used for strict
+signing policies because GitHub would sign with its own key.
+
+### Failure Handling
+
+- User rejects or times out: abort push, keep unsigned commits.
+- Turnkey failure: abort push, surface error with retry option.
+- Session destroyed mid-sign: abort and require retry.
+
+## Data Model, Security, and Rollout
+
+### Tables
+
+`user_signing_profiles`
+
+- id
+- user_id
+- turnkey_suborg_id
+- turnkey_key_id
+- github_key_id
+- status
+- created_at
+- revoked_at
+
+`signing_events`
+
+- id
+- session_id
+- user_id
+- repo
+- branch
+- commit_count
+- status
+- created_at
+- completed_at
+
+### Security Properties
+
+- Private keys never exist in sandboxes or Valet servers.
+- Valet cannot sign without user approval.
+- User cannot sign without Valet API key.
+- Turnkey provides an audit trail for all signing events.
+
+### Org Policy Flags
+
+- signing_enabled
+- signing_required
+- signing_policy (per_push, per_session)
+- signing_approver_policy (session_owner, last_prompter, designated)
+
+### Rollout
+
+1. Internal pilot with a single org.
+2. Enable for opt-in enterprises.
+3. Add org-level enforcement and merge-commit requirements.
+
+## Success Criteria
+
+- GitHub "Verified" badge for Valet commits.
+- Branch protection rule "Require signed commits" passes.
+- All signing requires WebAuthn approval.
+- Merge commits are signed via Turnkey.

--- a/docs/plans/2026-03-06-ssh-2of2-commit-signing-plan.md
+++ b/docs/plans/2026-03-06-ssh-2of2-commit-signing-plan.md
@@ -1,0 +1,472 @@
+# SSH 2-of-2 Commit Signing Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement SSH commit signing with Turnkey 2-of-2 co-signing and per-push WebAuthn approval.
+
+**Architecture:** Add signing enrollment + relay in worker, a DO approval state machine, runner signing orchestration, sandbox signer helper, and a frontend approval modal.
+
+**Tech Stack:** Cloudflare Worker (Hono), Durable Objects, React (TanStack), Bun runner, Turnkey API.
+
+---
+
+### Task 1: Add signing tables and schema
+
+**Files:**
+- Create: `packages/worker/migrations/0056_signing.sql`
+- Create: `packages/worker/src/lib/schema/signing.ts`
+- Modify: `packages/worker/src/lib/schema/index.ts`
+- Create: `packages/worker/src/lib/db/signing.ts`
+- Modify: `packages/worker/src/lib/db.ts`
+- Test: `packages/worker/src/lib/db/__tests__/signing.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createSigningProfile } from '../signing';
+
+describe('signing db', () => {
+  it('creates a signing profile', async () => {
+    const result = await createSigningProfile({
+      userId: 'user-1',
+      turnkeySuborgId: 'tk-suborg',
+      turnkeyKeyId: 'tk-key',
+      githubKeyId: 'gh-key',
+    });
+    expect(result.userId).toBe('user-1');
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm test --filter signing`
+Expected: FAIL with "createSigningProfile is not defined"
+
+**Step 3: Write minimal implementation**
+
+```sql
+-- packages/worker/migrations/0056_signing.sql
+CREATE TABLE user_signing_profiles (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  turnkey_suborg_id TEXT NOT NULL,
+  turnkey_key_id TEXT NOT NULL,
+  github_key_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  revoked_at TEXT
+);
+
+CREATE TABLE signing_events (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  repo TEXT NOT NULL,
+  branch TEXT NOT NULL,
+  commit_count INTEGER NOT NULL,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  completed_at TEXT
+);
+```
+
+```ts
+// packages/worker/src/lib/schema/signing.ts
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+
+export const userSigningProfiles = sqliteTable('user_signing_profiles', {
+  id: text('id').primaryKey(),
+  userId: text('user_id').notNull(),
+  turnkeySuborgId: text('turnkey_suborg_id').notNull(),
+  turnkeyKeyId: text('turnkey_key_id').notNull(),
+  githubKeyId: text('github_key_id').notNull(),
+  status: text('status').notNull(),
+  createdAt: text('created_at').notNull(),
+  revokedAt: text('revoked_at'),
+});
+
+export const signingEvents = sqliteTable('signing_events', {
+  id: text('id').primaryKey(),
+  sessionId: text('session_id').notNull(),
+  userId: text('user_id').notNull(),
+  repo: text('repo').notNull(),
+  branch: text('branch').notNull(),
+  commitCount: integer('commit_count').notNull(),
+  status: text('status').notNull(),
+  createdAt: text('created_at').notNull(),
+  completedAt: text('completed_at'),
+});
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm test --filter signing`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/worker/migrations/0056_signing.sql packages/worker/src/lib/schema/signing.ts packages/worker/src/lib/schema/index.ts packages/worker/src/lib/db/signing.ts packages/worker/src/lib/db.ts packages/worker/src/lib/db/__tests__/signing.test.ts
+git commit -m "feat(worker): add signing schema"
+```
+
+### Task 2: Add Turnkey client and signing service
+
+**Files:**
+- Create: `packages/worker/src/services/turnkey.ts`
+- Create: `packages/worker/src/services/signing.ts`
+- Test: `packages/worker/src/services/__tests__/signing.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { signCommitPayload } from '../signing';
+
+describe('signing service', () => {
+  it('wraps ssh signature', async () => {
+    const signature = await signCommitPayload({
+      payload: 'payload',
+      turnkeyKeyId: 'key',
+      userSignature: 'webauthn',
+    });
+    expect(signature).toContain('BEGIN SSH SIGNATURE');
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm test --filter signing service`
+Expected: FAIL with "signCommitPayload is not defined"
+
+**Step 3: Write minimal implementation**
+
+```ts
+// packages/worker/src/services/turnkey.ts
+export type TurnkeySignRequest = {
+  payload: string;
+  turnkeyKeyId: string;
+  userSignature: string;
+};
+
+export async function turnkeySignRaw(_req: TurnkeySignRequest) {
+  return { r: '00', s: '00' };
+}
+```
+
+```ts
+// packages/worker/src/services/signing.ts
+import { turnkeySignRaw } from './turnkey';
+
+export async function signCommitPayload(input: {
+  payload: string;
+  turnkeyKeyId: string;
+  userSignature: string;
+}) {
+  const raw = await turnkeySignRaw({
+    payload: input.payload,
+    turnkeyKeyId: input.turnkeyKeyId,
+    userSignature: input.userSignature,
+  });
+  return `-----BEGIN SSH SIGNATURE-----\n${raw.r}.${raw.s}\n-----END SSH SIGNATURE-----`;
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm test --filter signing service`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/worker/src/services/turnkey.ts packages/worker/src/services/signing.ts packages/worker/src/services/__tests__/signing.test.ts
+git commit -m "feat(worker): add turnkey signing service"
+```
+
+### Task 3: Add signing routes
+
+**Files:**
+- Create: `packages/worker/src/routes/signing.ts`
+- Modify: `packages/worker/src/index.ts`
+- Test: `packages/worker/src/routes/__tests__/signing.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { app } from '../../index';
+
+describe('signing routes', () => {
+  it('returns a signing request id', async () => {
+    const res = await app.request('/api/signing/request', { method: 'POST' });
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm test --filter signing routes`
+Expected: FAIL with 404
+
+**Step 3: Write minimal implementation**
+
+```ts
+// packages/worker/src/routes/signing.ts
+import { Hono } from 'hono';
+
+export const signingRouter = new Hono();
+
+signingRouter.post('/request', (c) => {
+  return c.json({ id: 'signing-request-id' });
+});
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm test --filter signing routes`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/worker/src/routes/signing.ts packages/worker/src/index.ts packages/worker/src/routes/__tests__/signing.test.ts
+git commit -m "feat(worker): add signing routes"
+```
+
+### Task 4: Add SessionAgent DO signing state machine
+
+**Files:**
+- Modify: `packages/worker/src/durable-objects/session-agent.ts`
+- Modify: `packages/shared/src/types/index.ts`
+- Test: `packages/worker/src/durable-objects/__tests__/session-agent-signing.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+
+describe('session agent signing state', () => {
+  it('transitions to awaiting_approval', async () => {
+    expect(true).toBe(false);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm test --filter session-agent signing`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+```ts
+// packages/shared/src/types/index.ts
+export type SigningState = 'idle' | 'awaiting_approval' | 'signing' | 'signed' | 'rejected' | 'timeout' | 'failed';
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm test --filter session-agent signing`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/worker/src/durable-objects/session-agent.ts packages/shared/src/types/index.ts packages/worker/src/durable-objects/__tests__/session-agent-signing.test.ts
+git commit -m "feat(worker): add signing state machine"
+```
+
+### Task 5: Add runner signing orchestration
+
+**Files:**
+- Create: `packages/runner/src/git-signing.ts`
+- Modify: `packages/runner/src/prompt.ts`
+- Test: `packages/runner/src/__tests__/git-signing.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { shouldSignBeforePush } from '../git-signing';
+
+describe('runner signing', () => {
+  it('requires signing when unsigned commits exist', () => {
+    expect(shouldSignBeforePush(['a'])).toBe(true);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm test --filter runner signing`
+Expected: FAIL with "shouldSignBeforePush is not defined"
+
+**Step 3: Write minimal implementation**
+
+```ts
+// packages/runner/src/git-signing.ts
+export function shouldSignBeforePush(commits: string[]) {
+  return commits.length > 0;
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm test --filter runner signing`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/runner/src/git-signing.ts packages/runner/src/prompt.ts packages/runner/src/__tests__/git-signing.test.ts
+git commit -m "feat(runner): add signing orchestration"
+```
+
+### Task 6: Add frontend signing modal
+
+**Files:**
+- Create: `packages/client/src/components/signing/SigningModal.tsx`
+- Create: `packages/client/src/api/signing.ts`
+- Modify: `packages/client/src/components/layout/app-shell.tsx`
+- Test: `packages/client/src/components/signing/SigningModal.test.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { SigningModal } from './SigningModal';
+
+it('renders signing details', () => {
+  render(<SigningModal open repo="valet" branch="main" commits={['a']} />);
+  expect(screen.getByText('valet')).toBeInTheDocument();
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm test --filter SigningModal`
+Expected: FAIL with "SigningModal is not defined"
+
+**Step 3: Write minimal implementation**
+
+```tsx
+// packages/client/src/components/signing/SigningModal.tsx
+export function SigningModal(props: {
+  open: boolean;
+  repo: string;
+  branch: string;
+  commits: string[];
+}) {
+  if (!props.open) return null;
+  return (
+    <div>
+      <h2>Sign commits</h2>
+      <div>{props.repo}</div>
+      <div>{props.branch}</div>
+    </div>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm test --filter SigningModal`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/client/src/components/signing/SigningModal.tsx packages/client/src/api/signing.ts packages/client/src/components/layout/app-shell.tsx packages/client/src/components/signing/SigningModal.test.tsx
+git commit -m "feat(client): add signing modal"
+```
+
+### Task 7: Add sandbox signer helper
+
+**Files:**
+- Create: `packages/runner/src/bin/valet-sign.ts`
+- Modify: `docker/start.sh`
+- Test: `packages/runner/src/bin/__tests__/valet-sign.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { formatSigningRequest } from '../valet-sign';
+
+describe('valet-sign', () => {
+  it('formats a signing request', () => {
+    expect(formatSigningRequest('payload')).toContain('payload');
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm test --filter valet-sign`
+Expected: FAIL with "formatSigningRequest is not defined"
+
+**Step 3: Write minimal implementation**
+
+```ts
+// packages/runner/src/bin/valet-sign.ts
+export function formatSigningRequest(payload: string) {
+  return JSON.stringify({ payload });
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm test --filter valet-sign`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/runner/src/bin/valet-sign.ts docker/start.sh packages/runner/src/bin/__tests__/valet-sign.test.ts
+git commit -m "feat(runner): add valet-sign helper"
+```
+
+### Task 8: End-to-end signing test
+
+**Files:**
+- Create: `packages/worker/src/routes/__tests__/signing-flow.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+
+describe('signing flow', () => {
+  it('blocks push without approval', () => {
+    expect(true).toBe(false);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm test --filter signing flow`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+```ts
+// Add mocked end-to-end flow with stubbed Turnkey + WebAuthn
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm test --filter signing flow`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/worker/src/routes/__tests__/signing-flow.test.ts
+git commit -m "test: add signing flow coverage"
+```


### PR DESCRIPTION
## Summary
- add enterprise SSH 2-of-2 signing bean with scope and phases
- update existing git signing bean with chosen direction and links
- add formal design doc plus implementation plan for execution

## Testing
- not run (docs only)
