### PR TITLE
feat: configurable Drive corpora org setting (TKAI-49)

### DIFF
--- a/packages/client/src/api/admin.ts
+++ b/packages/client/src/api/admin.ts
@@ -27,7 +27,7 @@ export function useUpdateOrgSettings() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: Partial<Pick<OrgSettings, 'name' | 'allowedEmailDomain' | 'allowedEmails' | 'domainGatingEnabled' | 'emailAllowlistEnabled' | 'modelPreferences' | 'enabledLoginProviders' | 'driveLabelsGuardEnabled' | 'driveRequiredLabelIds' | 'driveLabelsFailMode'>>) =>
+    mutationFn: (data: Partial<Pick<OrgSettings, 'name' | 'allowedEmailDomain' | 'allowedEmails' | 'domainGatingEnabled' | 'emailAllowlistEnabled' | 'modelPreferences' | 'enabledLoginProviders' | 'driveLabelsGuardEnabled' | 'driveRequiredLabelIds' | 'driveLabelsFailMode' | 'driveCorpora'>>) =>
       api.put<OrgSettings>('/admin', data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: adminKeys.settings() });

--- a/packages/client/src/routes/settings/admin.tsx
+++ b/packages/client/src/routes/settings/admin.tsx
@@ -101,7 +101,7 @@ function AdminSettingsPage() {
         <InvitesSection />
         <UsersSection currentUserId={user.id} />
         <DefaultSkillsSection />
-        <DriveLabelsGuardSection />
+        <GoogleDriveSection />
         <ActionPoliciesSection />
         <PluginsSection />
       </div>
@@ -2612,7 +2612,7 @@ function LoginProvidersSection() {
 
 // --- Drive Labels Guard ---
 
-function DriveLabelsGuardSection() {
+function GoogleDriveSection() {
   const { data: settings } = useOrgSettings();
   const updateSettings = useUpdateOrgSettings();
   const { data: labelsData, isLoading: labelsLoading } = useDriveLabels();
@@ -2620,6 +2620,7 @@ function DriveLabelsGuardSection() {
   const [enabled, setEnabled] = React.useState(false);
   const [selectedIds, setSelectedIds] = React.useState<string[]>([]);
   const [failMode, setFailMode] = React.useState<'deny' | 'allow'>('deny');
+  const [driveCorpora, setDriveCorpora] = React.useState<'user' | 'domain' | 'allDrives'>('user');
   const [saved, setSaved] = React.useState(false);
 
   React.useEffect(() => {
@@ -2627,6 +2628,7 @@ function DriveLabelsGuardSection() {
     setEnabled(settings.driveLabelsGuardEnabled ?? false);
     setSelectedIds(settings.driveRequiredLabelIds ?? []);
     setFailMode(settings.driveLabelsFailMode ?? 'deny');
+    setDriveCorpora(settings.driveCorpora ?? 'user');
   }, [settings]);
 
   const labelsAvailable = labelsData?.available === true;
@@ -2644,6 +2646,7 @@ function DriveLabelsGuardSection() {
         driveLabelsGuardEnabled: enabled,
         driveRequiredLabelIds: selectedIds,
         driveLabelsFailMode: failMode,
+        driveCorpora,
       },
       {
         onSuccess: () => {
@@ -2655,88 +2658,116 @@ function DriveLabelsGuardSection() {
   }
 
   return (
-    <Section title="Drive Labels Guard">
-      <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-4">
-        Require files shared with the agent to have specific Google Drive labels before actions are allowed.
-      </p>
-
-      {!labelsLoading && !labelsAvailable && (
-        <div className="mb-4 flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 dark:border-amber-800 dark:bg-amber-900/30">
-          <span className="text-xs text-amber-700 dark:text-amber-300">
-            {labelsData?.reason ?? 'Connect a Google Workspace integration to configure Drive Labels.'}
-          </span>
+    <Section title="Google Drive">
+      <div className="space-y-6">
+        <div>
+          <label htmlFor="drive-corpora" className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+            File discovery scope
+          </label>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-2">
+            Controls which files Drive search and list actions can see.
+          </p>
+          <select
+            id="drive-corpora"
+            value={driveCorpora}
+            onChange={(e) => setDriveCorpora(e.target.value as 'user' | 'domain' | 'allDrives')}
+            className={selectClass}
+          >
+            <option value="user">User — only files owned by or shared with the user</option>
+            <option value="domain">Domain — all files shared with the organization</option>
+            <option value="allDrives">All Drives — user files plus all accessible shared drives</option>
+          </select>
         </div>
-      )}
 
-      <div className="space-y-4">
-        <label className="flex items-center gap-3 text-sm">
-          <input
-            type="checkbox"
-            checked={enabled}
-            onChange={(e) => setEnabled(e.target.checked)}
-            disabled={!labelsAvailable}
-            className="h-4 w-4 rounded border-neutral-300 text-neutral-900 focus:ring-neutral-500 dark:border-neutral-600 dark:bg-neutral-800 disabled:opacity-50"
-          />
-          <span className="font-medium text-neutral-700 dark:text-neutral-300">
-            Enable Drive Labels guard
-          </span>
-        </label>
+        <hr className="border-neutral-200 dark:border-neutral-700" />
 
-        {enabled && labelsAvailable && (
-          <>
-            <div>
-              <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
-                Required labels{' '}
-                <span className="font-normal text-neutral-400">(files must have at least one)</span>
-              </p>
-              {labelsLoading ? (
-                <p className="text-sm text-neutral-400">Loading labels...</p>
-              ) : labelsList.length === 0 ? (
-                <p className="text-sm text-neutral-400">No labels found in your Drive account.</p>
-              ) : (
-                <div className="space-y-1 max-h-48 overflow-y-auto rounded-md border border-neutral-200 bg-neutral-50 p-2 dark:border-neutral-700 dark:bg-neutral-900">
-                  {labelsList.map((label) => (
-                    <label key={label.id} className="flex items-center gap-2 text-sm cursor-pointer px-1 py-0.5 rounded hover:bg-neutral-100 dark:hover:bg-neutral-800">
-                      <input
-                        type="checkbox"
-                        checked={selectedIds.includes(label.id)}
-                        onChange={() => toggleLabel(label.id)}
-                        className="h-4 w-4 rounded border-neutral-300 text-neutral-900 focus:ring-neutral-500 dark:border-neutral-600 dark:bg-neutral-800"
-                      />
-                      <span className="text-neutral-700 dark:text-neutral-300">{label.name}</span>
-                      <span className="text-xs text-neutral-400">{label.type}</span>
-                    </label>
-                  ))}
+        <div>
+          <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+            Labels guard
+          </p>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-3">
+            Require files shared with the agent to have specific Google Drive labels before actions are allowed.
+          </p>
+
+          {!labelsLoading && !labelsAvailable && (
+            <div className="mb-4 flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 dark:border-amber-800 dark:bg-amber-900/30">
+              <span className="text-xs text-amber-700 dark:text-amber-300">
+                {labelsData?.reason ?? 'Connect a Google Workspace integration to configure Drive Labels.'}
+              </span>
+            </div>
+          )}
+
+          <div className="space-y-4">
+            <label className="flex items-center gap-3 text-sm">
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={(e) => setEnabled(e.target.checked)}
+                disabled={!labelsAvailable}
+                className="h-4 w-4 rounded border-neutral-300 text-neutral-900 focus:ring-neutral-500 dark:border-neutral-600 dark:bg-neutral-800 disabled:opacity-50"
+              />
+              <span className="font-medium text-neutral-700 dark:text-neutral-300">
+                Enable Drive Labels guard
+              </span>
+            </label>
+
+            {enabled && labelsAvailable && (
+              <>
+                <div>
+                  <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
+                    Required labels{' '}
+                    <span className="font-normal text-neutral-400">(files must have at least one)</span>
+                  </p>
+                  {labelsLoading ? (
+                    <p className="text-sm text-neutral-400">Loading labels...</p>
+                  ) : labelsList.length === 0 ? (
+                    <p className="text-sm text-neutral-400">No labels found in your Drive account.</p>
+                  ) : (
+                    <div className="space-y-1 max-h-48 overflow-y-auto rounded-md border border-neutral-200 bg-neutral-50 p-2 dark:border-neutral-700 dark:bg-neutral-900">
+                      {labelsList.map((label) => (
+                        <label key={label.id} className="flex items-center gap-2 text-sm cursor-pointer px-1 py-0.5 rounded hover:bg-neutral-100 dark:hover:bg-neutral-800">
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.includes(label.id)}
+                            onChange={() => toggleLabel(label.id)}
+                            className="h-4 w-4 rounded border-neutral-300 text-neutral-900 focus:ring-neutral-500 dark:border-neutral-600 dark:bg-neutral-800"
+                          />
+                          <span className="text-neutral-700 dark:text-neutral-300">{label.name}</span>
+                          <span className="text-xs text-neutral-400">{label.type}</span>
+                        </label>
+                      ))}
+                    </div>
+                  )}
                 </div>
-              )}
-            </div>
 
-            <div>
-              <label htmlFor="drive-fail-mode" className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
-                Fail mode
-              </label>
-              <select
-                id="drive-fail-mode"
-                value={failMode}
-                onChange={(e) => setFailMode(e.target.value as 'deny' | 'allow')}
-                className={selectClass}
-              >
-                <option value="deny">Deny — block the action if labels are missing</option>
-                <option value="allow">Allow — log a warning but proceed anyway</option>
-              </select>
-              {failMode === 'allow' && (
-                <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
-                  Warning: allow mode will not block actions on unlabeled files.
-                </p>
-              )}
-            </div>
-          </>
-        )}
+                <div>
+                  <label htmlFor="drive-fail-mode" className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                    Fail mode
+                  </label>
+                  <select
+                    id="drive-fail-mode"
+                    value={failMode}
+                    onChange={(e) => setFailMode(e.target.value as 'deny' | 'allow')}
+                    className={selectClass}
+                  >
+                    <option value="deny">Deny — block the action if labels are missing</option>
+                    <option value="allow">Allow — log a warning but proceed anyway</option>
+                  </select>
+                  {failMode === 'allow' && (
+                    <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+                      Warning: allow mode will not block actions on unlabeled files.
+                    </p>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        </div>
 
         <div className="flex items-center gap-3">
           <Button
             onClick={handleSave}
-            disabled={!labelsAvailable || updateSettings.isPending}
+            disabled={updateSettings.isPending}
           >
             {updateSettings.isPending ? 'Saving...' : 'Save'}
           </Button>

--- a/packages/plugin-google-workspace/src/actions/__tests__/resolve-corpora.test.ts
+++ b/packages/plugin-google-workspace/src/actions/__tests__/resolve-corpora.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCorpora } from '../drive-actions.js';
+import type { ActionContext } from '@valet/sdk/integrations';
+
+function makeCtx(guardConfig?: Record<string, unknown>): ActionContext {
+  return {
+    credentials: { access_token: 'test' },
+    userId: 'user-1',
+    guardConfig,
+  };
+}
+
+describe('resolveCorpora', () => {
+  it('returns "user" when guardConfig is missing', () => {
+    expect(resolveCorpora(makeCtx())).toBe('user');
+  });
+
+  it('returns "user" when driveCorpora key is missing', () => {
+    expect(resolveCorpora(makeCtx({}))).toBe('user');
+  });
+
+  it('returns "user" when driveCorpora is not a string', () => {
+    expect(resolveCorpora(makeCtx({ driveCorpora: 42 }))).toBe('user');
+    expect(resolveCorpora(makeCtx({ driveCorpora: true }))).toBe('user');
+    expect(resolveCorpora(makeCtx({ driveCorpora: null }))).toBe('user');
+  });
+
+  it('returns "user" for an invalid string value', () => {
+    expect(resolveCorpora(makeCtx({ driveCorpora: 'everything' }))).toBe('user');
+    expect(resolveCorpora(makeCtx({ driveCorpora: '' }))).toBe('user');
+  });
+
+  it('returns "user" when set to "user"', () => {
+    expect(resolveCorpora(makeCtx({ driveCorpora: 'user' }))).toBe('user');
+  });
+
+  it('returns "domain" when set to "domain"', () => {
+    expect(resolveCorpora(makeCtx({ driveCorpora: 'domain' }))).toBe('domain');
+  });
+
+  it('returns "allDrives" when set to "allDrives"', () => {
+    expect(resolveCorpora(makeCtx({ driveCorpora: 'allDrives' }))).toBe('allDrives');
+  });
+});

--- a/packages/plugin-google-workspace/src/actions/drive-actions.ts
+++ b/packages/plugin-google-workspace/src/actions/drive-actions.ts
@@ -101,6 +101,14 @@ function getLabelFilter(params: unknown): string | undefined {
   return (params as Record<string, unknown> | null)?.__labelFilter as string | undefined;
 }
 
+const VALID_CORPORA = new Set(['user', 'domain', 'allDrives']);
+
+/** Return the org-configured corpora value, falling back to `'user'`. */
+function resolveCorpora(ctx: ActionContext): string {
+  const value = ctx.guardConfig?.driveCorpora;
+  return typeof value === 'string' && VALID_CORPORA.has(value) ? value : 'user';
+}
+
 /**
  * Compose a user query with an optional label filter clause.
  * Uses parenthesization to prevent Drive API operator precedence bugs.
@@ -392,6 +400,7 @@ async function executeAction(
           : 'modifiedTime desc';
 
         const qs = new URLSearchParams({
+          corpora: resolveCorpora(ctx),
           fields: `nextPageToken,files(${LIST_FILE_FIELDS})`,
           pageSize: String(p.maxResults || 20),
           supportsAllDrives: 'true',
@@ -450,6 +459,7 @@ async function executeAction(
           : 'modifiedTime desc';
 
         const qs = new URLSearchParams({
+          corpora: resolveCorpora(ctx),
           q: finalQuery,
           fields: `nextPageToken,files(${LIST_FILE_FIELDS})`,
           pageSize: String(p.maxResults || 10),
@@ -500,6 +510,7 @@ async function executeAction(
         const orderByParam = p.orderBy || 'modifiedTime';
 
         const qs = new URLSearchParams({
+          corpora: resolveCorpora(ctx),
           q: finalQuery,
           fields: `nextPageToken,files(id,name,modifiedTime,createdTime,webViewLink,owners(displayName,emailAddress))`,
           pageSize: String(p.maxResults || 20),
@@ -551,6 +562,7 @@ async function executeAction(
         const finalQuery = composeQuery(queryParts.join(' and '), labelFilter);
 
         const qs = new URLSearchParams({
+          corpora: resolveCorpora(ctx),
           q: finalQuery,
           fields: `nextPageToken,files(id,name,modifiedTime,createdTime,webViewLink,owners(displayName))`,
           pageSize: String(p.maxResults || 10),
@@ -587,6 +599,7 @@ async function executeAction(
         const finalQuery = composeQuery(queryParts.join(' and '), labelFilter);
 
         const qs = new URLSearchParams({
+          corpora: resolveCorpora(ctx),
           q: finalQuery,
           fields: 'nextPageToken,files(id,name,mimeType,size,modifiedTime,webViewLink,owners(displayName))',
           pageSize: String(p.maxResults || 50),
@@ -654,6 +667,7 @@ async function executeAction(
 
         // Count children
         const childQs = new URLSearchParams({
+          corpora: resolveCorpora(ctx),
           q: `'${escapeDriveQuery(folderId)}' in parents and trashed=false`,
           fields: 'files(id)',
           pageSize: '100',
@@ -960,3 +974,4 @@ async function executeAction(
 
 export const driveActionDefs: ActionDefinition[] = allActions;
 export { executeAction as executeDriveAction };
+export { resolveCorpora };

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -157,6 +157,7 @@ export interface AgentSession {
   purpose?: SessionPurpose;
   title?: string;
   parentSessionId?: string;
+  parentThreadId?: string;
   containerId?: string;
   sandboxId?: string;
   tunnelUrls?: Record<string, string>;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -310,6 +310,7 @@ export interface OrgSettings {
   driveLabelsGuardEnabled: boolean;
   driveRequiredLabelIds: string[];
   driveLabelsFailMode: 'deny' | 'allow';
+  driveCorpora: 'user' | 'domain' | 'allDrives';
   createdAt: Date;
   updatedAt: Date;
 }

--- a/packages/worker/migrations/0008_add_parent_thread_id.sql
+++ b/packages/worker/migrations/0008_add_parent_thread_id.sql
@@ -1,0 +1,5 @@
+-- Add parent_thread_id to sessions so child sessions can reliably route
+-- idle/completion notifications back to the correct orchestrator thread.
+-- Previously this was only stored in the child DO's transient SQL state,
+-- which is lost if the child DO is re-initialized.
+ALTER TABLE sessions ADD COLUMN parent_thread_id TEXT;

--- a/packages/worker/migrations/0009_add_drive_domain_corpora.sql
+++ b/packages/worker/migrations/0009_add_drive_domain_corpora.sql
@@ -1,0 +1,2 @@
+-- Add org setting for Drive files.list corpora scope (user, domain, allDrives)
+ALTER TABLE org_settings ADD COLUMN drive_corpora TEXT NOT NULL DEFAULT 'user';

--- a/packages/worker/src/durable-objects/session-agent.ts
+++ b/packages/worker/src/durable-objects/session-agent.ts
@@ -1591,6 +1591,9 @@ export class SessionAgentDO {
 
     if (threadId) {
       const inMemoryThreadSessionId = this.getChannelOcSessionId(channelKey);
+      // handlePrompt needs both OC session hydration AND continuation context,
+      // so we call hydrateThreadResumeContext directly (single D1 query) rather
+      // than using ensureThreadOcSessionHydrated which only handles OC sessions.
       if (!inMemoryThreadSessionId || !continuationContext) {
         const hydrated = await this.hydrateThreadResumeContext(threadId);
         if (!inMemoryThreadSessionId && hydrated.opencodeSessionId) {
@@ -2734,13 +2737,15 @@ export class SessionAgentDO {
         }
 
         try {
+          const resolvedParentThreadId = this.promptQueue.getProcessingThreadId() || undefined;
+          console.log(`[SessionAgentDO] spawn-child: parentSession=${this.sessionState.sessionId} parentThreadId=${resolvedParentThreadId || 'NONE'} task="${msg.task?.slice(0, 60)}"`);
           const result = await spawnChild(
             this.appDb,
             this.env,
             {
               parentSessionId: this.sessionState.sessionId,
               userId: this.sessionState.userId,
-              parentThreadId: this.promptQueue.getProcessingThreadId() || undefined,
+              parentThreadId: resolvedParentThreadId,
               spawnRequest: spawnRequest as Record<string, unknown> & { doWsUrl: string; envVars: Record<string, string> },
               backendUrl,
               terminateUrl: this.sessionState.terminateUrl,
@@ -3623,6 +3628,20 @@ export class SessionAgentDO {
     };
   }
 
+  /**
+   * Ensure the channel_state table has the OpenCode session ID for a thread channel.
+   * Checks the in-memory cache first; if missing, hydrates from D1's session_threads table.
+   * Called from handleSystemMessage and sendNextQueuedPrompt. (handlePrompt calls
+   * hydrateThreadResumeContext directly since it also needs continuation context.)
+   */
+  private async ensureThreadOcSessionHydrated(threadId: string, channelKey: string): Promise<void> {
+    const existing = this.getChannelOcSessionId(channelKey);
+    if (existing) return;
+    const hydrated = await this.hydrateThreadResumeContext(threadId);
+    if (hydrated.opencodeSessionId) {
+      this.setChannelOcSessionId(channelKey, hydrated.opencodeSessionId);
+    }
+  }
 
   private async handlePromptComplete(messageId?: string) {
     try {
@@ -4064,7 +4083,17 @@ export class SessionAgentDO {
       const parentSessionId = session?.parentSessionId;
       if (!parentSessionId) return;
       const childTitle = session?.title || session?.workspace || `Child ${sessionId.slice(0, 8)}`;
-      const parentThreadId = this.sessionState.parentThreadId;
+      // Prefer DO state, fall back to D1 — the DO value can be lost if the
+      // child session is re-initialized (e.g., orchestrator restart clears
+      // the prompt queue before the spawn-child message arrives).
+      const doThreadId = this.sessionState.parentThreadId;
+      const d1ThreadId = session?.parentThreadId;
+      const parentThreadId = doThreadId || d1ThreadId;
+      if (!doThreadId && d1ThreadId) {
+        console.warn(`[SessionAgentDO] notifyParentEvent: DO state missing parentThreadId, falling back to D1 — child=${sessionId} parent=${parentSessionId} threadId=${d1ThreadId} status=${options?.childStatus}`);
+      } else {
+        console.log(`[SessionAgentDO] notifyParentEvent: child=${sessionId} parent=${parentSessionId} parentThreadId=${parentThreadId || 'NONE'} status=${options?.childStatus}`);
+      }
       const parentDoId = this.env.SESSIONS.idFromName(parentSessionId);
       const parentDO = this.env.SESSIONS.get(parentDoId);
       await parentDO.fetch(new Request('http://do/system-message', {
@@ -4088,6 +4117,9 @@ export class SessionAgentDO {
   }
 
   private async handleSystemMessage(content: string, parts?: Record<string, unknown>, wake?: boolean, threadId?: string) {
+    if (parts?.childSessionId) {
+      console.log(`[SessionAgentDO] handleSystemMessage: childEvent childSession=${parts.childSessionId} childStatus=${parts.childStatus} threadId=${threadId || 'NONE'} wake=${wake}`);
+    }
     const messageId = crypto.randomUUID();
     const serializedParts = parts ? JSON.stringify(parts) : null;
 
@@ -4180,6 +4212,9 @@ export class SessionAgentDO {
           const ownerDetails = ownerId ? await this.getUserDetails(ownerId) : undefined;
           const sysModelPrefs = await this.resolveModelPreferences(ownerDetails);
           const sysChannelKey = this.channelKeyFrom(sysChannelType, sysChannelId);
+          if (threadId) {
+            await this.ensureThreadOcSessionHydrated(threadId, sysChannelKey);
+          }
           const sysOcSessionId = this.getChannelOcSessionId(sysChannelKey);
           const sysDispatched = this.runnerLink.send({
             type: 'prompt',
@@ -4493,15 +4528,8 @@ export class SessionAgentDO {
     const queueModelPrefs = await this.resolveModelPreferences(queueOwnerDetails);
     const queueChannelKey = this.channelKeyFrom(queueChannelType, queueChannelId);
 
-    // Hydrate thread resume context for deferred prompts (mirrors handlePrompt's hydration)
     if (queueThreadId) {
-      const inMemoryOcSessionId = this.getChannelOcSessionId(queueChannelKey);
-      if (!inMemoryOcSessionId) {
-        const hydrated = await this.hydrateThreadResumeContext(queueThreadId);
-        if (hydrated.opencodeSessionId) {
-          this.setChannelOcSessionId(queueChannelKey, hydrated.opencodeSessionId);
-        }
-      }
+      await this.ensureThreadOcSessionHydrated(queueThreadId, queueChannelKey);
     }
 
     const queueOcSessionId = this.getChannelOcSessionId(queueChannelKey);

--- a/packages/worker/src/durable-objects/session-agent.ts
+++ b/packages/worker/src/durable-objects/session-agent.ts
@@ -415,6 +415,7 @@ export class SessionAgentDO {
       driveLabelsGuardEnabled: settings.driveLabelsGuardEnabled,
       driveRequiredLabelIds: settings.driveRequiredLabelIds,
       driveLabelsFailMode: settings.driveLabelsFailMode,
+      driveCorpora: settings.driveCorpora,
     };
     this.guardConfigExpiresAt = now + 60_000;
     return this.guardConfigCache;

--- a/packages/worker/src/lib/db/org.ts
+++ b/packages/worker/src/lib/db/org.ts
@@ -20,6 +20,7 @@ function rowToOrgSettings(row: typeof orgSettings.$inferSelect): OrgSettings {
     driveLabelsGuardEnabled: Boolean(row.driveLabelsGuardEnabled),
     driveRequiredLabelIds: JSON.parse(row.driveRequiredLabelIds || '[]') as string[],
     driveLabelsFailMode: (row.driveLabelsFailMode || 'deny') as 'deny' | 'allow',
+    driveCorpora: (row.driveCorpora || 'user') as OrgSettings['driveCorpora'],
     createdAt: toDate(row.createdAt),
     updatedAt: toDate(row.updatedAt),
   };
@@ -72,6 +73,7 @@ export async function getOrgSettings(db: AppDb): Promise<OrgSettings> {
       driveLabelsGuardEnabled: false,
       driveRequiredLabelIds: [],
       driveLabelsFailMode: 'deny' as const,
+      driveCorpora: 'user' as const,
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -81,7 +83,7 @@ export async function getOrgSettings(db: AppDb): Promise<OrgSettings> {
 
 export async function updateOrgSettings(
   db: AppDb,
-  updates: Partial<Pick<OrgSettings, 'name' | 'allowedEmailDomain' | 'allowedEmails' | 'domainGatingEnabled' | 'emailAllowlistEnabled' | 'modelPreferences' | 'enabledLoginProviders' | 'driveLabelsGuardEnabled' | 'driveRequiredLabelIds' | 'driveLabelsFailMode'>>
+  updates: Partial<Pick<OrgSettings, 'name' | 'allowedEmailDomain' | 'allowedEmails' | 'domainGatingEnabled' | 'emailAllowlistEnabled' | 'modelPreferences' | 'enabledLoginProviders' | 'driveLabelsGuardEnabled' | 'driveRequiredLabelIds' | 'driveLabelsFailMode' | 'driveCorpora'>>
 ): Promise<OrgSettings> {
   const setValues: Record<string, unknown> = {};
 
@@ -95,6 +97,7 @@ export async function updateOrgSettings(
   if (updates.driveLabelsGuardEnabled !== undefined) setValues.driveLabelsGuardEnabled = updates.driveLabelsGuardEnabled ? 1 : 0;
   if (updates.driveRequiredLabelIds !== undefined) setValues.driveRequiredLabelIds = JSON.stringify(updates.driveRequiredLabelIds);
   if (updates.driveLabelsFailMode !== undefined) setValues.driveLabelsFailMode = updates.driveLabelsFailMode;
+  if (updates.driveCorpora !== undefined) setValues.driveCorpora = updates.driveCorpora;
 
   if (Object.keys(setValues).length > 0) {
     setValues.updatedAt = sql`datetime('now')`;

--- a/packages/worker/src/lib/db/sessions.ts
+++ b/packages/worker/src/lib/db/sessions.ts
@@ -67,6 +67,7 @@ function rowToSession(row: typeof sessions.$inferSelect & { personaName?: string
     status: row.status as AgentSession['status'],
     title: row.title || undefined,
     parentSessionId: row.parentSessionId || undefined,
+    parentThreadId: row.parentThreadId || undefined,
     containerId: row.containerId || undefined,
     metadata: row.metadata || undefined,
     errorMessage: row.errorMessage || undefined,
@@ -124,7 +125,7 @@ function rowToShareLink(row: typeof sessionShareLinks.$inferSelect): SessionShar
 
 export async function createSession(
   db: AppDb,
-  data: { id: string; userId: string; workspace: string; title?: string; parentSessionId?: string; containerId?: string; metadata?: Record<string, unknown>; personaId?: string; isOrchestrator?: boolean; purpose?: SessionPurpose }
+  data: { id: string; userId: string; workspace: string; title?: string; parentSessionId?: string; parentThreadId?: string; containerId?: string; metadata?: Record<string, unknown>; personaId?: string; isOrchestrator?: boolean; purpose?: SessionPurpose }
 ): Promise<AgentSession> {
   const purpose = data.purpose || (data.isOrchestrator ? 'orchestrator' : 'interactive');
 
@@ -137,6 +138,7 @@ export async function createSession(
     metadata: data.metadata || null,
     title: data.title || null,
     parentSessionId: data.parentSessionId || null,
+    parentThreadId: data.parentThreadId || null,
     personaId: data.personaId || null,
     isOrchestrator: data.isOrchestrator ?? false,
     purpose,
@@ -149,6 +151,7 @@ export async function createSession(
     status: 'initializing',
     title: data.title,
     parentSessionId: data.parentSessionId,
+    parentThreadId: data.parentThreadId,
     containerId: data.containerId,
     metadata: data.metadata,
     personaId: data.personaId,
@@ -248,6 +251,7 @@ export async function getUserSessions(
       status: row.status,
       title: row.title || undefined,
       parentSessionId: row.parent_session_id || undefined,
+      parentThreadId: row.parent_thread_id || undefined,
       containerId: row.container_id || undefined,
       metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
       errorMessage: row.error_message || undefined,

--- a/packages/worker/src/lib/schema/org.ts
+++ b/packages/worker/src/lib/schema/org.ts
@@ -16,6 +16,7 @@ export const orgSettings = sqliteTable('org_settings', {
   driveLabelsGuardEnabled: integer('drive_labels_guard_enabled').notNull().default(0),
   driveRequiredLabelIds: text('drive_required_label_ids').notNull().default('[]'),
   driveLabelsFailMode: text('drive_labels_fail_mode').notNull().default('deny'),
+  driveCorpora: text('drive_corpora').notNull().default('user'),
   createdAt: text().default(sql`(datetime('now'))`),
   updatedAt: text().default(sql`(datetime('now'))`),
 });

--- a/packages/worker/src/lib/schema/sessions.ts
+++ b/packages/worker/src/lib/schema/sessions.ts
@@ -19,6 +19,7 @@ export const sessions = sqliteTable('sessions', {
   activeSeconds: integer().notNull().default(0),
   title: text(),
   parentSessionId: text(),
+  parentThreadId: text(),
   personaId: text(),
   isOrchestrator: integer({ mode: 'boolean' }).notNull().default(false),
   purpose: text().notNull().default('interactive'),

--- a/packages/worker/src/routes/admin.ts
+++ b/packages/worker/src/routes/admin.ts
@@ -48,6 +48,7 @@ adminRouter.put('/', async (c) => {
     driveLabelsGuardEnabled?: boolean;
     driveRequiredLabelIds?: string[];
     driveLabelsFailMode?: 'deny' | 'allow';
+    driveCorpora?: 'user' | 'domain' | 'allDrives';
   }>();
 
   if (body.modelPreferences !== undefined) {
@@ -83,6 +84,10 @@ adminRouter.put('/', async (c) => {
 
   if (body.driveLabelsFailMode !== undefined && !['deny', 'allow'].includes(body.driveLabelsFailMode)) {
     throw new ValidationError('driveLabelsFailMode must be "deny" or "allow"');
+  }
+
+  if (body.driveCorpora !== undefined && !['user', 'domain', 'allDrives'].includes(body.driveCorpora)) {
+    throw new ValidationError('driveCorpora must be "user", "domain", or "allDrives"');
   }
 
   const settings = await updateOrgSettings(c.get('db'), body);

--- a/packages/worker/src/services/session-cross.ts
+++ b/packages/worker/src/services/session-cross.ts
@@ -135,6 +135,7 @@ export async function spawnChild(
     workspace: params.workspace,
     title: params.title || params.workspace,
     parentSessionId,
+    parentThreadId,
     personaId: params.personaId,
   });
 


### PR DESCRIPTION
## Summary

- Adds a `driveCorpora` org setting (`user` | `domain` | `allDrives`) that controls the Google Drive API `corpora` parameter on all `files.list` calls
- Flows through the existing `guardConfig` pipeline: org settings DB -> SessionAgentDO (60s cache) -> ActionContext -> plugin
- Default is `user` (no behavior change without admin action)
- Admin UI: renamed "Drive Labels Guard" section to "Google Drive", added a "File discovery scope" dropdown above the existing labels guard controls

Resolves [TKAI-49](https://linear.app/turnkey/issue/TKAI-49)

## Changes

| Layer | File | What |
|-------|------|------|
| Migration | `0009_add_drive_domain_corpora.sql` | `drive_corpora TEXT NOT NULL DEFAULT 'user'` |
| Schema | `lib/schema/org.ts` | Drizzle field |
| Types | `shared/types/index.ts` | `driveCorpora` on `OrgSettings` |
| DB | `lib/db/org.ts` | Row mapper, defaults, update |
| DO | `session-agent.ts` | Pass through `guardConfig` |
| API | `routes/admin.ts` | Accept + validate in PUT body |
| Plugin | `drive-actions.ts` | `resolveCorpora(ctx)` helper, all 6 `files.list` calls |
| Tests | `resolve-corpora.test.ts` | 7 tests for the helper |
| UI | `admin.tsx` | Dropdown in Google Drive settings section |

## Test plan

- [ ] Verify default behavior unchanged: new org with no setting change should use `corpora=user`
- [ ] Set to `domain` in admin UI, confirm Drive list/search actions return org-shared docs
- [ ] Set to `allDrives`, confirm shared drive files appear
- [ ] Set back to `user`, confirm scoped down again
- [ ] Verify single-file operations (get_document_info, download_file, etc.) are unaffected
- [ ] Run `pnpm typecheck` (passes)
- [ ] Run plugin tests: `cd packages/plugin-google-workspace && pnpm test` (7/7 resolveCorpora tests pass)