### PR TITLE
fix: strip Slack approval buttons immediately on click

### DIFF
--- a/packages/worker/src/routes/slack-events.ts
+++ b/packages/worker/src/routes/slack-events.ts
@@ -632,6 +632,37 @@ slackEventsRouter.post('/slack/interactive', async (c) => {
     return slackError('Only the session owner can respond to this prompt.');
   }
 
+  // Strip the buttons immediately so the user sees their click landed and can't
+  // re-click while the DO processes the resolution. We do this via response_url
+  // (no token lookup needed) and await it so it lands before the DO's later
+  // chat.update with the final "Approved/Denied by ..." state.
+  const responseUrl = payload.response_url as string | undefined;
+  const originalMessage = payload.message as Record<string, unknown> | undefined;
+  if (responseUrl && originalMessage) {
+    const originalBlocks = (originalMessage.blocks as Array<Record<string, unknown>> | undefined) ?? [];
+    const preservedBlocks = originalBlocks.filter((b) => b.type !== 'actions');
+    const processingBlocks = [
+      ...preservedBlocks,
+      { type: 'context', elements: [{ type: 'mrkdwn', text: '⏳ Processing…' }] },
+    ];
+    try {
+      const resp = await fetch(responseUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          replace_original: true,
+          text: (originalMessage.text as string) || 'Processing…',
+          blocks: processingBlocks,
+        }),
+      });
+      if (!resp.ok) {
+        console.warn(`[Slack Interactive] response_url update failed: status=${resp.status}`);
+      }
+    } catch (err) {
+      console.warn('[Slack Interactive] response_url update threw:', err);
+    }
+  }
+
   // Respond to Slack immediately (3-second deadline)
   // Process resolution asynchronously — the DO validates prompt existence and ownership
   c.executionCtx.waitUntil((async () => {


### PR DESCRIPTION
## Summary

- Slack interactive prompts kept their Approve/Deny buttons clickable for the entire duration of the underlying tool execution. The handler returned 200 within Slack's 3-second deadline (`packages/worker/src/routes/slack-events.ts:659`), which dropped Slack's spinner, but the message wasn't actually updated until the DO finished `executeActionAndSend` (`session-agent.ts:5836`) and only then called `chat.update`. On slow actions that gap was many seconds, during which users could re-click Approve.
- Fix: before scheduling the DO call, POST to the payload's `response_url` with `replace_original: true` and the original blocks minus the `actions` block, plus a "⏳ Processing…" context line. The DO's existing final-state `chat.update` still runs at the end and overwrites with "✅ Approved by …" / "❌ Denied by …".
- Slack-only change. No `ChannelTransport` interface change. Wrapped in try/catch — if `response_url` fails the old behavior is preserved.

## Test plan

- [ ] `pnpm typecheck` passes (verified locally)
- [ ] Deploy to dev: `ENVIRONMENT=dev make deploy-worker`
- [ ] Trigger an approval-gated action in Slack, click **Approve** — buttons should disappear within ~500ms and be replaced by "⏳ Processing…", then by "✅ Approved by …" once the action completes
- [ ] Repeat with **Deny** — same intermediate state, then "❌ Denied by …"
- [ ] Try a slow approval (real third-party API call) and confirm buttons stay gone for the entire processing window
- [ ] Check `make logs-cloudflare` for `[Slack Interactive] response_url update failed` warnings — should be zero