### PR TITLE
fix: unblock /auth/providers on cold start + show error UI on login

### DIFF
--- a/packages/client/src/components/auth/login-form.tsx
+++ b/packages/client/src/components/auth/login-form.tsx
@@ -163,10 +163,11 @@ export function LoginForm() {
   const workerUrl = getWorkerBaseUrl();
   const error = new URLSearchParams(window.location.search).get('error');
 
-  const { data: providers, isLoading } = useQuery({
+  const { data: providers, isLoading, isError, refetch, isFetching } = useQuery({
     queryKey: authKeys.providers,
     queryFn: fetchAuthProviders,
     staleTime: 60_000,
+    retry: 3,
   });
 
   const redirectProviders = providers?.filter(p => p.protocol !== 'credentials') ?? [];
@@ -209,6 +210,20 @@ export function LoginForm() {
 
         {isLoading ? (
           <LoadingSkeleton />
+        ) : isError ? (
+          <div className="space-y-2 text-center">
+            <p className="text-sm text-red-600">
+              Couldn't load sign-in options. Please try again.
+            </p>
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => { refetch(); }}
+              disabled={isFetching}
+            >
+              {isFetching ? 'Retrying...' : 'Retry'}
+            </Button>
+          </div>
         ) : (
           <>
             {redirectProviders.map((provider, idx) => (

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -122,12 +122,21 @@ app.onError(errorHandler);
 // Sync plugin registry to D1 on cold start. Runs in the background via
 // ctx.waitUntil so requests never block on it — the registry is idempotent
 // and slightly stale content for one request is acceptable.
+//
+// Skip entirely for public latency-critical paths so cold isolates serving
+// the login screen / health checks / OAuth redirects don't even spin up
+// the work alongside them.
+const PLUGIN_SYNC_SKIP_PREFIXES = ['/auth', '/health'];
 app.use('*', async (c, next) => {
-  c.executionCtx.waitUntil(
-    syncPluginsOnce(c.env.DB).catch((err) => {
-      console.error('[plugin-sync] Sync failed, continuing:', err);
-    }),
-  );
+  const path = c.req.path;
+  const skip = PLUGIN_SYNC_SKIP_PREFIXES.some((p) => path === p || path.startsWith(`${p}/`));
+  if (!skip) {
+    c.executionCtx.waitUntil(
+      syncPluginsOnce(c.env.DB).catch((err) => {
+        console.error('[plugin-sync] Sync failed, continuing:', err);
+      }),
+    );
+  }
   return next();
 });
 

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -119,13 +119,15 @@ app.use(
 // Error handling
 app.onError(errorHandler);
 
-// Sync plugin registry to D1 on cold start (best-effort — don't block requests on failure)
+// Sync plugin registry to D1 on cold start. Runs in the background via
+// ctx.waitUntil so requests never block on it — the registry is idempotent
+// and slightly stale content for one request is acceptable.
 app.use('*', async (c, next) => {
-  try {
-    await syncPluginsOnce(c.env.DB);
-  } catch (err) {
-    console.error('[plugin-sync] Sync failed, continuing:', err);
-  }
+  c.executionCtx.waitUntil(
+    syncPluginsOnce(c.env.DB).catch((err) => {
+      console.error('[plugin-sync] Sync failed, continuing:', err);
+    }),
+  );
   return next();
 });
 


### PR DESCRIPTION
## Summary

Fixes a prod issue where the Valet login page renders with no sign-in buttons — just two dark gray rectangles where the provider buttons should be. Those rectangles were the loading skeleton; users hit the page before the worker finished booting.

Three layered fixes (one commit each):

1. **`fix(worker): run plugin sync in background, not blocking requests`** — `syncPluginsOnce` was awaited in a `app.use('*', …)` middleware, doing ~47 serial D1 writes before the route handler ran. On a cold isolate, every public request (including `/auth/providers`) waited for that. Moved it into `c.executionCtx.waitUntil(...)` so it runs after the response is sent. The registry sync is already idempotent and best-effort — slightly stale content for the first request is fine.

2. **`fix(worker): skip plugin sync on public latency-critical paths`** — even with `waitUntil`, kicking the sync off on every unauthenticated request still wastes D1 capacity on the cold-start path users see most. Skip entirely for `/auth/*` and `/health*`. Authenticated traffic on `/api/*` still drives it.

3. **`fix(client): show error + retry on LoginForm when providers fetch fails`** — when `/auth/providers` errored out, the loading skeleton would disappear and `providers` would be `undefined`, so the card rendered with just a title and zero buttons — visually identical to "no providers configured." Added an explicit error message + Retry button, and bumped that one query's retry count from the default 1 to 3 so transient cold-starts don't trip it.

## Root cause writeup

Full RCA (with code references) is in the linked secret gist: https://gist.github.com/figitaki/887c9a34e95a8820ba14280399f2abda

Fixes #1, #2, and #3 from that doc. (#4 — rate-limiting the sync — is left as defense-in-depth follow-up.)

## Test plan

- [ ] `cd packages/worker && pnpm typecheck` — clean
- [ ] `cd packages/client && pnpm typecheck` — clean
- [ ] Deploy to a preview env and confirm `/auth/providers` returns within ~100ms on a cold isolate
- [ ] Force `fetchAuthProviders` to fail (e.g. block the request in devtools) and confirm the LoginForm shows the error + Retry button instead of an empty card
- [ ] Confirm authenticated `/api/*` traffic still triggers a plugin sync (check worker logs for `[plugin-sync]`)