### PR TITLE
feat: require ENVIRONMENT=dev|prod for all deploy targets

### DIFF
--- a/.env.deploy.example
+++ b/.env.deploy.example
@@ -1,12 +1,14 @@
 # Deployment Configuration
-# Copy to .env.deploy and set PROJECT_NAME. That's the only required value.
-# Everything else is auto-discovered or derived. See scripts/deploy.sh.
+# Copy to .env.deploy.<env> (e.g. .env.deploy.dev, .env.deploy.prod)
+# Usage: ENVIRONMENT=dev make deploy
+#
+# All resource names derive from PROJECT_NAME to avoid collisions:
+#   Worker:  ${PROJECT_NAME}           (e.g. valet-prod)
+#   Pages:   ${PROJECT_NAME}-client    (e.g. valet-prod-client)
+#   D1:      ${PROJECT_NAME}-db        (e.g. valet-prod-db)
+#   R2:      ${PROJECT_NAME}-storage   (e.g. valet-prod-storage)
+#   Modal:   ${PROJECT_NAME}-backend   (e.g. valet-prod-backend)
 
-# Project name — all resource names derive from this to avoid collisions:
-#   Worker:  ${PROJECT_NAME}           (e.g. valet-conner)
-#   Pages:   ${PROJECT_NAME}-client    (e.g. valet-conner-client)
-#   D1:      ${PROJECT_NAME}-db        (e.g. valet-conner-db)
-#   R2:      ${PROJECT_NAME}-storage   (e.g. valet-conner-storage)
 PROJECT_NAME=valet-yourname
 
 # Optional: comma-separated email allowlist (empty = no restriction)
@@ -15,4 +17,5 @@ ALLOWED_EMAILS=
 # Optional overrides (auto-discovered if omitted):
 # D1_DATABASE_ID=           # looked up from wrangler d1 list
 # MODAL_BACKEND_URL=        # constructed from modal profile
+# MODAL_APP_NAME=           # default: ${PROJECT_NAME}-backend
 # MODAL_DEPLOY_CMD=         # default: uv run --project backend modal deploy

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ wrangler.deploy.toml
 .env.local
 .env.*.local
 .env.deploy
+.env.deploy.*
+!.env.deploy.example
 .dev.vars
 
 # Client production env (generated from .env.deploy at build time)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,10 +131,11 @@ make generate-registries # Regenerate action/channel plugin registries
 # Logs
 make logs-cloudflare     # Tail deployed Cloudflare Worker logs
 
-# Deploy
-make deploy              # Deploy worker + modal + client (includes migrations)
-make deploy-migrate      # Apply D1 migrations to production only
-make release             # Full idempotent release: install, build, push image, deploy
+# Deploy (requires ENVIRONMENT=dev|prod)
+ENVIRONMENT=dev make deploy              # Deploy worker + modal + client (includes migrations)
+ENVIRONMENT=prod make deploy-worker      # Deploy just the worker to prod
+ENVIRONMENT=prod make deploy-migrate     # Apply D1 migrations to prod
+ENVIRONMENT=prod make release            # Full idempotent release to prod
 ```
 
 ### Applying D1 Migrations to Production
@@ -142,7 +143,7 @@ make release             # Full idempotent release: install, build, push image, 
 `make deploy` includes the migration step, but if you need to apply migrations separately:
 
 ```bash
