### PR TITLE
TKAI-2: add session tracing propagation

### DIFF
--- a/docs/specs/2026-04-24-session-tracing-design.md
+++ b/docs/specs/2026-04-24-session-tracing-design.md
@@ -10,6 +10,22 @@
 
 ---
 
+## Implementation Notes — 2026-05-06
+
+TKAI-2 starts with a dependency-free OTLP/HTTP JSON tracer shared by the Worker and Runner. Tracing remains a no-op unless `OTEL_EXPORTER_OTLP_ENDPOINT` is configured, while W3C `traceparent` propagation is still generated so partial deploys remain backward-compatible.
+
+Implemented coverage:
+
+- Worker session lifecycle spans for spawn, restore, hibernate, and terminate.
+- Worker prompt/workflow dispatch spans with `valet.queue.wait_ms`, `valet.queue.reason`, and protocol `traceparent` injection.
+- Runner bootstrap, repo setup, prompt turn, workflow execution, tool, and LLM usage spans.
+- Sandbox env propagation for `TRACEPARENT`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, and `OTEL_CAPTURE_CONTENT`.
+- Persisted lifecycle trace linkage in SessionAgent DO state via `lifecycleTraceId` and `lifecycleSpanId`.
+
+The OpenCode plugin phase remains future work; the first implementation captures tool and LLM usage from the Runner's existing SSE processing.
+
+---
+
 ## Goal
 
 Add OpenTelemetry-native tracing across all three layers of the Valet stack (Worker DO, Runner, OpenCode) so that every agent session's lifecycle — from sandbox provisioning through LLM calls to teardown — is visible as correlated traces in Grafana Tempo.

--- a/docs/specs/2026-04-24-session-tracing-design.md
+++ b/docs/specs/2026-04-24-session-tracing-design.md
@@ -19,6 +19,7 @@ Implemented coverage:
 - Worker session lifecycle spans for spawn, restore, hibernate, and terminate.
 - Worker prompt/workflow dispatch spans with `valet.queue.wait_ms`, `valet.queue.reason`, and protocol `traceparent` injection.
 - Runner bootstrap, repo setup, prompt turn, workflow execution, tool, and LLM usage spans.
+- Runner LLM/tool spans follow OpenLIT's OpenTelemetry GenAI conventions where the Runner has data: `chat <model>` client spans include `gen_ai.operation.name`, legacy `gen_ai.system`, OTel `gen_ai.provider.name`, model, stream, output type, and token usage attributes; tool spans use `execute_tool <tool>` with `gen_ai.tool.*` attributes.
 - Sandbox env propagation for `TRACEPARENT`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, and `OTEL_CAPTURE_CONTENT`.
 - Persisted lifecycle trace linkage in SessionAgent DO state via `lifecycleTraceId` and `lifecycleSpanId`.
 

--- a/packages/runner/src/agent-client.ts
+++ b/packages/runner/src/agent-client.ts
@@ -31,6 +31,31 @@ export interface PromptAuthor {
   authorEmail?: string;
 }
 
+/**
+ * Payload delivered to the Runner when the DO dispatches a prompt.
+ * Bundled into a single object instead of a positional argument list because
+ * the wire shape keeps growing (model prefs, attachments, channel routing,
+ * traceparent…) and per-arg signatures are no longer reviewable.
+ */
+export interface PromptDispatch {
+  messageId: string;
+  content: string;
+  model?: string;
+  author?: PromptAuthor;
+  modelPreferences?: string[];
+  attachments?: PromptAttachment[];
+  channelType?: string;
+  channelId?: string;
+  opencodeSessionId?: string;
+  continuationContext?: string;
+  threadId?: string;
+  replyChannelType?: string;
+  replyChannelId?: string;
+  traceparent?: string;
+}
+
+export type PromptHandlerFn = (dispatch: PromptDispatch) => void | Promise<void>;
+
 const MAX_RECONNECT_DELAY_MS = 30_000;
 const INITIAL_RECONNECT_DELAY_MS = 1_000;
 const PING_INTERVAL_MS = 30_000;
@@ -54,7 +79,7 @@ export class AgentClient {
   private pendingTokenRefresh: { requestId: string; resolve: (result: { accessToken: string; expiresAt?: string }) => void } | null = null;
   private reconnectCallback?: () => void;
 
-  private promptHandler: ((messageId: string, content: string, model?: string, author?: PromptAuthor, modelPreferences?: string[], attachments?: PromptAttachment[], channelType?: string, channelId?: string, opencodeSessionId?: string, continuationContext?: string, threadId?: string, replyChannelType?: string, replyChannelId?: string, traceparent?: string) => void | Promise<void>) | null = null;
+  private promptHandler: PromptHandlerFn | null = null;
   private answerHandler: ((questionId: string, answer: string | boolean) => void | Promise<void>) | null = null;
   private stopHandler: (() => void) | null = null;
   private abortHandler: ((channelType?: string, channelId?: string) => void | Promise<void>) | null = null;
@@ -894,7 +919,7 @@ export class AgentClient {
 
   // ─── Inbound Handlers (DO → Runner) ─────────────────────────────────
 
-  onPrompt(handler: (messageId: string, content: string, model?: string, author?: PromptAuthor, modelPreferences?: string[], attachments?: PromptAttachment[], channelType?: string, channelId?: string, opencodeSessionId?: string, continuationContext?: string, threadId?: string, replyChannelType?: string, replyChannelId?: string, traceparent?: string) => void | Promise<void>): void {
+  onPrompt(handler: PromptHandlerFn): void {
     this.promptHandler = handler;
   }
 
@@ -1012,7 +1037,22 @@ export class AgentClient {
           const author: PromptAuthor | undefined = (msg.authorId || msg.gitName || msg.gitEmail || msg.authorName || msg.authorEmail)
             ? { authorId: msg.authorId, gitName: msg.gitName, gitEmail: msg.gitEmail, authorName: msg.authorName, authorEmail: msg.authorEmail }
             : undefined;
-          await this.promptHandler?.(msg.messageId, msg.content, msg.model, author, msg.modelPreferences, msg.attachments, msg.channelType, msg.channelId, msg.opencodeSessionId, msg.continuationContext, msg.threadId, msg.replyChannelType, msg.replyChannelId, msg.traceparent);
+          await this.promptHandler?.({
+            messageId: msg.messageId,
+            content: msg.content,
+            model: msg.model,
+            author,
+            modelPreferences: msg.modelPreferences,
+            attachments: msg.attachments,
+            channelType: msg.channelType,
+            channelId: msg.channelId,
+            opencodeSessionId: msg.opencodeSessionId,
+            continuationContext: msg.continuationContext,
+            threadId: msg.threadId,
+            replyChannelType: msg.replyChannelType,
+            replyChannelId: msg.replyChannelId,
+            traceparent: msg.traceparent,
+          });
           break;
         }
         case "answer":

--- a/packages/runner/src/agent-client.ts
+++ b/packages/runner/src/agent-client.ts
@@ -21,6 +21,7 @@ import type {
 import { gitCredentials } from "./git-credentials.js";
 import { setupGitConfig, cloneRepo } from "./git-setup.js";
 import { APPROVAL_TIMEOUT_MS } from "./timeouts.js";
+import { flushTracing, parentFromTraceparent, startSpan } from "./tracing.js";
 
 export interface PromptAuthor {
   authorId?: string;
@@ -53,7 +54,7 @@ export class AgentClient {
   private pendingTokenRefresh: { requestId: string; resolve: (result: { accessToken: string; expiresAt?: string }) => void } | null = null;
   private reconnectCallback?: () => void;
 
-  private promptHandler: ((messageId: string, content: string, model?: string, author?: PromptAuthor, modelPreferences?: string[], attachments?: PromptAttachment[], channelType?: string, channelId?: string, opencodeSessionId?: string, continuationContext?: string, threadId?: string, replyChannelType?: string, replyChannelId?: string) => void | Promise<void>) | null = null;
+  private promptHandler: ((messageId: string, content: string, model?: string, author?: PromptAuthor, modelPreferences?: string[], attachments?: PromptAttachment[], channelType?: string, channelId?: string, opencodeSessionId?: string, continuationContext?: string, threadId?: string, replyChannelType?: string, replyChannelId?: string, traceparent?: string) => void | Promise<void>) | null = null;
   private answerHandler: ((questionId: string, answer: string | boolean) => void | Promise<void>) | null = null;
   private stopHandler: (() => void) | null = null;
   private abortHandler: ((channelType?: string, channelId?: string) => void | Promise<void>) | null = null;
@@ -69,7 +70,7 @@ export class AgentClient {
     resumeToken?: string;
     decision?: "approve" | "deny";
     payload: Record<string, unknown>;
-  }, model?: string, modelPreferences?: string[]) => void | Promise<void>) | null = null;
+  }, model?: string, modelPreferences?: string[], traceparent?: string) => void | Promise<void>) | null = null;
   private newSessionHandler: ((channelType: string, channelId: string, requestId: string) => void | Promise<void>) | null = null;
   private initHandler: (() => void | Promise<void>) | null = null;
   private openCodeConfigHandler: ((config: { tools?: Record<string, boolean>; providerKeys?: Record<string, string>; instructions?: string[]; isOrchestrator?: boolean; customProviders?: Array<{ providerId: string; displayName: string; baseUrl: string; apiKey?: string; models: Array<{ id: string; name?: string; contextLimit?: number; outputLimit?: number }> }> }) => void | Promise<void>) | null = null;
@@ -893,7 +894,7 @@ export class AgentClient {
 
   // ─── Inbound Handlers (DO → Runner) ─────────────────────────────────
 
-  onPrompt(handler: (messageId: string, content: string, model?: string, author?: PromptAuthor, modelPreferences?: string[], attachments?: PromptAttachment[], channelType?: string, channelId?: string, opencodeSessionId?: string, continuationContext?: string, threadId?: string, replyChannelType?: string, replyChannelId?: string) => void | Promise<void>): void {
+  onPrompt(handler: (messageId: string, content: string, model?: string, author?: PromptAuthor, modelPreferences?: string[], attachments?: PromptAttachment[], channelType?: string, channelId?: string, opencodeSessionId?: string, continuationContext?: string, threadId?: string, replyChannelType?: string, replyChannelId?: string, traceparent?: string) => void | Promise<void>): void {
     this.promptHandler = handler;
   }
 
@@ -940,7 +941,7 @@ export class AgentClient {
     resumeToken?: string;
     decision?: "approve" | "deny";
     payload: Record<string, unknown>;
-  }, model?: string, modelPreferences?: string[]) => void | Promise<void>): void {
+  }, model?: string, modelPreferences?: string[], traceparent?: string) => void | Promise<void>): void {
     this.workflowExecuteHandler = handler;
   }
 
@@ -1011,7 +1012,7 @@ export class AgentClient {
           const author: PromptAuthor | undefined = (msg.authorId || msg.gitName || msg.gitEmail || msg.authorName || msg.authorEmail)
             ? { authorId: msg.authorId, gitName: msg.gitName, gitEmail: msg.gitEmail, authorName: msg.authorName, authorEmail: msg.authorEmail }
             : undefined;
-          await this.promptHandler?.(msg.messageId, msg.content, msg.model, author, msg.modelPreferences, msg.attachments, msg.channelType, msg.channelId, msg.opencodeSessionId, msg.continuationContext, msg.threadId, msg.replyChannelType, msg.replyChannelId);
+          await this.promptHandler?.(msg.messageId, msg.content, msg.model, author, msg.modelPreferences, msg.attachments, msg.channelType, msg.channelId, msg.opencodeSessionId, msg.continuationContext, msg.threadId, msg.replyChannelType, msg.replyChannelId, msg.traceparent);
           break;
         }
         case "answer":
