### PR TITLE
feat: surface MCP tools in action policy settings UI

### DIFF
--- a/packages/client/src/components/settings/action-policy-dialog.tsx
+++ b/packages/client/src/components/settings/action-policy-dialog.tsx
@@ -145,6 +145,8 @@ function TypeaheadCombobox({
   placeholder,
   disabled,
   renderItem,
+  allowFreeText,
+  freeTextHint,
 }: {
   items: TypeaheadItem[];
   value: string;
@@ -152,6 +154,10 @@ function TypeaheadCombobox({
   placeholder: string;
   disabled?: boolean;
   renderItem?: (item: TypeaheadItem, highlighted: boolean) => React.ReactNode;
+  /** When true, the user can type a custom value that isn't in the list. */
+  allowFreeText?: boolean;
+  /** Hint text shown below the input when free-text is enabled. */
+  freeTextHint?: string;
 }) {
   const [query, setQuery] = React.useState('');
   const [showDropdown, setShowDropdown] = React.useState(false);
@@ -173,10 +179,23 @@ function TypeaheadCombobox({
     );
   }, [query, items]);
 
+  // Whether the current query text is an exact match to an existing item
+  const queryMatchesItem = React.useMemo(() => {
+    const q = query.trim();
+    if (!q) return false;
+    return items.some((i) => i.id === q || i.label.toLowerCase() === q.toLowerCase());
+  }, [query, items]);
+
+  // Show "Use custom value" option when free text is enabled and query doesn't match existing items
+  const showFreeTextOption = allowFreeText && query.trim() && !queryMatchesItem;
+
+  // Total selectable items in the dropdown (filtered + optional free-text entry)
+  const totalDropdownItems = filtered.length + (showFreeTextOption ? 1 : 0);
+
   // Reset highlight when filtered list changes
   React.useEffect(() => {
     setHighlightedIndex(0);
-  }, [filtered.length]);
+  }, [filtered.length, showFreeTextOption]);
 
   // Scroll highlighted item into view
   React.useEffect(() => {
@@ -185,19 +204,24 @@ function TypeaheadCombobox({
     item?.scrollIntoView({ block: 'nearest' });
   }, [highlightedIndex, showDropdown]);
 
-  // Click-outside dismiss
+  // Click-outside dismiss — commit free-text on blur if applicable
   React.useEffect(() => {
     function handleClick(e: MouseEvent) {
       if (
         dropdownRef.current && !dropdownRef.current.contains(e.target as Node) &&
         inputRef.current && !inputRef.current.contains(e.target as Node)
       ) {
+        // If user typed a free-text value and clicked away, commit it
+        if (allowFreeText && query.trim() && !queryMatchesItem) {
+          onChange(query.trim());
+          setQuery('');
+        }
         setShowDropdown(false);
       }
     }
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
-  }, []);
+  }, [allowFreeText, query, queryMatchesItem, onChange]);
 
   function handleSelect(id: string) {
     onChange(id);
@@ -206,14 +230,23 @@ function TypeaheadCombobox({
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
-    if (!showDropdown || filtered.length === 0) {
-      if (e.key === 'Escape') setShowDropdown(false);
+    if (e.key === 'Escape') {
+      setShowDropdown(false);
+      return;
+    }
+
+    if (!showDropdown || totalDropdownItems === 0) {
+      // Allow Enter to commit free-text even when dropdown is not shown
+      if (e.key === 'Enter' && allowFreeText && query.trim()) {
+        e.preventDefault();
+        handleSelect(query.trim());
+      }
       return;
     }
     switch (e.key) {
       case 'ArrowDown':
         e.preventDefault();
-        setHighlightedIndex((i) => Math.min(i + 1, filtered.length - 1));
+        setHighlightedIndex((i) => Math.min(i + 1, totalDropdownItems - 1));
         break;
       case 'ArrowUp':
         e.preventDefault();
@@ -221,12 +254,12 @@ function TypeaheadCombobox({
         break;
       case 'Enter':
         e.preventDefault();
-        if (filtered[highlightedIndex]) {
+        if (showFreeTextOption && highlightedIndex === filtered.length) {
+          // Free-text option is highlighted
+          handleSelect(query.trim());
+        } else if (filtered[highlightedIndex]) {
           handleSelect(filtered[highlightedIndex].id);
         }
-        break;
-      case 'Escape':
-        setShowDropdown(false);
         break;
     }
   }
@@ -257,6 +290,9 @@ function TypeaheadCombobox({
           disabled && 'cursor-not-allowed opacity-50',
         )}
       />
+      {allowFreeText && freeTextHint && !showDropdown && !value && (
+        <p className="mt-1 text-xs text-neutral-400 dark:text-neutral-500">{freeTextHint}</p>
+      )}
       {value && !showDropdown && (
         <button
           type="button"
@@ -272,7 +308,7 @@ function TypeaheadCombobox({
           </svg>
         </button>
       )}
-      {showDropdown && filtered.length > 0 && (
+      {showDropdown && (filtered.length > 0 || showFreeTextOption) && (
         <div
           ref={dropdownRef}
           className="absolute z-20 mt-1 max-h-60 w-full overflow-auto rounded-md border border-neutral-200 bg-white shadow-lg dark:border-neutral-700 dark:bg-neutral-800"
@@ -316,9 +352,29 @@ function TypeaheadCombobox({
               )}
             </button>
           ))}
+          {showFreeTextOption && (
+            <button
+              key="__free_text__"
+              type="button"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                handleSelect(query.trim());
+              }}
+              onMouseEnter={() => setHighlightedIndex(filtered.length)}
+              className={cn(
+                'flex w-full items-center gap-2 border-t border-neutral-100 px-3 py-2 text-left text-sm dark:border-neutral-700',
+                highlightedIndex === filtered.length
+                  ? 'bg-neutral-100 dark:bg-neutral-700'
+                  : 'hover:bg-neutral-50 dark:hover:bg-neutral-700/50',
+              )}
+            >
+              <span className="text-neutral-500 dark:text-neutral-400">Use</span>
+              <span className="font-mono text-neutral-900 dark:text-neutral-100">{query.trim()}</span>
+            </button>
+          )}
         </div>
       )}
-      {showDropdown && filtered.length === 0 && query && (
+      {showDropdown && filtered.length === 0 && query && !allowFreeText && (
         <div className="absolute z-20 mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm text-neutral-500 shadow-lg dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-400">
           No results for &ldquo;{query}&rdquo;
         </div>
@@ -608,7 +664,9 @@ export function ActionPolicyDialog({ open, onOpenChange, policy, onSave, isPendi
                   items={serviceItems}
                   value={service}
                   onChange={handleServiceChange}
-                  placeholder="Search services..."
+                  placeholder="Search services or type a name..."
+                  allowFreeText
+                  freeTextHint="Type a service name like &quot;linear&quot; if it doesn't appear in the list"
                 />
               </div>
             )}
@@ -623,8 +681,10 @@ export function ActionPolicyDialog({ open, onOpenChange, policy, onSave, isPendi
                   items={actionItems}
                   value={actionId}
                   onChange={setActionId}
-                  placeholder={service ? 'Search actions...' : 'Select a service first'}
+                  placeholder={service ? 'Search actions or type an ID...' : 'Select a service first'}
                   disabled={!service}
+                  allowFreeText
+                  freeTextHint="Type an action ID like &quot;linear.save_issue&quot; if it doesn't appear"
                 />
               </div>
             )}

--- a/packages/worker/migrations/0066_mcp_tool_cache.sql
+++ b/packages/worker/migrations/0066_mcp_tool_cache.sql
@@ -1,0 +1,16 @@
+-- Cache of MCP tool metadata discovered at runtime.
+-- Populated by SessionAgentDO when tools are listed with valid credentials.
+-- Read by the catalog endpoint to surface MCP tools in the policy editor UI.
+
+CREATE TABLE IF NOT EXISTS mcp_tool_cache (
+  service     TEXT NOT NULL,
+  action_id   TEXT NOT NULL,
+  name        TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  risk_level  TEXT NOT NULL DEFAULT 'medium',
+  discovered_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (service, action_id)
+);
+
+CREATE INDEX idx_mcp_tool_cache_service ON mcp_tool_cache(service);

--- a/packages/worker/src/durable-objects/session-agent.ts
+++ b/packages/worker/src/durable-objects/session-agent.ts
@@ -17,6 +17,7 @@ import { resolveMode } from '../services/action-policy.js';
 import { invokeAction, markExecuted, markFailed, approveInvocation, denyInvocation } from '../services/actions.js';
 import { updateInvocationStatus } from '../lib/db/actions.js';
 import { getDisabledActionsIndex, isActionDisabled } from '../lib/db/disabled-actions.js';
+import { upsertMcpToolCache } from '../lib/db/mcp-tool-cache.js';
 import { getActivePluginArtifacts, getPluginSettings, getAutoEnabledServices } from '../lib/db/plugins.js';
 import { getPersonaSkills, getOrgDefaultSkills, searchSkills, listSkills, getSkill, getSkillBySlug, createSkill, updateSkill, deleteSkill, getPersonaToolWhitelist, createPersona, updatePersona, deletePersona, getPersonaWithFiles, upsertPersonaFile, attachSkillToPersona, detachSkillFromPersona, getPersonaSkillsForApi } from '../lib/db.js';
 import type { ChannelTarget, ChannelContext } from '@valet/sdk';
@@ -8448,6 +8449,7 @@ export class SessionAgentDO {
 
       const tools: unknown[] = [];
       const warnings: Array<{ service: string; displayName: string; reason: string; message: string; integrationId: string }> = [];
+      const mcpCacheEntries: Array<{ service: string; actionId: string; name: string; description: string; riskLevel: string }> = [];
 
       for (const integration of dedupedIntegrations) {
         // If filtering by service, skip non-matching integrations
@@ -8546,6 +8548,15 @@ export class SessionAgentDO {
           // Cache discovered risk levels so handleCallTool doesn't need to re-fetch
           this.discoveredToolRiskLevels.set(compositeId, action.riskLevel);
 
+          // Collect entry for D1 MCP tool cache (so catalog endpoint can surface these)
+          mcpCacheEntries.push({
+            service: integration.service,
+            actionId: action.id,
+            name: action.name,
+            description: action.description,
+            riskLevel: action.riskLevel,
+          });
+
           tools.push({
             id: compositeId,
             name: action.name,
@@ -8554,6 +8565,14 @@ export class SessionAgentDO {
             params: action.inputSchema || this.serializeZodSchema(action.params),
           });
         }
+      }
+
+      // Fire-and-forget: persist discovered tools to D1 cache for the catalog endpoint.
+      // This allows MCP tools to appear in the policy editor UI even without live credentials.
+      if (mcpCacheEntries.length > 0) {
+        upsertMcpToolCache(this.appDb, mcpCacheEntries).catch((err) => {
+          console.warn('[SessionAgentDO] mcp tool cache upsert failed:', err instanceof Error ? err.message : String(err));
+        });
       }
 
       this.sendToRunner({

--- a/packages/worker/src/lib/db.ts
+++ b/packages/worker/src/lib/db.ts
@@ -33,3 +33,4 @@ export * from './db/skills.js';
 export * from './db/persona-tools.js';
 export * from './db/threads.js';
 export * from './db/channel-threads.js';
+export * from './db/mcp-tool-cache.js';

--- a/packages/worker/src/lib/db/mcp-tool-cache.ts
+++ b/packages/worker/src/lib/db/mcp-tool-cache.ts
@@ -1,0 +1,71 @@
+import { eq } from 'drizzle-orm';
+import type { AppDb } from '../drizzle.js';
+import { mcpToolCache } from '../schema/index.js';
+
+export interface McpToolCacheEntry {
+  service: string;
+  actionId: string;
+  name: string;
+  description: string;
+  riskLevel: string;
+}
+
+/**
+ * Upsert a batch of MCP tool entries for a given service.
+ * Uses INSERT ... ON CONFLICT to update existing rows.
+ */
+export async function upsertMcpToolCache(
+  db: AppDb,
+  entries: McpToolCacheEntry[],
+): Promise<void> {
+  if (entries.length === 0) return;
+
+  const now = new Date().toISOString();
+  for (const entry of entries) {
+    await db
+      .insert(mcpToolCache)
+      .values({
+        service: entry.service,
+        actionId: entry.actionId,
+        name: entry.name,
+        description: entry.description,
+        riskLevel: entry.riskLevel,
+        discoveredAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [mcpToolCache.service, mcpToolCache.actionId],
+        set: {
+          name: entry.name,
+          description: entry.description,
+          riskLevel: entry.riskLevel,
+          updatedAt: now,
+        },
+      });
+  }
+}
+
+/**
+ * List all cached MCP tools, optionally filtered by service.
+ * Returns entries ordered by service + actionId.
+ */
+export async function listMcpToolCache(
+  db: AppDb,
+  serviceFilter?: string,
+): Promise<McpToolCacheEntry[]> {
+  let query = db
+    .select({
+      service: mcpToolCache.service,
+      actionId: mcpToolCache.actionId,
+      name: mcpToolCache.name,
+      description: mcpToolCache.description,
+      riskLevel: mcpToolCache.riskLevel,
+    })
+    .from(mcpToolCache);
+
+  if (serviceFilter) {
+    query = query.where(eq(mcpToolCache.service, serviceFilter)) as typeof query;
+  }
+
+  return query.all();
+}

--- a/packages/worker/src/lib/schema/index.ts
+++ b/packages/worker/src/lib/schema/index.ts
@@ -22,3 +22,4 @@ export * from './skills.js';
 export * from './persona-tools.js';
 export * from './threads.js';
 export * from './channel-threads.js';
+export * from './mcp-tool-cache.js';

--- a/packages/worker/src/lib/schema/mcp-tool-cache.ts
+++ b/packages/worker/src/lib/schema/mcp-tool-cache.ts
@@ -1,0 +1,15 @@
+import { sqliteTable, text, index, primaryKey } from 'drizzle-orm/sqlite-core';
+import { sql } from 'drizzle-orm';
+
+export const mcpToolCache = sqliteTable('mcp_tool_cache', {
+  service: text().notNull(),
+  actionId: text('action_id').notNull(),
+  name: text().notNull(),
+  description: text().notNull().default(''),
+  riskLevel: text('risk_level').notNull().default('medium'),
+  discoveredAt: text('discovered_at').notNull().default(sql`(datetime('now'))`),
+  updatedAt: text('updated_at').notNull().default(sql`(datetime('now'))`),
+}, (table) => [
+  primaryKey({ columns: [table.service, table.actionId] }),
+  index('idx_mcp_tool_cache_service').on(table.service),
+]);

--- a/packages/worker/src/routes/integrations.ts
+++ b/packages/worker/src/routes/integrations.ts
@@ -17,6 +17,7 @@ import * as integrationService from '../services/integrations.js';
 import { integrationRegistry } from '../integrations/registry.js';
 import { revokeCredential } from '../services/credentials.js';
 import { getDb } from '../lib/drizzle.js';
+import { listMcpToolCache } from '../lib/db/mcp-tool-cache.js';
 
 export const integrationsRouter = new Hono<{ Bindings: Env; Variables: Variables }>();
 
@@ -176,6 +177,13 @@ integrationsRouter.get('/available', async (c) => {
 integrationsRouter.get('/actions', async (c) => {
   const serviceFilter = c.req.query('service');
   const packages = integrationRegistry.listPackages();
+
+  // Build a lookup of provider display names by service for cache entries
+  const displayNameMap = new Map<string, string>();
+  for (const pkg of packages) {
+    displayNameMap.set(pkg.service, pkg.provider.displayName);
+  }
+
   const catalog: Array<{
     service: string;
     serviceDisplayName: string;
@@ -185,12 +193,17 @@ integrationsRouter.get('/actions', async (c) => {
     riskLevel: string;
   }> = [];
 
+  // Track which service:actionId combos we've already added from static sources
+  const seen = new Set<string>();
+
   for (const pkg of packages) {
     if (serviceFilter && pkg.service !== serviceFilter) continue;
     // listActions may be async (e.g. MCP-backed sources). Without credentials
     // MCP sources return [] gracefully, which is fine for the catalog endpoint.
     const actions = await (pkg.actions?.listActions() ?? []);
     for (const a of actions) {
+      const key = `${pkg.service}:${a.id}`;
+      seen.add(key);
       catalog.push({
         service: pkg.service,
         serviceDisplayName: pkg.provider.displayName,
@@ -200,6 +213,29 @@ integrationsRouter.get('/actions', async (c) => {
         riskLevel: a.riskLevel,
       });
     }
+  }
+
+  // Merge cached MCP tool metadata (discovered at runtime by SessionAgentDO).
+  // This surfaces MCP-backed tools that can't be listed without credentials.
+  try {
+    const appDb = getDb(c.env.DB);
+    const cached = await listMcpToolCache(appDb, serviceFilter ?? undefined);
+    for (const entry of cached) {
+      const key = `${entry.service}:${entry.actionId}`;
+      if (seen.has(key)) continue; // static source already provided this tool
+      seen.add(key);
+      catalog.push({
+        service: entry.service,
+        serviceDisplayName: displayNameMap.get(entry.service) ?? entry.service,
+        actionId: entry.actionId,
+        name: entry.name,
+        description: entry.description,
+        riskLevel: entry.riskLevel,
+      });
+    }
+  } catch (err) {
+    // Cache read failure is non-fatal — static catalog still works
+    console.warn('[integrations/actions] mcp tool cache read failed:', err instanceof Error ? err.message : String(err));
   }
 
   return c.json({ actions: catalog });


### PR DESCRIPTION
## Summary

MCP integrations (Linear, Notion, Stripe, etc.) were invisible in the Action Policy settings UI because the catalog endpoint (`GET /api/integrations/actions`) calls `listActions()` without user credentials, and MCP-backed sources return `[]` without credentials since they can't call the remote MCP server.

This PR implements two complementary solutions:

### Option B: Cache discovered MCP tools in D1

- **New `mcp_tool_cache` table** with composite primary key `(service, action_id)` storing tool name, description, risk level, and timestamps
- **SessionAgentDO** writes discovered tools to the cache (fire-and-forget with `.catch()` error handling) every time `handleListTools` successfully fetches tools with valid credentials
- **Catalog endpoint** merges cached entries with the static tool list, deduplicating by `service:actionId` so static sources take precedence
- Tools appear in the catalog after first session use — acceptable friction since the free-text fallback (below) covers the gap

### Option C: Free-text entry in the policy dialog

- **TypeaheadCombobox** gains `allowFreeText` and `freeTextHint` props
- When enabled, users can type custom service names (e.g., `linear`) or action IDs (e.g., `linear.save_issue`) that don't appear in the autocomplete list
- A "Use `<value>`" option appears at the bottom of the dropdown when no exact match exists
- Free-text values are committed on Enter, click, or blur (click-outside)
- Existing catalog entries still appear as autocomplete suggestions

## Files Changed

| File | Change |
|------|--------|
| `packages/worker/migrations/0066_mcp_tool_cache.sql` | New D1 migration |
| `packages/worker/src/lib/schema/mcp-tool-cache.ts` | Drizzle schema definition |
| `packages/worker/src/lib/schema/index.ts` | Re-export new schema |
| `packages/worker/src/lib/db/mcp-tool-cache.ts` | `upsertMcpToolCache` and `listMcpToolCache` helpers |
| `packages/worker/src/lib/db.ts` | Re-export new DB helpers |
| `packages/worker/src/durable-objects/session-agent.ts` | Collect + fire-and-forget write discovered tools to cache |
| `packages/worker/src/routes/integrations.ts` | Merge cached tools into catalog response |
| `packages/client/src/components/settings/action-policy-dialog.tsx` | Free-text support in TypeaheadCombobox |

## Testing

- `pnpm typecheck` passes cleanly
- Policy enforcement layer (string matching on `service:actionId`) already works with MCP tools — only the catalog/UI was broken