-make deploy-migrate
+ENVIRONMENT=prod make deploy-migrate
 ```
 
 All deploy targets (`deploy-worker`, `deploy-migrate`, `deploy-modal`, `deploy-client`) are thin wrappers around `scripts/deploy.sh` which auto-discovers config (D1 ID, Modal workspace URL, worker URL) from CLI tools when values aren't set in `.env.deploy`.

--- a/Makefile
+++ b/Makefile
@@ -25,15 +25,24 @@
 
 # Configuration
 # =============
-# Source deployment config if it exists (copy .env.deploy.example to .env.deploy)
--include .env.deploy
+# Per-environment config: .env.deploy.dev, .env.deploy.prod, etc.
+# Usage: ENVIRONMENT=dev make deploy
+#
+# For local dev targets (dev-worker, dev-client, etc.) ENVIRONMENT is not required.
+# For deploy/bootstrap/destroy targets, ENVIRONMENT must be set.
 
-# Project name — all resource names derive from this (set in .env.deploy)
+ifdef ENVIRONMENT
+-include .env.deploy.$(ENVIRONMENT)
+endif
+
+# Project name — all resource names derive from this (set in .env.deploy.<env>)
 PROJECT_NAME ?= valet
 CF_WORKER_NAME ?= $(PROJECT_NAME)
 PAGES_PROJECT_NAME ?= $(PROJECT_NAME)-client
 D1_DATABASE_NAME ?= $(PROJECT_NAME)-db
 R2_BUCKET_NAME ?= $(PROJECT_NAME)-storage
+
+MODAL_APP_NAME ?= $(PROJECT_NAME)-backend
 
 WORKER_URL ?= http://localhost:8787
 WORKER_PROD_URL ?= https://$(CF_WORKER_NAME).workers.dev
@@ -564,16 +573,16 @@ e2e-ci: ## E2E tests for CI (includes cleanup)
 # that already exist. After bootstrap, update .env.deploy with the D1
 # database ID printed below, then run `make deploy`.
 
-bootstrap: bootstrap-d1 bootstrap-r2 bootstrap-pages ## Create all remote Cloudflare resources
+bootstrap: _require-env bootstrap-d1 bootstrap-r2 bootstrap-pages ## Create all remote Cloudflare resources (ENVIRONMENT=dev|prod)
 	@echo ""
 	@echo "$(GREEN)========================================$(NC)"
-	@echo "$(GREEN)Bootstrap complete!$(NC)"
+	@echo "$(GREEN)Bootstrap complete! [$(ENVIRONMENT)]$(NC)"
 	@echo "$(GREEN)========================================$(NC)"
 	@echo ""
 	@echo "Next steps:"
-	@echo "  1. Copy the D1 database ID above into .env.deploy as D1_DATABASE_ID"
-	@echo "  2. Run $(YELLOW)make bootstrap-secrets$(NC) to set worker secrets"
-	@echo "  3. Run $(YELLOW)make deploy$(NC) to deploy everything"
+	@echo "  1. Copy the D1 database ID above into .env.deploy.$(ENVIRONMENT) as D1_DATABASE_ID"
+	@echo "  2. Run $(YELLOW)ENVIRONMENT=$(ENVIRONMENT) make bootstrap-secrets$(NC) to set worker secrets"
+	@echo "  3. Run $(YELLOW)ENVIRONMENT=$(ENVIRONMENT) make deploy$(NC) to deploy everything"
 
 bootstrap-d1: ## Create D1 database
 	@echo "$(GREEN)Creating D1 database '$(D1_DATABASE_NAME)'...$(NC)"
@@ -593,7 +602,7 @@ bootstrap-pages: ## Create Cloudflare Pages project
 		&& echo "$(YELLOW)Pages project already exists$(NC)" \
 		|| echo "$(GREEN)✓ Pages project created$(NC)"
 
-bootstrap-secrets: ## Set required worker secrets (interactive)
+bootstrap-secrets: _require-env ## Set required worker secrets (ENVIRONMENT=dev|prod)
 	@echo "$(GREEN)Setting secrets for worker '$(CF_WORKER_NAME)'...$(NC)"
 	@echo ""
 	@echo "Required secrets:"
@@ -630,9 +639,18 @@ VERSION ?= $(shell git rev-parse --short HEAD 2>/dev/null || date +%Y%m%d%H%M%S)
 generate-registries: ## Generate auto-discovered plugin registry files
 	@cd packages/worker && bun scripts/generate-plugin-registry.ts
 
-release: ## Full idempotent release: install, build, push image, deploy all
+# Guard: require ENVIRONMENT for deploy/bootstrap/destroy targets
+_require-env:
+ifndef ENVIRONMENT
+	$(error ENVIRONMENT is required. Usage: ENVIRONMENT=dev make <target>)
+endif
+ifeq (,$(wildcard .env.deploy.$(ENVIRONMENT)))
+	$(error Config file .env.deploy.$(ENVIRONMENT) not found. Copy .env.deploy.example to .env.deploy.$(ENVIRONMENT))
+endif
+
+release: _require-env ## Full idempotent release: install, build, push image, deploy all
 	@echo "$(GREEN)========================================$(NC)"
-	@echo "$(GREEN)Starting Release (version: $(VERSION))$(NC)"
+	@echo "$(GREEN)Starting Release [$(ENVIRONMENT)] (version: $(VERSION))$(NC)"
 	@echo "$(GREEN)========================================$(NC)"
 	@echo ""
 	@echo "Step 1/4: Installing dependencies..."
@@ -646,29 +664,29 @@ release: ## Full idempotent release: install, build, push image, deploy all
 	@make image-push VERSION=$(VERSION)
 	@echo ""
 	@echo "Step 4/4: Deploying (worker + migrations + modal + client)..."
-	@./scripts/deploy.sh all
+	@ENVIRONMENT=$(ENVIRONMENT) ./scripts/deploy.sh all
 	@echo ""
 	@echo "$(GREEN)========================================$(NC)"
-	@echo "$(GREEN)Release complete! (version: $(VERSION))$(NC)"
+	@echo "$(GREEN)Release complete! [$(ENVIRONMENT)] (version: $(VERSION))$(NC)"
 	@echo "$(GREEN)========================================$(NC)"
 	@echo ""
 	@echo "$(YELLOW)OpenCode Image:$(NC) $(GHCR_REPO):$(VERSION)"
 	@echo "$(YELLOW)Set OPENCODE_IMAGE in Cloudflare to this value.$(NC)"
 
-deploy: ## Deploy everything — auto-creates resources, discovers URLs
-	@./scripts/deploy.sh all
+deploy: _require-env ## Deploy everything (ENVIRONMENT=dev|prod)
+	@ENVIRONMENT=$(ENVIRONMENT) ./scripts/deploy.sh all
 
-deploy-worker: ## Deploy Cloudflare Worker (auto-discovers config)
-	@./scripts/deploy.sh worker
+deploy-worker: _require-env ## Deploy Cloudflare Worker (ENVIRONMENT=dev|prod)
+	@ENVIRONMENT=$(ENVIRONMENT) ./scripts/deploy.sh worker
 
-deploy-migrate: ## Apply D1 migrations to production
-	@./scripts/deploy.sh migrate
+deploy-migrate: _require-env ## Apply D1 migrations (ENVIRONMENT=dev|prod)
+	@ENVIRONMENT=$(ENVIRONMENT) ./scripts/deploy.sh migrate
 
-deploy-modal: ## Deploy Modal backend (includes runner)
-	@./scripts/deploy.sh modal
+deploy-modal: _require-env ## Deploy Modal backend (ENVIRONMENT=dev|prod)
+	@ENVIRONMENT=$(ENVIRONMENT) ./scripts/deploy.sh modal
 
-deploy-client: ## Build and deploy client to Cloudflare Pages
-	@./scripts/deploy.sh client
+deploy-client: _require-env ## Build and deploy client (ENVIRONMENT=dev|prod)
+	@ENVIRONMENT=$(ENVIRONMENT) ./scripts/deploy.sh client
 
 dev-client: ## Start client dev server
 	@echo "$(GREEN)Starting client on http://localhost:5173...$(NC)"
@@ -710,17 +728,14 @@ image-push: image-build ## Build and push OpenCode image to GHCR
 # ==========================================
 # Teardown / Destroy
 # ==========================================
-# These targets destroy PRODUCTION resources. Use with care.
+# These targets destroy remote resources. Use with care.
 # Resource names default to the current config (CF_WORKER_NAME, etc.)
 # but can be overridden, e.g.:
-#   make destroy CF_WORKER_NAME=old-name PAGES_PROJECT_NAME=old-pages ...
+#   ENVIRONMENT=dev make destroy CF_WORKER_NAME=old-name ...
 
-# Modal app name
-MODAL_APP_NAME ?= $(PROJECT_NAME)-backend
-
-destroy: ## Destroy all remote resources (Worker, D1, R2, Pages, Modal) — DESTRUCTIVE
+destroy: _require-env ## Destroy all remote resources (ENVIRONMENT=dev|prod) — DESTRUCTIVE
 	@echo "$(RED)========================================$(NC)"
-	@echo "$(RED)  DESTROYING PRODUCTION RESOURCES$(NC)"
+	@echo "$(RED)  DESTROYING $(ENVIRONMENT) RESOURCES$(NC)"
 	@echo "$(RED)========================================$(NC)"
 	@echo ""
 	@echo "  Worker:  $(CF_WORKER_NAME)"

--- a/backend/app.py
+++ b/backend/app.py
@@ -8,7 +8,7 @@ import modal
 
 from config import WHISPER_MODELS_MOUNT, WHISPER_MODELS_VOLUME
 
-app = modal.App("valet-backend")
+app = modal.App(os.environ.get("MODAL_APP_NAME", "valet-backend"))
 
 # Image for the web functions — includes our backend Python modules
 # Also mount runner package and docker files so sandbox image builds can reference them

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,18 +8,32 @@ NC='\033[0m'
 
 # ─── Config ──────────────────────────────────────────────────────────────────
 
-# Source deploy config if it exists
-if [ -f .env.deploy ]; then
-    set -a; source .env.deploy; set +a
+# Require ENVIRONMENT to select which config file to source
+: "${ENVIRONMENT:?Set ENVIRONMENT (dev|prod). Usage: ENVIRONMENT=prod $0 [command]}"
+
+DEPLOY_CONFIG=".env.deploy.${ENVIRONMENT}"
+if [ ! -f "$DEPLOY_CONFIG" ]; then
+    # Migration hint for old .env.deploy users
+    if [ -f .env.deploy ]; then
+        echo -e "${RED}Found .env.deploy but ENVIRONMENT=${ENVIRONMENT} requires ${DEPLOY_CONFIG}${NC}"
+        echo "Rename .env.deploy to .env.deploy.dev (or .env.deploy.prod) to migrate."
+    else
+        echo -e "${RED}Config file not found: ${DEPLOY_CONFIG}${NC}"
+        echo "Copy .env.deploy.example to ${DEPLOY_CONFIG} and set PROJECT_NAME."
+    fi
+    exit 1
 fi
 
-: "${PROJECT_NAME:?Set PROJECT_NAME in .env.deploy (e.g. valet-yourname)}"
+set -a; source "$DEPLOY_CONFIG"; set +a
 
-# Derived names (all overridable via .env.deploy)
+: "${PROJECT_NAME:?Set PROJECT_NAME in ${DEPLOY_CONFIG} (e.g. valet-prod)}"
+
+# Derived names (all overridable via config file)
 CF_WORKER_NAME="${CF_WORKER_NAME:-$PROJECT_NAME}"
 PAGES_PROJECT_NAME="${PAGES_PROJECT_NAME:-${PROJECT_NAME}-client}"
 D1_DATABASE_NAME="${D1_DATABASE_NAME:-${PROJECT_NAME}-db}"
 R2_BUCKET_NAME="${R2_BUCKET_NAME:-${PROJECT_NAME}-storage}"
+MODAL_APP_NAME="${MODAL_APP_NAME:-${PROJECT_NAME}-backend}"
 ALLOWED_EMAILS="${ALLOWED_EMAILS:-}"
 MODAL_DEPLOY_CMD="${MODAL_DEPLOY_CMD:-uv run --project backend modal deploy}"
 
@@ -153,9 +167,9 @@ cmd_migrate() {
 }
 
 cmd_modal() {
-    echo -e "${GREEN}Deploying Modal backend...${NC}"
-    $MODAL_DEPLOY_CMD backend/app.py
-    echo -e "${GREEN}✓ Modal backend deployed${NC}"
+    echo -e "${GREEN}Deploying Modal backend (${MODAL_APP_NAME})...${NC}"
+    MODAL_APP_NAME="$MODAL_APP_NAME" $MODAL_DEPLOY_CMD backend/app.py
+    echo -e "${GREEN}✓ Modal backend deployed (${MODAL_APP_NAME})${NC}"
 }
 
 cmd_client() {
@@ -187,7 +201,7 @@ cmd_client() {
 
 cmd_all() {
     echo -e "${GREEN}========================================${NC}"
-    echo -e "${GREEN}Deploying ${PROJECT_NAME}${NC}"
+    echo -e "${GREEN}Deploying ${PROJECT_NAME} (${ENVIRONMENT})${NC}"
     echo -e "${GREEN}========================================${NC}"
     echo ""
 
@@ -240,9 +254,9 @@ cmd_all() {
 
     # --- Step 6: Deploy Modal backend ---
     echo ""
-    echo "Step 6/7: Deploying Modal backend..."
-    $MODAL_DEPLOY_CMD backend/app.py
-    echo -e "${GREEN}✓ Modal backend deployed${NC}"
+    echo "Step 6/7: Deploying Modal backend (${MODAL_APP_NAME})..."
+    MODAL_APP_NAME="$MODAL_APP_NAME" $MODAL_DEPLOY_CMD backend/app.py
+    echo -e "${GREEN}✓ Modal backend deployed (${MODAL_APP_NAME})${NC}"
 
     # --- Step 7: Build and deploy client ---
     echo ""
@@ -264,7 +278,11 @@ cmd_all() {
     echo "  wrangler secret put ENCRYPTION_KEY --name ${CF_WORKER_NAME}"
     echo "  wrangler secret put GITHUB_CLIENT_ID --name ${CF_WORKER_NAME}"
     echo "  wrangler secret put GITHUB_CLIENT_SECRET --name ${CF_WORKER_NAME}"
+    echo "  wrangler secret put GOOGLE_CLIENT_ID --name ${CF_WORKER_NAME}"
+    echo "  wrangler secret put GOOGLE_CLIENT_SECRET --name ${CF_WORKER_NAME}"
     echo "  wrangler secret put FRONTEND_URL --name ${CF_WORKER_NAME}"
+    echo ""
+    echo -e "${YELLOW}Or run: ENVIRONMENT=${ENVIRONMENT} make bootstrap-secrets${NC}"
 }
 
 # ─── Dispatch ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- All deploy, bootstrap, and destroy targets now require `ENVIRONMENT=dev|prod` to be set explicitly
- Each environment gets its own config file (`.env.deploy.dev`, `.env.deploy.prod`) with isolated Cloudflare and Modal resources
- Modal app name is now parameterized via env var, fixing the mismatch between the hardcoded `valet-backend` in `app.py` and the Makefile's `${PROJECT_NAME}-backend` derivation
- Local dev targets (`dev-worker`, `dev-client`, etc.) are unchanged

Usage:
```bash
ENVIRONMENT=dev make deploy           # full deploy to dev
ENVIRONMENT=prod make deploy-worker   # just the worker to prod
ENVIRONMENT=prod make bootstrap       # first-time resource creation
ENVIRONMENT=prod make bootstrap-secrets  # set OAuth creds
```

## Test plan

- [x] `make deploy` without ENVIRONMENT errors with clear message
- [x] `ENVIRONMENT=prod make deploy` without `.env.deploy.prod` errors with clear message
- [x] `ENVIRONMENT=dev make deploy --dry-run` resolves config and runs deploy script
- [ ] `ENVIRONMENT=dev make deploy` runs full deploy against dev environment