@@ -1363,15 +1364,27 @@ export class AgentClient {
             Array.isArray(msg.modelPreferences)
               ? msg.modelPreferences.filter((entry): entry is string => typeof entry === "string" && !!entry.trim())
               : undefined,
+            msg.traceparent,
           );
           break;
         case "repo-config": {
-          const { token, expiresAt, gitConfig, repoUrl, branch, ref } = msg;
+          const { token, expiresAt, gitConfig, repoUrl, branch, ref, traceparent } = msg;
+          const repoSpan = startSpan("valet.runner.git_setup", {
+            parent: parentFromTraceparent(traceparent),
+            attributes: {
+              "valet.git.repo_url": repoUrl,
+              "valet.git.branch": branch,
+              "valet.git.ref": ref,
+            },
+          });
 
           // No token means the DO couldn't assemble credentials — resolve
           // repoReady so the runner doesn't burn the full timeout waiting.
           if (!token) {
             console.warn("[AgentClient] repo-config received with no token — skipping clone");
+            repoSpan.setAttribute("valet.git.skipped", true);
+            repoSpan.end();
+            await flushTracing();
             this._resolveRepoReady();
             break;
           }
@@ -1406,9 +1419,16 @@ export class AgentClient {
             // Clone repo if URL provided
             if (repoUrl) {
               const result = await cloneRepo({ repoUrl, branch, ref });
+              repoSpan.setAttribute("valet.git.success", result.success);
+              if (result.error) repoSpan.setAttribute("valet.git.error", result.error.slice(0, 300));
               this.send({ type: "repo:clone-complete", ...result });
             }
+          } catch (err) {
+            repoSpan.recordException(err);
+            throw err;
           } finally {
+            repoSpan.end();
+            await flushTracing();
             this._resolveRepoReady();
           }
           break;

--- a/packages/runner/src/bin.ts
+++ b/packages/runner/src/bin.ts
@@ -15,6 +15,7 @@ import { AgentClient } from "./agent-client.js";
 import { PromptHandler } from "./prompt.js";
 import { startGateway, cleanupAllCloudflared } from "./gateway.js";
 import { OpenCodeManager, type OpenCodeConfig } from "./opencode-manager.js";
+import { flushTracing, initTracing, parentFromTraceparent, startSpan, traceparentFromSpan } from "./tracing.js";
 
 function mergeOpenCodeConfig(
   current: OpenCodeConfig,
@@ -147,6 +148,16 @@ function buildInitialConfig(): OpenCodeConfig {
 // ─── Main ────────────────────────────────────────────────────────────────
 
 async function main() {
+  process.env.SESSION_ID = sessionId!;
+  initTracing(sessionId!);
+  const bootstrapSpan = startSpan("valet.runner.bootstrap", {
+    parent: parentFromTraceparent(process.env.TRACEPARENT),
+    attributes: {
+      "valet.session.id": sessionId,
+      "valet.runner.version": "0.1.0",
+    },
+  });
+  process.env.TRACEPARENT = traceparentFromSpan(bootstrapSpan);
   console.log(`[Runner] Starting for session ${sessionId}`);
   console.log(`[Runner] DO URL: ${doUrl}`);
 
@@ -390,9 +401,9 @@ async function main() {
   });
 
   // Register handlers
-  agentClient.onPrompt(async (messageId, content, model, author, modelPreferences, attachments, channelType, channelId, opencodeSessionId, continuationContext, threadId, replyChannelType, replyChannelId) => {
+  agentClient.onPrompt(async (messageId, content, model, author, modelPreferences, attachments, channelType, channelId, opencodeSessionId, continuationContext, threadId, replyChannelType, replyChannelId, traceparent) => {
     console.log(`[Runner] Received prompt: ${messageId}${model ? ` (model: ${model})` : ''}${author?.authorName ? ` (by: ${author.authorName})` : ''}${modelPreferences?.length ? ` (prefs: ${modelPreferences.length} models)` : ''}${attachments?.length ? ` (attachments: ${attachments.length})` : ''}${channelType ? ` (channel: ${channelType})` : ''}${replyChannelType ? ` (replyChannel: ${replyChannelType})` : ''}${continuationContext ? ' (with continuation context)' : ''}`);
-    await promptHandler.handlePrompt(messageId, content, model, author, modelPreferences, attachments, channelType, channelId, opencodeSessionId, continuationContext, threadId, replyChannelType, replyChannelId);
+    await promptHandler.handlePrompt(messageId, content, model, author, modelPreferences, attachments, channelType, channelId, opencodeSessionId, continuationContext, threadId, replyChannelType, replyChannelId, traceparent);
   });
 
   agentClient.onAnswer(async (questionId, answer) => {
@@ -441,9 +452,9 @@ async function main() {
     await promptHandler.handleNewSession(channelType, channelId, requestId);
   });
 
-  agentClient.onWorkflowExecute(async (executionId, payload, model, modelPreferences) => {
+  agentClient.onWorkflowExecute(async (executionId, payload, model, modelPreferences, traceparent) => {
     console.log(`[Runner] Received workflow execution dispatch: ${executionId} (${payload.kind})`);
-    await promptHandler.handleWorkflowExecutionDispatch(executionId, payload, model, modelPreferences);
+    await promptHandler.handleWorkflowExecutionDispatch(executionId, payload, model, modelPreferences, traceparent);
   });
 
   agentClient.onTunnelDelete(async (name, actor) => {
@@ -540,6 +551,8 @@ async function main() {
     cleanupAllCloudflared();
     await openCodeManager.shutdown();
     agentClient.disconnect();
+    bootstrapSpan.end();
+    await flushTracing();
     process.exit(0);
   };
 
@@ -618,6 +631,7 @@ async function main() {
   clearTimeout(bootTimeoutHandle!);
   if (bootResult === "timeout") {
     console.warn("[Runner] Timed out waiting for boot prerequisites (repo clone / plugin content) — proceeding");
+    bootstrapSpan.setAttribute("valet.runner.boot_timeout", true);
   } else {
     console.log("[Runner] Boot prerequisites complete (repo clone + plugin content)");
   }
@@ -625,6 +639,8 @@ async function main() {
   // Signal readiness — this triggers the DO to drain any queued prompts.
   agentClient.sendAgentStatus("idle");
   console.log("[Runner] Ready — sent initial agentStatus: idle to DO");
+  bootstrapSpan.end();
+  await flushTracing();
 
   // Discover models in background — not needed for prompt handling
   promptHandler.fetchAvailableModels().then((models) => {

--- a/packages/runner/src/bin.ts
+++ b/packages/runner/src/bin.ts
@@ -401,9 +401,10 @@ async function main() {
   });
 
   // Register handlers
-  agentClient.onPrompt(async (messageId, content, model, author, modelPreferences, attachments, channelType, channelId, opencodeSessionId, continuationContext, threadId, replyChannelType, replyChannelId, traceparent) => {
+  agentClient.onPrompt(async (dispatch) => {
+    const { messageId, model, author, modelPreferences, attachments, channelType, replyChannelType, continuationContext } = dispatch;
     console.log(`[Runner] Received prompt: ${messageId}${model ? ` (model: ${model})` : ''}${author?.authorName ? ` (by: ${author.authorName})` : ''}${modelPreferences?.length ? ` (prefs: ${modelPreferences.length} models)` : ''}${attachments?.length ? ` (attachments: ${attachments.length})` : ''}${channelType ? ` (channel: ${channelType})` : ''}${replyChannelType ? ` (replyChannel: ${replyChannelType})` : ''}${continuationContext ? ' (with continuation context)' : ''}`);
-    await promptHandler.handlePrompt(messageId, content, model, author, modelPreferences, attachments, channelType, channelId, opencodeSessionId, continuationContext, threadId, replyChannelType, replyChannelId, traceparent);
+    await promptHandler.handlePrompt(dispatch);
   });
 
   agentClient.onAnswer(async (questionId, answer) => {

--- a/packages/runner/src/prompt.test.ts
+++ b/packages/runner/src/prompt.test.ts
@@ -98,19 +98,15 @@ describe("PromptHandler thread resume", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    await handler.handlePrompt(
-      "message-1",
-      "actual user prompt",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "thread",
-      "thread-1",
-      "persisted-thread",
-      "saved continuation context",
-      "thread-1",
-    );
+    await handler.handlePrompt({
+      messageId: "message-1",
+      content: "actual user prompt",
+      channelType: "thread",
+      channelId: "thread-1",
+      opencodeSessionId: "persisted-thread",
+      continuationContext: "saved continuation context",
+      threadId: "thread-1",
+    });
 
     expect(fetchCalls.map((call) => `${call.method} ${call.url}`)).toEqual([
       "GET http://opencode.test/session/persisted-thread",
@@ -158,19 +154,15 @@ describe("PromptHandler thread resume", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    await handler.handlePrompt(
-      "message-2",
-      "resume this task",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "thread",
-      "thread-2",
-      "persisted-missing",
-      "restored conversation summary",
-      "thread-2",
-    );
+    await handler.handlePrompt({
+      messageId: "message-2",
+      content: "resume this task",
+      channelType: "thread",
+      channelId: "thread-2",
+      opencodeSessionId: "persisted-missing",
+      continuationContext: "restored conversation summary",
+      threadId: "thread-2",
+    });
 
     expect(fetchCalls.map((call) => `${call.method} ${call.url}`)).toEqual([
       "GET http://opencode.test/session/persisted-missing",
@@ -234,19 +226,15 @@ describe("PromptHandler thread resume", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    await handler.handlePrompt(
-      "message-3",
-      "continue the work",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "thread",
-      "thread-3",
-      "persisted-transient",
-      "resume summary from before restart",
-      "thread-3",
-    );
+    await handler.handlePrompt({
+      messageId: "message-3",
+      content: "continue the work",
+      channelType: "thread",
+      channelId: "thread-3",
+      opencodeSessionId: "persisted-transient",
+      continuationContext: "resume summary from before restart",
+      threadId: "thread-3",
+    });
 
     const callNames = fetchCalls.map((call) => `${call.method} ${call.url}`);
     expect(callNames).toContain("GET http://opencode.test/session/persisted-transient");
@@ -300,19 +288,14 @@ describe("PromptHandler thread resume", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    await handler.handlePrompt(
-      "message-4",
-      "start from here",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "thread",
-      "thread-4",
-      undefined,
-      "old summary that should be injected for legacy resume",
-      "thread-4",
-    );
+    await handler.handlePrompt({
+      messageId: "message-4",
+      content: "start from here",
+      channelType: "thread",
+      channelId: "thread-4",
+      continuationContext: "old summary that should be injected for legacy resume",
+      threadId: "thread-4",
+    });
 
     expect(fetchCalls.map((call) => `${call.method} ${call.url}`)).toEqual([
       "POST http://opencode.test/session",
@@ -370,16 +353,12 @@ describe("PromptHandler dedup guard", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     // Fire first prompt but don't await — it will hang on the sync fetch
-    const firstPromise = handler.handlePrompt(
-      "msg-1",
-      "first prompt",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "thread",
-      "ch-dedup",
-    );
+    const firstPromise = handler.handlePrompt({
+      messageId: "msg-1",
+      content: "first prompt",
+      channelType: "thread",
+      channelId: "ch-dedup",
+    });
 
     // Wait until syncPromptInFlight is set (first prompt has reached the fetch)
     await new Promise<void>((resolve) => {
@@ -395,16 +374,12 @@ describe("PromptHandler dedup guard", () => {
     });
 
     // Send duplicate — same messageId, same channel
-    await handler.handlePrompt(
-      "msg-1",
-      "first prompt",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "thread",
-      "ch-dedup",
-    );
+    await handler.handlePrompt({
+      messageId: "msg-1",
+      content: "first prompt",
+      channelType: "thread",
+      channelId: "ch-dedup",
+    });
 
     // Duplicate path must send sendComplete to unblock the DO
     expect(agentClient.sendComplete).toHaveBeenCalledWith("msg-1");
@@ -700,16 +675,13 @@ describe("PromptHandler text file extraction", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    await handler.handlePrompt(
-      "msg-text-1",
-      "please review this file",
-      undefined,
-      undefined,
-      undefined,
-      [{ type: "file", mime: "text/plain", url: dataUrl, filename: "notes.txt" }],
-      "thread",
-      "ch-text",
-    );
+    await handler.handlePrompt({
+      messageId: "msg-text-1",
+      content: "please review this file",
+      attachments: [{ type: "file", mime: "text/plain", url: dataUrl, filename: "notes.txt" }],
+      channelType: "thread",
+      channelId: "ch-text",
+    });
 
     // The sync prompt should have text file content appended after the message and no file parts
     const syncCall = fetchCalls.find(
@@ -755,16 +727,13 @@ describe("PromptHandler text file extraction", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    await handler.handlePrompt(
-      "msg-json-1",
-      "analyze this config",
-      undefined,
-      undefined,
-      undefined,
-      [{ type: "file", mime: "application/json", url: dataUrl, filename: "config.json" }],
-      "thread",
-      "ch-json",
-    );
+    await handler.handlePrompt({
+      messageId: "msg-json-1",
+      content: "analyze this config",
+      attachments: [{ type: "file", mime: "application/json", url: dataUrl, filename: "config.json" }],
+      channelType: "thread",
+      channelId: "ch-json",
+    });
 
     const syncCall = fetchCalls.find(
       (c) => c.url === "http://opencode.test/session/json-session/message" && c.method === "POST",
@@ -805,19 +774,16 @@ describe("PromptHandler text file extraction", () => {
 
     vi.stubGlobal("fetch", fetchMock);
 
-    await handler.handlePrompt(
-      "msg-mixed-1",
-      "check both files",
-      undefined,
-      undefined,
-      undefined,
-      [
+    await handler.handlePrompt({
+      messageId: "msg-mixed-1",
+      content: "check both files",
+      attachments: [
         { type: "file", mime: "text/plain", url: textDataUrl, filename: "code.txt" },
         { type: "file", mime: "image/png", url: imageDataUrl, filename: "screenshot.png" },
       ],
-      "thread",
-      "ch-mixed",
-    );
+      channelType: "thread",
+      channelId: "ch-mixed",
+    });
 
     const syncCall = fetchCalls.find(
       (c) => c.url === "http://opencode.test/session/mixed-session/message" && c.method === "POST",

--- a/packages/runner/src/prompt.ts
+++ b/packages/runner/src/prompt.ts
@@ -27,6 +27,7 @@ import {
   type WorkflowStepExecutionContext,
   type WorkflowStepExecutionResult,
 } from "./workflow-engine.js";
+import { flushTracing, parentFromTraceparent, startSpan, traceparentFromSpan } from "./tracing.js";
 
 // OpenCode ToolState status values
 type ToolStatus = "pending" | "running" | "completed" | "error";
@@ -635,6 +636,7 @@ export class PromptHandler {
    * explicit.
    */
   private currentPromptChannel: ChannelSession | null = null;
+  private currentPromptTraceparent: string | undefined;
 
   // Legacy single-session compat — points to currentPromptChannel's OC session ID
   // Used by ephemeral sessions, reviews, etc. that don't need per-channel routing
@@ -1101,16 +1103,35 @@ export class PromptHandler {
     payload: WorkflowExecutionDispatchPayload,
     model?: string,
     modelPreferences?: string[],
+    traceparent?: string,
   ): Promise<void> {
+    const span = startSpan("valet.workflow.execute", {
+      parent: parentFromTraceparent(traceparent),
+      attributes: {
+        "valet.session.id": this.runnerSessionId || undefined,
+        "valet.workflow.execution_id": executionId,
+        "valet.workflow.kind": payload.kind,
+      },
+    });
+    this.currentPromptTraceparent = traceparentFromSpan(span);
     const request: WorkflowExecutionDispatchPayload = {
       ...payload,
       executionId: payload.executionId || executionId,
     };
-    await this.handleWorkflowExecutionPrompt(`workflow:${executionId}`, request, {
-      emitChatError: false,
-      model,
-      modelPreferences,
-    });
+    try {
+      await this.handleWorkflowExecutionPrompt(`workflow:${executionId}`, request, {
+        emitChatError: false,
+        model,
+        modelPreferences,
+      });
+    } catch (err) {
+      span.recordException(err);
+      throw err;
+    } finally {
+      span.end();
+      await flushTracing();
+      this.currentPromptTraceparent = undefined;
+    }
   }
 
   private async executeWorkflowToolStep(
@@ -1435,8 +1456,19 @@ export class PromptHandler {
     });
   }
 
-  async handlePrompt(messageId: string, content: string, model?: string, author?: { authorId?: string; gitName?: string; gitEmail?: string; authorName?: string; authorEmail?: string }, modelPreferences?: string[], attachments?: PromptAttachment[], channelType?: string, channelId?: string, opencodeSessionId?: string, continuationContext?: string, threadId?: string, replyChannelType?: string, replyChannelId?: string): Promise<void> {
+  async handlePrompt(messageId: string, content: string, model?: string, author?: { authorId?: string; gitName?: string; gitEmail?: string; authorName?: string; authorEmail?: string }, modelPreferences?: string[], attachments?: PromptAttachment[], channelType?: string, channelId?: string, opencodeSessionId?: string, continuationContext?: string, threadId?: string, replyChannelType?: string, replyChannelId?: string, traceparent?: string): Promise<void> {
     console.log(`[PromptHandler] Handling prompt ${messageId}: "${content.slice(0, 80)}"${model ? ` (model: ${model})` : ''}${author?.authorName ? ` (by: ${author.authorName})` : ''}${modelPreferences?.length ? ` (prefs: ${modelPreferences.length})` : ''}${attachments?.length ? ` (attachments: ${attachments.length})` : ''}${channelType ? ` (channel: ${channelType})` : ''}${continuationContext ? ' (with continuation context)' : ''}`);
+    const turnSpan = startSpan("valet.turn", {
+      parent: parentFromTraceparent(traceparent),
+      attributes: {
+        "valet.session.id": this.runnerSessionId || undefined,
+        "valet.message.id": messageId,
+        "valet.channel.type": channelType,
+        "valet.channel.id": channelId,
+      },
+    });
+    this.currentPromptTraceparent = traceparentFromSpan(turnSpan);
+    process.env.TRACEPARENT = this.currentPromptTraceparent;
 
     // Dedup: if this exact messageId is already being processed by a sync prompt, skip it.
     // This handles the case where the DO re-dispatches after a transient disconnect
@@ -1445,6 +1477,10 @@ export class PromptHandler {
     if (channel.activeMessageId === messageId && channel.syncPromptInFlight) {
       console.log(`[PromptHandler] Ignoring duplicate prompt ${messageId} — sync prompt already in flight`);
       this.agentClient.sendComplete(messageId);
+      turnSpan.setAttribute("valet.turn.skipped", "duplicate_in_flight");
+      turnSpan.end();
+      await flushTracing();
+      this.currentPromptTraceparent = undefined;
       return;
     }
 
@@ -1818,10 +1854,15 @@ export class PromptHandler {
       await this.finalizeSyncResponse(channel, null, exhaustedError);
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
+      turnSpan.recordException(err);
       console.error("[PromptHandler] Error processing prompt:", errorMsg);
       this.agentClient.sendError(messageId, errorMsg);
       this.agentClient.sendComplete(this.activeMessageId ?? undefined);
       this.agentClient.sendAgentStatus("idle", undefined, messageId);
+    } finally {
+      turnSpan.end();
+      await flushTracing();
+      this.currentPromptTraceparent = undefined;
     }
   }
 
@@ -3232,7 +3273,10 @@ export class PromptHandler {
 
     const res = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(this.currentPromptTraceparent ? { Traceparent: this.currentPromptTraceparent } : {}),
+      },
       body: JSON.stringify(body),
       // @ts-expect-error Bun-specific option — disable default fetch timeout
       timeout: false,
@@ -3265,7 +3309,10 @@ export class PromptHandler {
 
     const res = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(this.currentPromptTraceparent ? { Traceparent: this.currentPromptTraceparent } : {}),
+      },
       body: JSON.stringify(body),
       signal,
       // @ts-expect-error Bun-specific option — disable default fetch timeout
@@ -3956,6 +4003,16 @@ export class PromptHandler {
     } else if (currentStatus === "completed") {
       const toolResult = state.output ?? null;
       console.log(`[PromptHandler] Tool "${toolName}" completed (output: ${typeof toolResult === "string" ? toolResult.length + " chars" : "null"})`);
+      const toolSpan = startSpan("valet.tool", {
+        parent: parentFromTraceparent(this.currentPromptTraceparent),
+        attributes: {
+          "valet.session.id": this.runnerSessionId || undefined,
+          "valet.message.id": channel.activeMessageId || undefined,
+          "valet.tool.name": toolName,
+          "valet.tool.status": currentStatus,
+        },
+      });
+      toolSpan.end();
 
       // Extract images from tool results that return structured objects with an images array.
       // For actions via call_tool, images are routed through the gateway's /api/image path instead
@@ -4028,6 +4085,17 @@ export class PromptHandler {
 
     } else if (currentStatus === "error") {
       console.log(`[PromptHandler] Tool "${toolName}" error: ${state.error}`);
+      const toolSpan = startSpan("valet.tool", {
+        parent: parentFromTraceparent(this.currentPromptTraceparent),
+        attributes: {
+          "valet.session.id": this.runnerSessionId || undefined,
+          "valet.message.id": channel.activeMessageId || undefined,
+          "valet.tool.name": toolName,
+          "valet.tool.status": currentStatus,
+          "valet.tool.error": state.error,
+        },
+      });
+      toolSpan.end();
       this.agentClient.sendToolUpdate(channel.turnId!, callID, toolName, "error", state.input ?? undefined, undefined, state.error ?? undefined);
     }
   }
@@ -4122,6 +4190,18 @@ export class PromptHandler {
               inputTokens: input,
               outputTokens: output,
             });
+            const llmSpan = startSpan("valet.llm", {
+              parent: parentFromTraceparent(this.currentPromptTraceparent),
+              attributes: {
+                "valet.session.id": this.runnerSessionId || undefined,
+                "valet.message.id": channel.activeMessageId || undefined,
+                "gen_ai.system": providerId,
+                "gen_ai.request.model": usageModel,
+                "gen_ai.usage.input_tokens": input,
+                "gen_ai.usage.output_tokens": output,
+              },
+            });
+            llmSpan.end();
           }
         }
       }

--- a/packages/runner/src/prompt.ts
+++ b/packages/runner/src/prompt.ts
@@ -27,10 +27,52 @@ import {
   type WorkflowStepExecutionContext,
   type WorkflowStepExecutionResult,
 } from "./workflow-engine.js";
-import { flushTracing, parentFromTraceparent, startSpan, traceparentFromSpan } from "./tracing.js";
+import { flushTracing, parentFromTraceparent, SpanKind, startSpan, traceparentFromSpan } from "./tracing.js";
 
 // OpenCode ToolState status values
 type ToolStatus = "pending" | "running" | "completed" | "error";
+
+const GEN_AI_PROVIDER_OPENCODE = "opencode";
+const GEN_AI_OPERATION_CHAT = "chat";
+const GEN_AI_OPERATION_EXECUTE_TOOL = "execute_tool";
+const GEN_AI_OUTPUT_TYPE_TEXT = "text";
+
+function captureOtelContent(): boolean {
+  const value = process.env.OTEL_CAPTURE_CONTENT?.trim().toLowerCase();
+  return value === "1" || value === "true" || value === "yes";
+}
+
+function truncateTelemetryContent(value: string, maxLength = 8000): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...[truncated]` : value;
+}
+
+function stringifyTelemetryContent(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  try {
+    return truncateTelemetryContent(typeof value === "string" ? value : JSON.stringify(value));
+  } catch {
+    return truncateTelemetryContent(String(value));
+  }
+}
+
+function normalizeGenAIProvider(providerId: string | undefined): string {
+  if (!providerId?.trim()) return GEN_AI_PROVIDER_OPENCODE;
+  const provider = providerId.trim().toLowerCase().replace(/_/g, "-");
+  if (provider === "azure-openai" || provider === "azure") return "azure.ai.openai";
+  if (provider === "amazon-bedrock" || provider === "bedrock") return "aws.bedrock";
+  if (provider === "google" || provider === "google-ai" || provider === "gemini") return "gcp.gemini";
+  if (provider === "vertex" || provider === "vertex-ai") return "vertex_ai";
+  if (provider === "mistral") return "mistral_ai";
+  return provider;
+}
+
+function buildGenAIMessage(role: string, content: string): string {
+  return JSON.stringify([{ role, content: truncateTelemetryContent(content) }]);
+}
+
+function toolTypeForName(toolName: string): string {
+  return toolName.startsWith("mcp__") ? "extension" : "function";
+}
 
 interface ToolState {
   status: ToolStatus;
@@ -450,6 +492,8 @@ export class ChannelSession {
   activeAssistantMessageIds = new Set<string>();
   // Latest full assistant text snapshot observed via message.updated
   latestAssistantTextSnapshot = "";
+  // Current user prompt, retained only long enough to optionally attach to GenAI spans.
+  activePromptContent = "";
   // Compact event trace for debugging empty-response classification
   recentEventTrace: string[] = [];
   lastError: string | null = null;
@@ -522,6 +566,7 @@ export class ChannelSession {
     this.messageRoles.clear();
     this.activeAssistantMessageIds.clear();
     this.latestAssistantTextSnapshot = "";
+    this.activePromptContent = "";
     this.recentEventTrace = [];
     this.waitForEventForced = false;
     this.abortedForYield = false;
@@ -580,6 +625,7 @@ export class ChannelSession {
     this.messageRoles.clear();
     this.activeAssistantMessageIds.clear();
     this.latestAssistantTextSnapshot = "";
+    this.activePromptContent = "";
     this.recentEventTrace = [];
     this.syncPromptInFlight = false;
     this.awaitingAssistantForAttempt = false;
@@ -1632,6 +1678,7 @@ export class PromptHandler {
       }
 
       // Store failover state (use post-transcription values so model failover doesn't re-transcribe)
+      channel.activePromptContent = effectiveContent;
       this.currentModelPreferences = failoverChain.length > 0 ? failoverChain : undefined;
       this.pendingRetryContent = effectiveContent;
       this.pendingRetryAttachments = effectiveAttachments;
@@ -4003,13 +4050,26 @@ export class PromptHandler {
     } else if (currentStatus === "completed") {
       const toolResult = state.output ?? null;
       console.log(`[PromptHandler] Tool "${toolName}" completed (output: ${typeof toolResult === "string" ? toolResult.length + " chars" : "null"})`);
-      const toolSpan = startSpan("valet.tool", {
+      const toolSpan = startSpan(`${GEN_AI_OPERATION_EXECUTE_TOOL} ${toolName}`, {
         parent: parentFromTraceparent(this.currentPromptTraceparent),
         attributes: {
           "valet.session.id": this.runnerSessionId || undefined,
           "valet.message.id": channel.activeMessageId || undefined,
+          "gen_ai.system": GEN_AI_PROVIDER_OPENCODE,
+          "gen_ai.provider.name": GEN_AI_PROVIDER_OPENCODE,
+          "gen_ai.operation.name": GEN_AI_OPERATION_EXECUTE_TOOL,
+          "gen_ai.tool.name": toolName,
+          "gen_ai.tool.call.id": callID,
+          "gen_ai.tool.call.type": toolTypeForName(toolName),
+          "gen_ai.tool.type": toolTypeForName(toolName),
           "valet.tool.name": toolName,
           "valet.tool.status": currentStatus,
+          ...(captureOtelContent()
+            ? {
+                "gen_ai.tool.call.arguments": stringifyTelemetryContent(state.input),
+                "gen_ai.tool.call.result": stringifyTelemetryContent(toolResult),
+              }
+            : {}),
         },
       });
       toolSpan.end();
@@ -4085,16 +4145,30 @@ export class PromptHandler {
 
     } else if (currentStatus === "error") {
       console.log(`[PromptHandler] Tool "${toolName}" error: ${state.error}`);
-      const toolSpan = startSpan("valet.tool", {
+      const toolSpan = startSpan(`${GEN_AI_OPERATION_EXECUTE_TOOL} ${toolName}`, {
         parent: parentFromTraceparent(this.currentPromptTraceparent),
         attributes: {
           "valet.session.id": this.runnerSessionId || undefined,
           "valet.message.id": channel.activeMessageId || undefined,
+          "gen_ai.system": GEN_AI_PROVIDER_OPENCODE,
+          "gen_ai.provider.name": GEN_AI_PROVIDER_OPENCODE,
+          "gen_ai.operation.name": GEN_AI_OPERATION_EXECUTE_TOOL,
+          "gen_ai.tool.name": toolName,
+          "gen_ai.tool.call.id": callID,
+          "gen_ai.tool.call.type": toolTypeForName(toolName),
+          "gen_ai.tool.type": toolTypeForName(toolName),
+          "error.type": "ToolExecutionError",
           "valet.tool.name": toolName,
           "valet.tool.status": currentStatus,
           "valet.tool.error": state.error,
+          ...(captureOtelContent()
+            ? {
+                "gen_ai.tool.call.arguments": stringifyTelemetryContent(state.input),
+              }
+            : {}),
         },
       });
+      toolSpan.recordException(state.error || "tool execution failed");
       toolSpan.end();
       this.agentClient.sendToolUpdate(channel.turnId!, callID, toolName, "error", state.input ?? undefined, undefined, state.error ?? undefined);
     }
@@ -4190,15 +4264,36 @@ export class PromptHandler {
               inputTokens: input,
               outputTokens: output,
             });
-            const llmSpan = startSpan("valet.llm", {
+            const provider = normalizeGenAIProvider(providerId);
+            const requestModel = modelId || usageModel;
+            const llmSpan = startSpan(`${GEN_AI_OPERATION_CHAT} ${requestModel}`, {
               parent: parentFromTraceparent(this.currentPromptTraceparent),
+              kind: SpanKind.CLIENT,
               attributes: {
                 "valet.session.id": this.runnerSessionId || undefined,
                 "valet.message.id": channel.activeMessageId || undefined,
-                "gen_ai.system": providerId,
-                "gen_ai.request.model": usageModel,
+                "valet.llm.provider_id": providerId,
+                "valet.llm.model_id": modelId,
+                "gen_ai.system": provider,
+                "gen_ai.provider.name": provider,
+                "gen_ai.operation.name": GEN_AI_OPERATION_CHAT,
+                "gen_ai.request.model": requestModel,
+                "gen_ai.response.model": requestModel,
+                "gen_ai.request.is_stream": true,
+                "gen_ai.output.type": GEN_AI_OUTPUT_TYPE_TEXT,
                 "gen_ai.usage.input_tokens": input,
                 "gen_ai.usage.output_tokens": output,
+                "gen_ai.usage.total_tokens": input + output,
+                ...(captureOtelContent()
+                  ? {
+                      "gen_ai.input.messages": channel.activePromptContent
+                        ? buildGenAIMessage("user", channel.activePromptContent)
+                        : undefined,
+                      "gen_ai.output.messages": channel.latestAssistantTextSnapshot
+                        ? buildGenAIMessage("assistant", channel.latestAssistantTextSnapshot)
+                        : undefined,
+                    }
+                  : {}),
               },
             });
             llmSpan.end();

--- a/packages/runner/src/prompt.ts
+++ b/packages/runner/src/prompt.ts
@@ -17,7 +17,7 @@
  */
 
 import { createTwoFilesPatch } from "diff";
-import { AgentClient, type PromptAuthor } from "./agent-client.js";
+import { AgentClient, type PromptAuthor, type PromptDispatch } from "./agent-client.js";
 import type { AvailableModels, DiffFile, PromptAttachment, ReviewFileSummary, ReviewResultData } from "./types.js";
 import { compileWorkflowDefinition, type NormalizedWorkflowStep } from "./workflow-compiler.js";
 import {
@@ -1502,7 +1502,23 @@ export class PromptHandler {
     });
   }
 
-  async handlePrompt(messageId: string, content: string, model?: string, author?: { authorId?: string; gitName?: string; gitEmail?: string; authorName?: string; authorEmail?: string }, modelPreferences?: string[], attachments?: PromptAttachment[], channelType?: string, channelId?: string, opencodeSessionId?: string, continuationContext?: string, threadId?: string, replyChannelType?: string, replyChannelId?: string, traceparent?: string): Promise<void> {
+  async handlePrompt(dispatch: PromptDispatch): Promise<void> {
+    const {
+      messageId,
+      content,
+      model,
+      author,
+      modelPreferences,
+      attachments,
+      channelType,
+      channelId,
+      opencodeSessionId,
+      continuationContext,
+      threadId,
+      replyChannelType,
+      replyChannelId,
+      traceparent,
+    } = dispatch;
     console.log(`[PromptHandler] Handling prompt ${messageId}: "${content.slice(0, 80)}"${model ? ` (model: ${model})` : ''}${author?.authorName ? ` (by: ${author.authorName})` : ''}${modelPreferences?.length ? ` (prefs: ${modelPreferences.length})` : ''}${attachments?.length ? ` (attachments: ${attachments.length})` : ''}${channelType ? ` (channel: ${channelType})` : ''}${continuationContext ? ' (with continuation context)' : ''}`);
     const turnSpan = startSpan("valet.turn", {
       parent: parentFromTraceparent(traceparent),

--- a/packages/runner/src/tracing.ts
+++ b/packages/runner/src/tracing.ts
@@ -1,0 +1,44 @@
+import {
+  SimpleTracer,
+  formatTraceparent,
+  parseTraceparent,
+  type SimpleSpan,
+  type SpanAttributes,
+  type TraceContext,
+} from "@valet/shared";
+
+let tracer: SimpleTracer | null = null;
+let sessionId: string | undefined;
+
+export function initTracing(currentSessionId: string): SimpleTracer {
+  sessionId = currentSessionId;
+  tracer = new SimpleTracer({
+    serviceName: "valet-runner",
+    endpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+    headers: process.env.OTEL_EXPORTER_OTLP_HEADERS,
+    resourceAttributes: {
+      "valet.session.id": currentSessionId,
+    },
+  });
+  return tracer;
+}
+
+export function startSpan(
+  name: string,
+  options: { parent?: TraceContext | null; attributes?: SpanAttributes } = {},
+): SimpleSpan {
+  if (!tracer) initTracing(sessionId || process.env.SESSION_ID || "unknown");
+  return tracer!.startSpan(name, options);
+}
+
+export async function flushTracing(): Promise<void> {
+  await tracer?.flush();
+}
+
+export function parentFromTraceparent(traceparent: string | undefined): TraceContext | null {
+  return parseTraceparent(traceparent || process.env.TRACEPARENT);
+}
+
+export function traceparentFromSpan(span: SimpleSpan): string {
+  return formatTraceparent(span.context);
+}

--- a/packages/runner/src/tracing.ts
+++ b/packages/runner/src/tracing.ts
@@ -1,9 +1,11 @@
 import {
   SimpleTracer,
+  SpanKind,
   formatTraceparent,
   parseTraceparent,
   type SimpleSpan,
   type SpanAttributes,
+  type SpanKindValue,
   type TraceContext,
 } from "@valet/shared";
 
@@ -25,7 +27,7 @@ export function initTracing(currentSessionId: string): SimpleTracer {
 
 export function startSpan(
   name: string,
-  options: { parent?: TraceContext | null; attributes?: SpanAttributes } = {},
+  options: { parent?: TraceContext | null; attributes?: SpanAttributes; kind?: SpanKindValue } = {},
 ): SimpleSpan {
   if (!tracer) initTracing(sessionId || process.env.SESSION_ID || "unknown");
   return tracer!.startSpan(name, options);
@@ -42,3 +44,5 @@ export function parentFromTraceparent(traceparent: string | undefined): TraceCon
 export function traceparentFromSpan(span: SimpleSpan): string {
   return formatTraceparent(span.context);
 }
+
+export { SpanKind };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,3 +3,4 @@ export * from './types/message-parts.js';
 export * from './types/runner-protocol.js';
 export * from './errors.js';
 export * from './scope-key.js';
+export * from './tracing.js';

--- a/packages/shared/src/tracing.test.ts
+++ b/packages/shared/src/tracing.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { SimpleTracer, SpanKind } from './tracing.js';
+
+describe('SimpleTracer', () => {
+  it('exports OpenLIT-compatible span kinds and array attributes as OTLP JSON', async () => {
+    let exportedBody: unknown;
+    const tracer = new SimpleTracer({
+      serviceName: 'valet-runner',
+      endpoint: 'https://otel.example.test/otlp',
+      fetchFn: (async (_url: string | URL | Request, init?: RequestInit) => {
+        exportedBody = JSON.parse(String(init?.body));
+        return new Response(null, { status: 200 });
+      }) as typeof fetch,
+    });
+
+    const span = tracer.startSpan('chat gpt-4o', {
+      kind: SpanKind.CLIENT,
+      attributes: {
+        'gen_ai.operation.name': 'chat',
+        'gen_ai.response.finish_reasons': ['stop'],
+        'gen_ai.usage.total_tokens': 12,
+      },
+    });
+    span.end();
+    await tracer.flush();
+
+    const body = exportedBody as {
+      resourceSpans: Array<{
+        scopeSpans: Array<{
+          spans: Array<{
+            name: string;
+            kind: number;
+            attributes: Array<{ key: string; value: Record<string, unknown> }>;
+          }>;
+        }>;
+      }>;
+    };
+    const exportedSpan = body.resourceSpans[0]?.scopeSpans[0]?.spans[0];
+    expect(exportedSpan?.name).toBe('chat gpt-4o');
+    expect(exportedSpan?.kind).toBe(SpanKind.CLIENT);
+    expect(exportedSpan?.attributes).toContainEqual({
+      key: 'gen_ai.response.finish_reasons',
+      value: { arrayValue: { values: [{ stringValue: 'stop' }] } },
+    });
+  });
+});

--- a/packages/shared/src/tracing.ts
+++ b/packages/shared/src/tracing.ts
@@ -36,6 +36,18 @@ export interface TracerOptions {
   headers?: string;
   resourceAttributes?: SpanAttributes;
   fetchFn?: typeof fetch;
+  /**
+   * Auto-flush once the buffered span count reaches this threshold.
+   * Set to 0 or undefined to disable auto-flush (callers must invoke flush() manually).
+   */
+  maxQueuedSpans?: number;
+  /**
+   * Hook invoked with the auto-flush promise so the host can keep the
+   * Promise alive (e.g. via `ctx.waitUntil` in a Cloudflare Worker DO).
+   * If omitted, auto-flush errors are logged and the promise is otherwise
+   * fire-and-forget.
+   */
+  scheduleFlush?: (flush: Promise<void>) => void;
 }
 
 interface FinishedSpan {
@@ -144,6 +156,8 @@ export class SimpleTracer {
   private readonly serviceName: string;
   private readonly resourceAttributes: SpanAttributes;
   private readonly fetchFn: typeof fetch;
+  private readonly maxQueuedSpans: number;
+  private readonly scheduleFlush?: (flush: Promise<void>) => void;
   private readonly spans: FinishedSpan[] = [];
 
   constructor(options: TracerOptions) {
@@ -152,6 +166,8 @@ export class SimpleTracer {
     this.serviceName = options.serviceName;
     this.resourceAttributes = options.resourceAttributes || {};
     this.fetchFn = options.fetchFn || fetch;
+    this.maxQueuedSpans = options.maxQueuedSpans ?? 0;
+    this.scheduleFlush = options.scheduleFlush;
   }
 
   get enabled(): boolean {
@@ -178,6 +194,14 @@ export class SimpleTracer {
   record(span: FinishedSpan): void {
     if (!this.enabled) return;
     this.spans.push(span);
+    if (this.maxQueuedSpans > 0 && this.spans.length >= this.maxQueuedSpans) {
+      const flushPromise = this.flush();
+      if (this.scheduleFlush) {
+        this.scheduleFlush(flushPromise);
+      } else {
+        flushPromise.catch((err) => console.warn('[Tracing] Auto-flush failed:', err));
+      }
+    }
   }
 
   async flush(): Promise<void> {
@@ -209,7 +233,9 @@ function randomHex(byteLength: number): string {
 }
 
 function msToUnixNano(ms: number): string {
-  return `${Math.floor(ms) * 1_000_000}`;
+  // Epoch nanoseconds exceed Number.MAX_SAFE_INTEGER, so multiply with BigInt
+  // to avoid silent precision loss in span timestamps.
+  return (BigInt(Math.floor(ms)) * 1_000_000n).toString();
 }
 
 function normalizeEndpoint(endpoint: string | undefined): string | undefined {

--- a/packages/shared/src/tracing.ts
+++ b/packages/shared/src/tracing.ts
@@ -1,0 +1,269 @@
+export interface TraceContext {
+  traceId: string;
+  spanId: string;
+  traceFlags?: string;
+}
+
+export interface SpanLink {
+  context: TraceContext;
+  attributes?: SpanAttributes;
+}
+
+export type SpanAttributeValue = string | number | boolean | undefined | null;
+export type SpanAttributes = Record<string, SpanAttributeValue>;
+
+export interface StartSpanOptions {
+  parent?: TraceContext | null;
+  links?: SpanLink[];
+  attributes?: SpanAttributes;
+  startTimeMs?: number;
+}
+
+export interface TracerOptions {
+  serviceName: string;
+  endpoint?: string;
+  headers?: string;
+  resourceAttributes?: SpanAttributes;
+  fetchFn?: typeof fetch;
+}
+
+interface FinishedSpan {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  startTimeUnixNano: string;
+  endTimeUnixNano: string;
+  attributes: SpanAttributes;
+  links: SpanLink[];
+  status?: { code: number; message?: string };
+}
+
+const TRACEPARENT_RE = /^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/i;
+
+export function parseTraceparent(value: string | null | undefined): TraceContext | null {
+  if (!value) return null;
+  const match = value.trim().match(TRACEPARENT_RE);
+  if (!match) return null;
+  const [, traceId, spanId, traceFlags] = match;
+  if (/^0+$/.test(traceId) || /^0+$/.test(spanId)) return null;
+  return { traceId: traceId.toLowerCase(), spanId: spanId.toLowerCase(), traceFlags: traceFlags.toLowerCase() };
+}
+
+export function formatTraceparent(context: TraceContext): string {
+  return `00-${context.traceId}-${context.spanId}-${context.traceFlags || '01'}`;
+}
+
+export function createTraceContext(parent?: TraceContext | null): TraceContext {
+  return {
+    traceId: parent?.traceId || randomHex(16),
+    spanId: randomHex(8),
+    traceFlags: parent?.traceFlags || '01',
+  };
+}
+
+export function isValidTraceContext(context: TraceContext | null | undefined): context is TraceContext {
+  return !!context && /^[0-9a-f]{32}$/.test(context.traceId) && /^[0-9a-f]{16}$/.test(context.spanId);
+}
+
+export class SimpleSpan {
+  readonly context: TraceContext;
+  readonly parent?: TraceContext | null;
+  private readonly tracer: SimpleTracer;
+  private readonly name: string;
+  private readonly startTimeMs: number;
+  private readonly attributes: SpanAttributes;
+  private readonly links: SpanLink[];
+  private ended = false;
+  private status: { code: number; message?: string } | undefined;
+
+  constructor(tracer: SimpleTracer, name: string, options: StartSpanOptions = {}) {
+    this.tracer = tracer;
+    this.name = name;
+    this.parent = options.parent;
+    this.startTimeMs = options.startTimeMs || Date.now();
+    this.attributes = { ...(options.attributes || {}) };
+    this.links = options.links || [];
+    this.context = createTraceContext(options.parent);
+  }
+
+  setAttribute(key: string, value: SpanAttributeValue): void {
+    this.attributes[key] = value;
+  }
+
+  setAttributes(attributes: SpanAttributes): void {
+    Object.assign(this.attributes, attributes);
+  }
+
+  recordException(error: unknown): void {
+    const message = error instanceof Error ? error.message : String(error);
+    this.attributes['exception.message'] = message.slice(0, 500);
+    if (error instanceof Error && error.name) this.attributes['exception.type'] = error.name;
+    this.status = { code: 2, message };
+  }
+
+  end(endTimeMs = Date.now()): void {
+    if (this.ended) return;
+    this.ended = true;
+    this.tracer.record({
+      traceId: this.context.traceId,
+      spanId: this.context.spanId,
+      parentSpanId: this.parent?.spanId,
+      name: this.name,
+      startTimeUnixNano: msToUnixNano(this.startTimeMs),
+      endTimeUnixNano: msToUnixNano(endTimeMs),
+      attributes: this.attributes,
+      links: this.links,
+      status: this.status,
+    });
+  }
+}
+
+export class SimpleTracer {
+  private readonly endpoint?: string;
+  private readonly headers: Record<string, string>;
+  private readonly serviceName: string;
+  private readonly resourceAttributes: SpanAttributes;
+  private readonly fetchFn: typeof fetch;
+  private readonly spans: FinishedSpan[] = [];
+
+  constructor(options: TracerOptions) {
+    this.endpoint = normalizeEndpoint(options.endpoint);
+    this.headers = parseOtelHeaders(options.headers);
+    this.serviceName = options.serviceName;
+    this.resourceAttributes = options.resourceAttributes || {};
+    this.fetchFn = options.fetchFn || fetch;
+  }
+
+  get enabled(): boolean {
+    return !!this.endpoint;
+  }
+
+  startSpan(name: string, options: StartSpanOptions = {}): SimpleSpan {
+    return new SimpleSpan(this, name, options);
+  }
+
+  async withSpan<T>(name: string, options: StartSpanOptions, fn: (span: SimpleSpan) => Promise<T>): Promise<T> {
+    const span = this.startSpan(name, options);
+    try {
+      const result = await fn(span);
+      span.end();
+      return result;
+    } catch (error) {
+      span.recordException(error);
+      span.end();
+      throw error;
+    }
+  }
+
+  record(span: FinishedSpan): void {
+    if (!this.enabled) return;
+    this.spans.push(span);
+  }
+
+  async flush(): Promise<void> {
+    if (!this.endpoint || this.spans.length === 0) return;
+    const spans = this.spans.splice(0, this.spans.length);
+    const body = buildOtlpJson(this.serviceName, this.resourceAttributes, spans);
+    try {
+      const response = await this.fetchFn(this.endpoint, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          ...this.headers,
+        },
+        body: JSON.stringify(body),
+      });
+      if (!response.ok) {
+        console.warn(`[Tracing] OTLP export failed: ${response.status} ${response.statusText}`);
+      }
+    } catch (error) {
+      console.warn('[Tracing] OTLP export failed:', error);
+    }
+  }
+}
+
+function randomHex(byteLength: number): string {
+  const bytes = new Uint8Array(byteLength);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function msToUnixNano(ms: number): string {
+  return `${Math.floor(ms) * 1_000_000}`;
+}
+
+function normalizeEndpoint(endpoint: string | undefined): string | undefined {
+  const trimmed = endpoint?.trim();
+  if (!trimmed) return undefined;
+  return trimmed.endsWith('/v1/traces')
+    ? trimmed
+    : `${trimmed.replace(/\/+$/, '')}/v1/traces`;
+}
+
+function parseOtelHeaders(headerSpec: string | undefined): Record<string, string> {
+  if (!headerSpec?.trim()) return {};
+  const headers: Record<string, string> = {};
+  for (const pair of headerSpec.split(',')) {
+    const idx = pair.indexOf('=');
+    if (idx <= 0) continue;
+    const key = decodeURIComponent(pair.slice(0, idx).trim());
+    const value = decodeURIComponent(pair.slice(idx + 1).trim());
+    if (key && value) headers[key] = value;
+  }
+  return headers;
+}
+
+function buildOtlpJson(serviceName: string, resourceAttributes: SpanAttributes, spans: FinishedSpan[]) {
+  return {
+    resourceSpans: [
+      {
+        resource: {
+          attributes: attributesToOtlp({
+            'service.name': serviceName,
+            ...resourceAttributes,
+          }),
+        },
+        scopeSpans: [
+          {
+            scope: { name: serviceName },
+            spans: spans.map((span) => ({
+              traceId: span.traceId,
+              spanId: span.spanId,
+              ...(span.parentSpanId ? { parentSpanId: span.parentSpanId } : {}),
+              name: span.name,
+              kind: 1,
+              startTimeUnixNano: span.startTimeUnixNano,
+              endTimeUnixNano: span.endTimeUnixNano,
+              attributes: attributesToOtlp(span.attributes),
+              ...(span.status ? { status: span.status } : {}),
+              ...(span.links.length > 0 ? { links: span.links.map(linkToOtlp) } : {}),
+            })),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function linkToOtlp(link: SpanLink) {
+  return {
+    traceId: link.context.traceId,
+    spanId: link.context.spanId,
+    attributes: attributesToOtlp(link.attributes || {}),
+  };
+}
+
+function attributesToOtlp(attributes: SpanAttributes) {
+  return Object.entries(attributes)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([key, value]) => ({ key, value: attributeValueToOtlp(value!) }));
+}
+
+function attributeValueToOtlp(value: string | number | boolean) {
+  if (typeof value === 'boolean') return { boolValue: value };
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? { intValue: String(value) } : { doubleValue: value };
+  }
+  return { stringValue: value };
+}

--- a/packages/shared/src/tracing.ts
+++ b/packages/shared/src/tracing.ts
@@ -9,7 +9,17 @@ export interface SpanLink {
   attributes?: SpanAttributes;
 }
 
-export type SpanAttributeValue = string | number | boolean | undefined | null;
+export const SpanKind = {
+  INTERNAL: 1,
+  SERVER: 2,
+  CLIENT: 3,
+  PRODUCER: 4,
+  CONSUMER: 5,
+} as const;
+
+export type SpanKindValue = (typeof SpanKind)[keyof typeof SpanKind];
+type SpanAttributeScalar = string | number | boolean;
+export type SpanAttributeValue = SpanAttributeScalar | readonly SpanAttributeScalar[] | undefined | null;
 export type SpanAttributes = Record<string, SpanAttributeValue>;
 
 export interface StartSpanOptions {
@@ -17,6 +27,7 @@ export interface StartSpanOptions {
   links?: SpanLink[];
   attributes?: SpanAttributes;
   startTimeMs?: number;
+  kind?: SpanKindValue;
 }
 
 export interface TracerOptions {
@@ -36,6 +47,7 @@ interface FinishedSpan {
   endTimeUnixNano: string;
   attributes: SpanAttributes;
   links: SpanLink[];
+  kind: SpanKindValue;
   status?: { code: number; message?: string };
 }
 
@@ -74,6 +86,7 @@ export class SimpleSpan {
   private readonly startTimeMs: number;
   private readonly attributes: SpanAttributes;
   private readonly links: SpanLink[];
+  private readonly kind: SpanKindValue;
   private ended = false;
   private status: { code: number; message?: string } | undefined;
 
@@ -84,6 +97,7 @@ export class SimpleSpan {
     this.startTimeMs = options.startTimeMs || Date.now();
     this.attributes = { ...(options.attributes || {}) };
     this.links = options.links || [];
+    this.kind = options.kind || SpanKind.INTERNAL;
     this.context = createTraceContext(options.parent);
   }
 
@@ -102,6 +116,10 @@ export class SimpleSpan {
     this.status = { code: 2, message };
   }
 
+  setStatus(code: number, message?: string): void {
+    this.status = { code, message };
+  }
+
   end(endTimeMs = Date.now()): void {
     if (this.ended) return;
     this.ended = true;
@@ -114,6 +132,7 @@ export class SimpleSpan {
       endTimeUnixNano: msToUnixNano(endTimeMs),
       attributes: this.attributes,
       links: this.links,
+      kind: this.kind,
       status: this.status,
     });
   }
@@ -232,7 +251,7 @@ function buildOtlpJson(serviceName: string, resourceAttributes: SpanAttributes, 
               spanId: span.spanId,
               ...(span.parentSpanId ? { parentSpanId: span.parentSpanId } : {}),
               name: span.name,
-              kind: 1,
+              kind: span.kind,
               startTimeUnixNano: span.startTimeUnixNano,
               endTimeUnixNano: span.endTimeUnixNano,
               attributes: attributesToOtlp(span.attributes),
@@ -260,7 +279,14 @@ function attributesToOtlp(attributes: SpanAttributes) {
     .map(([key, value]) => ({ key, value: attributeValueToOtlp(value!) }));
 }
 
-function attributeValueToOtlp(value: string | number | boolean) {
+function attributeValueToOtlp(value: SpanAttributeScalar | readonly SpanAttributeScalar[]): Record<string, unknown> {
+  if (Array.isArray(value)) {
+    return {
+      arrayValue: {
+        values: value.map(attributeValueToOtlp),
+      },
+    };
+  }
   if (typeof value === 'boolean') return { boolValue: value };
   if (typeof value === 'number') {
     return Number.isInteger(value) ? { intValue: String(value) } : { doubleValue: value };

--- a/packages/shared/src/types/runner-protocol.ts
+++ b/packages/shared/src/types/runner-protocol.ts
@@ -118,6 +118,8 @@ export type DOToRunnerMessage =
       authorName?: string;
       gitName?: string;
       gitEmail?: string;
+      /** W3C traceparent for correlating this runner turn with worker dispatch. */
+      traceparent?: string;
     }
   | { type: 'answer'; questionId: string; answer: string | boolean }
   | { type: 'stop' }
@@ -223,6 +225,8 @@ export type DOToRunnerMessage =
       model?: string;
       modelPreferences?: string[];
       payload: WorkflowExecutionDispatchPayload;
+      /** W3C traceparent for correlating this workflow dispatch with worker spans. */
+      traceparent?: string;
     }
   | {
       type: 'list-tools-result';
@@ -271,6 +275,8 @@ export type DOToRunnerMessage =
       repoUrl?: string;
       branch?: string;
       ref?: string;
+      /** W3C traceparent for runner bootstrap/repo setup correlation. */
+      traceparent?: string;
     }
   | { type: 'repo-token-refreshed'; token: string; expiresAt?: string; requestId?: string }
   | {

--- a/packages/worker/src/durable-objects/prompt-queue.ts
+++ b/packages/worker/src/durable-objects/prompt-queue.ts
@@ -438,12 +438,18 @@ export class PromptQueue {
     return parseInt(this.getState('promptReceivedAt') || '0', 10);
   }
 
-  stampPromptReceived(): void {
+  stampPromptReceived(reason?: string): void {
     this.setState('promptReceivedAt', String(Date.now()));
+    if (reason) this.setState('promptQueueReason', reason);
   }
 
   clearPromptReceived(): void {
     this.setState('promptReceivedAt', '');
+    this.setState('promptQueueReason', '');
+  }
+
+  get promptQueueReason(): string | undefined {
+    return this.getState('promptQueueReason') || undefined;
   }
 
   get currentPromptAuthorId(): string | undefined {

--- a/packages/worker/src/durable-objects/session-agent.ts
+++ b/packages/worker/src/durable-objects/session-agent.ts
@@ -405,6 +405,12 @@ export class SessionAgentDO {
         serviceName: 'valet-worker',
         endpoint: this.env.OTEL_EXPORTER_OTLP_ENDPOINT,
         headers: this.env.OTEL_EXPORTER_OTLP_HEADERS,
+        // Auto-flush in batches so high-volume span sites (prompt dispatch,
+        // child events) don't fire one OTLP POST per span. Boundary flushes
+        // (hibernate/terminate/error finally blocks) still call flushTracing()
+        // explicitly to drain the buffer before the DO goes idle.
+        maxQueuedSpans: 50,
+        scheduleFlush: (promise) => this.ctx.waitUntil(promise),
       });
 
       this.initialized = true;
@@ -2100,7 +2106,6 @@ export class SessionAgentDO {
     });
     dispatchSpan.setAttribute('valet.dispatch.sent', dispatched);
     dispatchSpan.end();
-    this.flushTracing();
     if (!dispatched) {
       // Runner disappeared between the check and send — revert to queued for recovery
       this.promptQueue.revertProcessingToQueued(messageId);
@@ -2834,7 +2839,6 @@ export class SessionAgentDO {
                 traceparent: formatTraceparent(dispatchSpan.context),
               });
               dispatchSpan.end();
-              this.flushTracing();
               this.promptQueue.stampDispatched();
               console.log(`[SessionAgentDO] agentStatus idle: dispatched initial prompt ${messageId}`);
             }
@@ -4616,7 +4620,6 @@ export class SessionAgentDO {
           });
           dispatchSpan.setAttribute('valet.dispatch.sent', sysDispatched);
           dispatchSpan.end();
-          this.flushTracing();
           if (!sysDispatched) {
             this.promptQueue.revertProcessingToQueued(messageId);
             this.promptQueue.runnerBusy = false;
@@ -4706,7 +4709,6 @@ export class SessionAgentDO {
     });
     dispatchSpan.setAttribute('valet.dispatch.sent', directWfDispatched);
     dispatchSpan.end();
-    this.flushTracing();
     if (!directWfDispatched) {
       this.promptQueue.runnerBusy = false;
       return queueWorkflowDispatch('runner_send_failed');
@@ -4882,7 +4884,6 @@ export class SessionAgentDO {
       });
       dispatchSpan.setAttribute('valet.dispatch.sent', wfDispatched);
       dispatchSpan.end();
-      this.flushTracing();
       if (!wfDispatched) {
         this.promptQueue.revertProcessingToQueued(prompt.id);
         this.promptQueue.runnerBusy = false;
@@ -4974,7 +4975,6 @@ export class SessionAgentDO {
     });
     dispatchSpan.setAttribute('valet.dispatch.sent', queueDispatched);
     dispatchSpan.end();
-    this.flushTracing();
     if (!queueDispatched) {
       this.promptQueue.revertProcessingToQueued(prompt.id);
       this.emitAuditEvent('prompt.dispatch_failed', `Queue dispatch failed, reverted: ${prompt.id.slice(0, 8)}`);

--- a/packages/worker/src/durable-objects/session-agent.ts
+++ b/packages/worker/src/durable-objects/session-agent.ts
@@ -15,6 +15,7 @@ import { resolveOrgPolicyMatch, updateInvocationStatus, upsertUserActionPolicyOv
 import { getActivePluginArtifacts, getPluginSettings } from '../lib/db/plugins.js';
 import { getPersonaSkills, getOrgDefaultSkills, getPersonaToolWhitelist } from '../lib/db.js';
 import type { ChannelTarget, ChannelContext, InteractivePrompt, InteractiveAction, InteractivePromptRef, InteractiveResolution } from '@valet/sdk';
+import { SimpleTracer, formatTraceparent, parseTraceparent, type SimpleSpan, type TraceContext, type SpanAttributes } from '@valet/shared';
 import { MessageStore } from './message-store.js';
 import { getChannelForMessage, dropEmission } from './channel-resolver.js';
 import { ChannelRouter } from './channel-router.js';
@@ -309,6 +310,7 @@ export class SessionAgentDO {
   private runnerLink!: RunnerLink;
   private sessionState!: SessionState;
   private lifecycle!: SessionLifecycle;
+  private tracer!: SimpleTracer;
 
   private static readonly RUNNER_GRACE_PERIOD_MS = 60_000;
   private static readonly MODAL_SANDBOX_MAX_LIFETIME_MS = 24 * 60 * 60 * 1000;
@@ -399,8 +401,61 @@ export class SessionAgentDO {
         ...stateDeps,
       });
       this.lifecycle = new SessionLifecycle(this.sessionState, this.ctx);
+      this.tracer = new SimpleTracer({
+        serviceName: 'valet-worker',
+        endpoint: this.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+        headers: this.env.OTEL_EXPORTER_OTLP_HEADERS,
+      });
 
       this.initialized = true;
+    });
+  }
+
+  private traceAttrs(attrs: SpanAttributes = {}): SpanAttributes {
+    return {
+      'valet.session.id': this.sessionState?.sessionId || undefined,
+      'valet.user.id': this.sessionState?.userId || undefined,
+      ...attrs,
+    };
+  }
+
+  private lifecycleContext(): TraceContext | null {
+    const traceId = this.sessionState.lifecycleTraceId;
+    const spanId = this.sessionState.lifecycleSpanId;
+    return parseTraceparent(traceId && spanId ? `00-${traceId}-${spanId}-01` : undefined);
+  }
+
+  private storeLifecycleContext(span: SimpleSpan): void {
+    this.sessionState.lifecycleTraceId = span.context.traceId;
+    this.sessionState.lifecycleSpanId = span.context.spanId;
+  }
+
+  private injectTraceparentIntoSpawnRequest(
+    spawnRequest: Record<string, unknown>,
+    traceparent: string,
+  ): Record<string, unknown> {
+    const envVars = {
+      ...((spawnRequest.envVars as Record<string, string> | undefined) || {}),
+      TRACEPARENT: traceparent,
+    };
+    return { ...spawnRequest, envVars };
+  }
+
+  private flushTracing(): void {
+    this.ctx.waitUntil(this.tracer.flush());
+  }
+
+  private startPromptDispatchSpan(attrs: SpanAttributes): SimpleSpan {
+    const queuedAt = this.promptQueue.promptReceivedAt;
+    const waitMs = queuedAt > 0 ? Date.now() - queuedAt : 0;
+    return this.tracer.startSpan('valet.prompt.dispatch', {
+      parent: this.lifecycleContext(),
+      attributes: this.traceAttrs({
+        'valet.queue.wait_ms': waitMs,
+        'valet.queue.reason': this.promptQueue.promptQueueReason || 'immediate',
+        'valet.queue.mode': this.promptQueue.queueMode,
+        ...attrs,
+      }),
     });
   }
 
@@ -1865,6 +1920,9 @@ export class SessionAgentDO {
       const reason = runnerBusy ? 'runner busy'
         : !runnerConnected ? 'no runner connected'
         : 'runner not ready';
+      const queueReason = runnerBusy ? 'runner_busy'
+        : !runnerConnected ? 'runner_disconnected'
+        : 'runner_not_ready';
       console.log(`[SessionAgentDO] handlePrompt: QUEUING (${reason}) channel=${channelKey} messageId=${messageId}`);
 
       // Single-slot enforcement: withdraw existing pending user prompt
@@ -1893,7 +1951,7 @@ export class SessionAgentDO {
         replyChannelType: effectiveReplyTo?.channelType, replyChannelId: effectiveReplyTo?.channelId,
         priority: skipSingleSlot ? 1 : 0,
       });
-      this.promptQueue.stampPromptReceived();
+      this.promptQueue.stampPromptReceived(queueReason);
       this.emitAuditEvent(
         'prompt.queued',
         `Queued: ${reason} (status=${status || 'unknown'}, sandbox=${sandboxId ? 'yes' : 'no'}, queued=${this.promptQueue.length})`,
@@ -1973,7 +2031,7 @@ export class SessionAgentDO {
     );
 
     console.log(`[SessionAgentDO] handlePrompt: DISPATCHING DIRECTLY channel=${channelKey} messageId=${messageId}`);
-    this.promptQueue.stampPromptReceived();
+    this.promptQueue.stampPromptReceived('immediate');
     // Insert into prompt_queue as 'processing' so it can be recovered if the runner disconnects
     this.promptQueue.enqueue({
       id: messageId, content, attachments: serializedQueuedAttachments, model, status: 'processing',
@@ -2012,6 +2070,11 @@ export class SessionAgentDO {
       : content;
 
     const channelOcSessionId = this.getChannelOcSessionId(channelKey);
+    const dispatchSpan = this.startPromptDispatchSpan({
+      'valet.message.id': messageId,
+      'valet.channel.type': channelType,
+      'valet.channel.id': channelId,
+    });
     const dispatched = this.runnerLink.send({
       type: 'prompt',
       messageId,
@@ -2033,7 +2096,11 @@ export class SessionAgentDO {
       opencodeSessionId: channelOcSessionId,
       modelPreferences: resolvedModelPrefs,
       continuationContext,
+      traceparent: formatTraceparent(dispatchSpan.context),
     });
+    dispatchSpan.setAttribute('valet.dispatch.sent', dispatched);
+    dispatchSpan.end();
+    this.flushTracing();
     if (!dispatched) {
       // Runner disappeared between the check and send — revert to queued for recovery
       this.promptQueue.revertProcessingToQueued(messageId);
@@ -2752,6 +2819,11 @@ export class SessionAgentDO {
               if (initialModel) {
                 this.sessionState.initialModel = undefined;
               }
+              this.promptQueue.stampPromptReceived('initial_prompt');
+              const dispatchSpan = this.startPromptDispatchSpan({
+                'valet.message.id': messageId,
+                'valet.prompt.source': 'initial',
+              });
               this.runnerLink.send({
                 type: 'prompt',
                 messageId,
@@ -2759,7 +2831,10 @@ export class SessionAgentDO {
                 model: initialModel || undefined,
                 opencodeSessionId: this.getChannelOcSessionId(this.channelKeyFrom(undefined, undefined)),
                 modelPreferences: ipModelPrefs,
+                traceparent: formatTraceparent(dispatchSpan.context),
               });
+              dispatchSpan.end();
+              this.flushTracing();
               this.promptQueue.stampDispatched();
               console.log(`[SessionAgentDO] agentStatus idle: dispatched initial prompt ${messageId}`);
             }
@@ -4046,6 +4121,14 @@ export class SessionAgentDO {
     spawnRequest: Record<string, unknown>,
   ): Promise<void> {
     const sessionId = this.sessionState.sessionId;
+    const span = this.tracer.startSpan('valet.sandbox.spawn', {
+      attributes: this.traceAttrs({
+        'valet.sandbox.image': typeof spawnRequest.imageType === 'string' ? spawnRequest.imageType : undefined,
+      }),
+    });
+    this.storeLifecycleContext(span);
+    const tracedSpawnRequest = this.injectTraceparentIntoSpawnRequest(spawnRequest, formatTraceparent(span.context));
+    this.sessionState.spawnRequest = tracedSpawnRequest;
     try {
       this.sessionState.sandboxWakeStartedAt = Date.now();
 
@@ -4053,7 +4136,11 @@ export class SessionAgentDO {
       // detect if a newer recovery/refresh started while we were waiting.
       const expectedGeneration = this.sessionState.sandboxGeneration;
 
-      const result = await this.lifecycle.spawnSandbox(backendUrl, spawnRequest);
+      const result = await this.lifecycle.spawnSandbox(backendUrl, tracedSpawnRequest);
+      span.setAttributes({
+        'valet.sandbox.id': result.sandboxId,
+        'duration_ms': result.durationMs,
+      });
 
       // Guard against stale spawn — a newer recovery/refresh may have started
       // while this spawn was in flight. Discard the result to avoid overwriting
@@ -4137,6 +4224,10 @@ export class SessionAgentDO {
         contextSessionId: sessionId || undefined,
       });
       await this.notifyParentEvent(`Child session event: ${sessionId} errored (${errorText}).`, { wake: true, childStatus: 'error' });
+      span.recordException(err);
+    } finally {
+      span.end();
+      this.flushTracing();
     }
   }
 
@@ -4208,7 +4299,22 @@ export class SessionAgentDO {
 
     // Only terminate sandbox if it's actually running (not hibernated/hibernating)
     if (currentStatus !== 'hibernated' && currentStatus !== 'hibernating') {
-      await this.lifecycle.terminateSandbox();
+      const span = this.tracer.startSpan('valet.sandbox.terminate', {
+        parent: this.lifecycleContext(),
+        attributes: this.traceAttrs({
+          'valet.sandbox.id': sandboxId,
+          'valet.stop.reason': reason,
+        }),
+      });
+      try {
+        await this.lifecycle.terminateSandbox();
+      } catch (err) {
+        span.recordException(err);
+        throw err;
+      } finally {
+        span.end();
+        this.flushTracing();
+      }
     }
 
     // Clear idle alarm
@@ -4490,6 +4596,13 @@ export class SessionAgentDO {
             await this.ensureThreadOcSessionHydrated(threadId, sysChannelKey);
           }
           const sysOcSessionId = this.getChannelOcSessionId(sysChannelKey);
+          this.promptQueue.stampPromptReceived('system_message');
+          const dispatchSpan = this.startPromptDispatchSpan({
+            'valet.message.id': messageId,
+            'valet.prompt.source': 'system',
+            'valet.channel.type': sysChannelType,
+            'valet.channel.id': sysChannelId,
+          });
           const sysDispatched = this.runnerLink.send({
             type: 'prompt',
             messageId,
@@ -4499,7 +4612,11 @@ export class SessionAgentDO {
             threadId: threadId || undefined,
             opencodeSessionId: sysOcSessionId,
             modelPreferences: sysModelPrefs,
+            traceparent: formatTraceparent(dispatchSpan.context),
           });
+          dispatchSpan.setAttribute('valet.dispatch.sent', sysDispatched);
+          dispatchSpan.end();
+          this.flushTracing();
           if (!sysDispatched) {
             this.promptQueue.revertProcessingToQueued(messageId);
             this.promptQueue.runnerBusy = false;
@@ -4576,12 +4693,20 @@ export class SessionAgentDO {
     const dispatchOwnerDetails = dispatchOwnerId ? await this.getUserDetails(dispatchOwnerId) : undefined;
     const dispatchModelPrefs = await this.resolveModelPreferences(dispatchOwnerDetails);
 
+    const dispatchSpan = this.startPromptDispatchSpan({
+      'valet.workflow.execution_id': executionId,
+      'valet.prompt.type': 'workflow_execute',
+    });
     const directWfDispatched = this.runnerLink.send({
       type: 'workflow-execute',
       executionId,
       payload: validPayload,
       modelPreferences: dispatchModelPrefs,
+      traceparent: formatTraceparent(dispatchSpan.context),
     });
+    dispatchSpan.setAttribute('valet.dispatch.sent', directWfDispatched);
+    dispatchSpan.end();
+    this.flushTracing();
     if (!directWfDispatched) {
       this.promptQueue.runnerBusy = false;
       return queueWorkflowDispatch('runner_send_failed');
@@ -4744,12 +4869,20 @@ export class SessionAgentDO {
       const queueOwnerId = this.sessionState.userId;
       const queueOwnerDetails = queueOwnerId ? await this.getUserDetails(queueOwnerId) : undefined;
       const queueModelPrefs = await this.resolveModelPreferences(queueOwnerDetails);
+      const dispatchSpan = this.startPromptDispatchSpan({
+        'valet.workflow.execution_id': queuedExecutionId,
+        'valet.prompt.type': 'workflow_execute',
+      });
       const wfDispatched = this.runnerLink.send({
         type: 'workflow-execute',
         executionId: queuedExecutionId,
         payload: queuedPayload,
         modelPreferences: queueModelPrefs,
+        traceparent: formatTraceparent(dispatchSpan.context),
       });
+      dispatchSpan.setAttribute('valet.dispatch.sent', wfDispatched);
+      dispatchSpan.end();
+      this.flushTracing();
       if (!wfDispatched) {
         this.promptQueue.revertProcessingToQueued(prompt.id);
         this.promptQueue.runnerBusy = false;
@@ -4813,6 +4946,11 @@ export class SessionAgentDO {
       ? `${prompt.contextPrefix}\n\n${prompt.content}`
       : prompt.content;
 
+    const dispatchSpan = this.startPromptDispatchSpan({
+      'valet.message.id': prompt.id,
+      'valet.channel.type': queueChannelType,
+      'valet.channel.id': queueChannelId,
+    });
     const queueDispatched = this.runnerLink.send({
       type: 'prompt',
       messageId: prompt.id,
@@ -4832,7 +4970,11 @@ export class SessionAgentDO {
       opencodeSessionId: queueOcSessionId,
       modelPreferences: queueModelPrefs,
       continuationContext: prompt.continuationContext || undefined,
+      traceparent: formatTraceparent(dispatchSpan.context),
     });
+    dispatchSpan.setAttribute('valet.dispatch.sent', queueDispatched);
+    dispatchSpan.end();
+    this.flushTracing();
     if (!queueDispatched) {
       this.promptQueue.revertProcessingToQueued(prompt.id);
       this.emitAuditEvent('prompt.dispatch_failed', `Queue dispatch failed, reverted: ${prompt.id.slice(0, 8)}`);
@@ -5349,6 +5491,13 @@ export class SessionAgentDO {
 
   private async performHibernate(): Promise<void> {
     const sessionId = this.sessionState.sessionId;
+    const span = this.tracer.startSpan('valet.sandbox.hibernate', {
+      parent: this.lifecycleContext(),
+      attributes: this.traceAttrs({
+        'valet.sandbox.id': this.sessionState.sandboxId,
+      }),
+    });
+    this.storeLifecycleContext(span);
 
     // Concurrency guard — prevents duplicate hibernate calls from overlapping alarms.
     // The alarm handler sets status to 'hibernating' before ctx.waitUntil(performHibernate()),
@@ -5356,12 +5505,18 @@ export class SessionAgentDO {
     const currentStatus = this.sessionState.status;
     if (currentStatus !== 'hibernating') {
       console.log(`[SessionAgentDO] performHibernate skipped — status is ${currentStatus}`);
+      span.setAttribute('valet.skip_reason', `status:${currentStatus}`);
+      span.end();
+      this.flushTracing();
       return;
     }
 
     if (!this.sessionState.sandboxId || !this.sessionState.hibernateUrl) {
       console.error('[SessionAgentDO] Cannot hibernate: missing sandboxId or hibernateUrl');
       this.sessionState.status = 'running';
+      span.setAttribute('valet.skip_reason', 'missing_sandbox_or_hibernate_url');
+      span.end();
+      this.flushTracing();
       return;
     }
 
@@ -5387,6 +5542,7 @@ export class SessionAgentDO {
 
       // Snapshot via lifecycle (pure HTTP)
       const result = await this.lifecycle.snapshotSandbox();
+      span.setAttribute('valet.snapshot.image_id', result.snapshotImageId);
 
       // Stop runner AFTER snapshot — ordering enforced by call sequence
       this.runnerLink.send({ type: 'stop' });
@@ -5432,6 +5588,7 @@ export class SessionAgentDO {
         this.ctx.waitUntil(this.performWake());
       }
     } catch (err) {
+      span.recordException(err);
       // 409: sandbox already exited — route through proper termination
       if (err instanceof SandboxAlreadyExitedError) {
         console.log(`[SessionAgentDO] Session ${sessionId} sandbox already finished — routing to handleStop`);
@@ -5467,14 +5624,27 @@ export class SessionAgentDO {
       this.broadcastToClients({ type: 'status', data: { status: 'error' } });
       this.broadcastToClients({ type: 'error', messageId: errId, error: errorText });
       await this.notifyParentEvent(`Child session event: ${sessionId} errored (${errorText}).`, { wake: true, childStatus: 'error' });
+    } finally {
+      span.end();
+      this.flushTracing();
     }
   }
 
   private async performWake(): Promise<void> {
+    const span = this.tracer.startSpan('valet.sandbox.restore', {
+      parent: this.lifecycleContext(),
+      attributes: this.traceAttrs({
+        'valet.snapshot.image_id': this.sessionState.snapshotImageId,
+      }),
+    });
+    this.storeLifecycleContext(span);
     // Concurrency guard — prevents duplicate wake calls
     const currentStatus = this.sessionState.status;
     if (currentStatus === 'restoring' || currentStatus === 'running') {
       console.log(`[SessionAgentDO] performWake skipped — already ${currentStatus}`);
+      span.setAttribute('valet.skip_reason', `status:${currentStatus}`);
+      span.end();
+      this.flushTracing();
       return;
     }
 
@@ -5492,6 +5662,9 @@ export class SessionAgentDO {
       this.broadcastToClients({ type: 'status', data: { status: 'error' } });
       this.broadcastToClients({ type: 'error', error: errorText });
       await this.notifyParentEvent(`Child session event: ${sessionId} errored (${errorText}).`, { wake: true, childStatus: 'error' });
+      span.setAttribute('valet.skip_reason', 'missing_restore_inputs');
+      span.end();
+      this.flushTracing();
       return;
     }
 
@@ -5508,9 +5681,17 @@ export class SessionAgentDO {
       }
 
       this.sessionState.sandboxWakeStartedAt = Date.now();
+      this.sessionState.spawnRequest = this.injectTraceparentIntoSpawnRequest(
+        this.sessionState.spawnRequest!,
+        formatTraceparent(span.context),
+      );
 
       // Restore via lifecycle (pure HTTP)
       const result = await this.lifecycle.restoreSandbox();
+      span.setAttributes({
+        'valet.sandbox.id': result.sandboxId,
+        'duration_ms': result.durationMs,
+      });
 
       this.emitEvent('sandbox_restore', {
         durationMs: result.durationMs,
@@ -5547,6 +5728,7 @@ export class SessionAgentDO {
       this.emitAuditEvent('session.restored', 'Session restored from hibernation');
       console.log(`[SessionAgentDO] Session ${sessionId} restored, new sandbox: ${result.sandboxId}`);
     } catch (err) {
+      span.recordException(err);
       console.error(`[SessionAgentDO] Failed to restore session ${sessionId}:`, err);
       const errorText = `Failed to restore session: ${err instanceof Error ? err.message : String(err)}`;
       this.sessionState.status = 'error';
@@ -5564,6 +5746,9 @@ export class SessionAgentDO {
       this.broadcastToClients({ type: 'status', data: { status: 'error' } });
       this.broadcastToClients({ type: 'error', messageId: errId, error: errorText });
       await this.notifyParentEvent(`Child session event: ${sessionId} errored (${errorText}).`, { wake: true, childStatus: 'error' });
+    } finally {
+      span.end();
+      this.flushTracing();
     }
   }
 
@@ -7046,21 +7231,22 @@ export class SessionAgentDO {
     // promise promptly. If we bail early or credentials fail, send with no repoUrl
     // so the Runner knows no clone is coming and doesn't burn the full timeout.
     const sessionId = this.sessionState.sessionId;
+    const traceparent = this.lifecycleContext() ? formatTraceparent(this.lifecycleContext()!) : undefined;
     if (!sessionId) {
-      this.runnerLink.send({ type: 'repo-config', token: null, gitConfig: {} });
+      this.runnerLink.send({ type: 'repo-config', token: null, gitConfig: {}, traceparent });
       return;
     }
 
     const gitState = await getSessionGitState(this.appDb, sessionId);
     const repoUrl = gitState?.sourceRepoUrl;
     if (!repoUrl) {
-      this.runnerLink.send({ type: 'repo-config', token: null, gitConfig: {} });
+      this.runnerLink.send({ type: 'repo-config', token: null, gitConfig: {}, traceparent });
       return;
     }
 
     const userId = this.sessionState.userId;
     if (!userId) {
-      this.runnerLink.send({ type: 'repo-config', token: null, gitConfig: {} });
+      this.runnerLink.send({ type: 'repo-config', token: null, gitConfig: {}, traceparent });
       return;
     }
 
@@ -7075,7 +7261,7 @@ export class SessionAgentDO {
 
       if (repoEnv.error) {
         console.warn(`[SessionAgentDO] sendRepoConfig: ${repoEnv.error}`);
-        this.runnerLink.send({ type: 'repo-config', token: null, gitConfig: {} });
+        this.runnerLink.send({ type: 'repo-config', token: null, gitConfig: {}, traceparent });
         return;
       }
 
@@ -7088,14 +7274,15 @@ export class SessionAgentDO {
           repoUrl,
           branch: gitState.branch ?? undefined,
           ref: gitState.ref ?? undefined,
+          traceparent,
         });
         console.log(`[SessionAgentDO] Sent repo-config to runner for ${repoUrl}`);
       } else {
-        this.runnerLink.send({ type: 'repo-config', token: null, gitConfig: {} });
+        this.runnerLink.send({ type: 'repo-config', token: null, gitConfig: {}, traceparent });
       }
     } catch (err) {
       console.error('[SessionAgentDO] Failed to assemble repo config for runner:', err);
-      this.runnerLink.send({ type: 'repo-config', token: null, gitConfig: {} });
+      this.runnerLink.send({ type: 'repo-config', token: null, gitConfig: {}, traceparent });
     }
   }
 

--- a/packages/worker/src/durable-objects/session-state.ts
+++ b/packages/worker/src/durable-objects/session-state.ts
@@ -125,6 +125,22 @@ export class SessionState {
     this.set('snapshotImageId', id || '');
   }
 
+  get lifecycleTraceId(): string | undefined {
+    return this.get('lifecycleTraceId') || undefined;
+  }
+
+  set lifecycleTraceId(id: string | undefined) {
+    this.set('lifecycleTraceId', id || '');
+  }
+
+  get lifecycleSpanId(): string | undefined {
+    return this.get('lifecycleSpanId') || undefined;
+  }
+
+  set lifecycleSpanId(id: string | undefined) {
+    this.set('lifecycleSpanId', id || '');
+  }
+
   // ─── Backend URLs ─────────────────────────────────────────────────
 
   get backendUrl(): string | undefined {
@@ -420,6 +436,8 @@ export class SessionState {
     this.runningStartedAt = 0;
     this.sandboxWakeStartedAt = 0;
     this.sandboxStartedAt = 0;
+    this.lifecycleTraceId = undefined;
+    this.lifecycleSpanId = undefined;
     this.initialPrompt = undefined;
     this.initialModel = undefined;
     this.parentThreadId = undefined;

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -40,6 +40,11 @@ export interface Env {
   // Optional Worker name fallback (used when FRONTEND_URL is a Pages domain).
   WORKER_NAME?: string;
 
+  // OpenTelemetry OTLP/HTTP export. Tracing is disabled when endpoint is unset.
+  OTEL_EXPORTER_OTLP_ENDPOINT?: string;
+  OTEL_EXPORTER_OTLP_HEADERS?: string;
+  OTEL_CAPTURE_CONTENT?: string;
+
   // Slack integration
   SLACK_SIGNING_SECRET?: string;
   SLACK_BOT_TOKEN?: string;

--- a/packages/worker/src/lib/env-assembly.ts
+++ b/packages/worker/src/lib/env-assembly.ts
@@ -18,6 +18,24 @@ export function generateRunnerToken(): string {
 }
 
 /**
+ * Assemble tracing env vars for sandbox processes. TRACEPARENT is supplied by
+ * the SessionAgent DO at spawn/restore time because it owns lifecycle spans.
+ */
+export function assembleTracingEnv(env: Env): Record<string, string> {
+  const envVars: Record<string, string> = {};
+  if (env.OTEL_EXPORTER_OTLP_ENDPOINT) {
+    envVars.OTEL_EXPORTER_OTLP_ENDPOINT = env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  }
+  if (env.OTEL_EXPORTER_OTLP_HEADERS) {
+    envVars.OTEL_EXPORTER_OTLP_HEADERS = env.OTEL_EXPORTER_OTLP_HEADERS;
+  }
+  if (env.OTEL_CAPTURE_CONTENT) {
+    envVars.OTEL_CAPTURE_CONTENT = env.OTEL_CAPTURE_CONTENT;
+  }
+  return envVars;
+}
+
+/**
  * Assemble LLM provider API keys from org DB keys, falling back to env vars.
  */
 export async function assembleProviderEnv(

--- a/packages/worker/src/services/orchestrator.ts
+++ b/packages/worker/src/services/orchestrator.ts
@@ -6,7 +6,7 @@ import { getDb } from '../lib/drizzle.js';
 import { buildDoWebSocketUrl } from '../lib/do-ws-url.js';
 import { buildOrchestratorPersonaFiles } from '../lib/orchestrator-persona.js';
 import { findPersonaByName, upsertPersonaByName, upsertPersonaFile } from '../lib/db/personas.js';
-import { generateRunnerToken, assembleProviderEnv, assembleCredentialEnv } from '../lib/env-assembly.js';
+import { generateRunnerToken, assembleProviderEnv, assembleCredentialEnv, assembleTracingEnv } from '../lib/env-assembly.js';
 import { ensureTodayJournal } from '../lib/db/memory-files.js';
 import { loadMemorySnapshot, formatMemorySnapshot } from '../lib/memory-snapshot.js';
 import { deriveSandboxJwtSecret } from '../lib/jwt.js';
@@ -132,6 +132,7 @@ export async function restartOrchestratorSession(
     IS_ORCHESTRATOR: 'true',
     ...providerVars,
     ...credentialVars,
+    ...assembleTracingEnv(env),
   };
 
   const doWsUrl = buildDoWebSocketUrl({

--- a/packages/worker/src/services/sessions.ts
+++ b/packages/worker/src/services/sessions.ts
@@ -5,7 +5,7 @@ import type { AppDb } from '../lib/drizzle.js';
 import { getDb } from '../lib/drizzle.js';
 import { deriveSandboxJwtSecret, signJWT } from '../lib/jwt.js';
 import { buildDoWebSocketUrl } from '../lib/do-ws-url.js';
-import { generateRunnerToken, assembleProviderEnv, assembleCredentialEnv, assembleCustomProviders, assembleBuiltInProviderModelConfigs, assembleRepoEnv } from '../lib/env-assembly.js';
+import { generateRunnerToken, assembleProviderEnv, assembleCredentialEnv, assembleCustomProviders, assembleBuiltInProviderModelConfigs, assembleRepoEnv, assembleTracingEnv } from '../lib/env-assembly.js';
 import { getCredential } from '../services/credentials.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -297,7 +297,7 @@ export async function createSession(
   // Build environment variables for the sandbox
   const providerVars = await assembleProviderEnv(appDb, env);
   const credentialVars = await assembleCredentialEnv(appDb, env, params.userId);
-  const envVars: Record<string, string> = { ...providerVars, ...credentialVars };
+  const envVars: Record<string, string> = { ...providerVars, ...credentialVars, ...assembleTracingEnv(env) };
 
   // Custom LLM providers
   const customProviders = await assembleCustomProviders(appDb, env.ENCRYPTION_KEY);


### PR DESCRIPTION
## Summary
- add a dependency-free OTLP/HTTP JSON tracer shared by worker and runner
- propagate W3C traceparent through sandbox env, DO→runner protocol messages, and runner→OpenCode HTTP calls
- instrument worker lifecycle/dispatch spans plus runner bootstrap, repo setup, turn, workflow, tool, and LLM usage spans
- document TKAI-2 implementation coverage in the session tracing spec

## Test plan

- [x] Unit tests
- [ ] Smoke test
- [ ] Deploy

Need to set.
```
OTEL_EXPORTER_OTLP_ENDPOINT=<grafana otlp endpoint>
OTEL_EXPORTER_OTLP_HEADERS=<auth headers>
```

## Verification
- `pnpm --filter @valet/shared typecheck`
- `pnpm --filter @valet/runner typecheck`
- `pnpm --filter @valet/worker typecheck`
- `pnpm --filter @valet/runner test -- src/prompt.test.ts`
- `pnpm --filter @valet/worker exec vitest run src/durable-objects/prompt-queue.test.ts src/durable-objects/runner-link.test.ts`

Refs TKAI-2