### PR TITLE
feat: add Socket.dev MCP integration plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ valet/
 │   ├── plugin-cloudflare/   # Cloudflare API integration
 │   ├── plugin-sentry/       # Sentry error tracking
 │   ├── plugin-deepwiki/     # DeepWiki knowledge base
+│   ├── plugin-socket/      # Socket.dev supply chain security
 │   ├── plugin-telegram/     # Telegram (channel adapter)
 │   ├── plugin-browser/      # Browser skill (content-only)
 │   ├── plugin-workflows/    # Workflow skill (content-only)

--- a/packages/plugin-socket/package.json
+++ b/packages/plugin-socket/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@valet/plugin-socket",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./actions": "./src/actions/index.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@valet/sdk": "workspace:*",
+    "@valet/shared": "workspace:*",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/plugin-socket/plugin.yaml
+++ b/packages/plugin-socket/plugin.yaml
@@ -1,0 +1,5 @@
+name: socket
+version: 0.0.1
+description: Socket.dev supply chain security — scan packages for vulnerabilities, malware, and risks
+icon: "\U0001F6E1"
+authRequired: false

--- a/packages/plugin-socket/src/actions/actions.ts
+++ b/packages/plugin-socket/src/actions/actions.ts
@@ -1,0 +1,8 @@
+import { McpActionSource } from '@valet/sdk';
+
+export const socketActions = new McpActionSource({
+  mcpUrl: 'https://mcp.socket.dev/',
+  serviceName: 'socket',
+  defaultRiskLevel: 'low',
+  noAuth: true,
+});

--- a/packages/plugin-socket/src/actions/index.ts
+++ b/packages/plugin-socket/src/actions/index.ts
@@ -1,0 +1,16 @@
+import type { IntegrationPackage } from '@valet/sdk';
+import { socketProvider } from './provider.js';
+import { socketActions } from './actions.js';
+
+export { socketProvider } from './provider.js';
+export { socketActions } from './actions.js';
+
+const socketPackage: IntegrationPackage = {
+  name: '@valet/actions-socket',
+  version: '0.0.1',
+  service: 'socket',
+  provider: socketProvider,
+  actions: socketActions,
+};
+
+export default socketPackage;

--- a/packages/plugin-socket/src/actions/provider.ts
+++ b/packages/plugin-socket/src/actions/provider.ts
@@ -1,0 +1,17 @@
+import type { IntegrationProvider, IntegrationCredentials } from '@valet/sdk';
+
+export const socketProvider: IntegrationProvider = {
+  service: 'socket',
+  displayName: 'Socket.dev',
+  authType: 'none',
+  supportedEntities: ['packages', 'vulnerabilities'],
+  oauthScopes: [],
+
+  validateCredentials(_credentials: IntegrationCredentials): boolean {
+    return true;
+  },
+
+  async testConnection(_credentials: IntegrationCredentials): Promise<boolean> {
+    return true;
+  },
+};

--- a/packages/plugin-socket/tsconfig.json
+++ b/packages/plugin-socket/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": []
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../sdk" }, { "path": "../shared" }]
+}

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -33,6 +33,7 @@
     "@valet/plugin-linear": "workspace:*",
     "@valet/plugin-notion": "workspace:*",
     "@valet/plugin-sentry": "workspace:*",
+    "@valet/plugin-socket": "workspace:*",
     "@valet/plugin-slack": "workspace:*",
     "@valet/plugin-stripe": "workspace:*",
     "@valet/plugin-telegram": "workspace:*",

--- a/packages/worker/src/integrations/packages.ts
+++ b/packages/worker/src/integrations/packages.ts
@@ -11,7 +11,8 @@ import pkg6 from '@valet/plugin-linear/actions';
 import pkg7 from '@valet/plugin-notion/actions';
 import pkg8 from '@valet/plugin-sentry/actions';
 import pkg9 from '@valet/plugin-slack/actions';
-import pkg10 from '@valet/plugin-stripe/actions';
-import pkg11 from '@valet/plugin-typefully/actions';
+import pkg10 from '@valet/plugin-socket/actions';
+import pkg11 from '@valet/plugin-stripe/actions';
+import pkg12 from '@valet/plugin-typefully/actions';
 
-export const installedIntegrations: IntegrationPackage[] = [pkg0, pkg1, pkg2, pkg3, pkg4, pkg5, pkg6, pkg7, pkg8, pkg9, pkg10, pkg11];
+export const installedIntegrations: IntegrationPackage[] = [pkg0, pkg1, pkg2, pkg3, pkg4, pkg5, pkg6, pkg7, pkg8, pkg9, pkg10, pkg11, pkg12];

--- a/packages/worker/src/plugins/content-registry.ts
+++ b/packages/worker/src/plugins/content-registry.ts
@@ -1746,6 +1746,15 @@ Large channels require paging via \`cursor\` / \`next_cursor\`. Prefer narrowing
     ],
   },
   {
+    name: "socket",
+    version: "0.0.1",
+    description: "Socket.dev supply chain security — scan packages for vulnerabilities, malware, and risks",
+    icon: "🛡",
+    authRequired: false,
+    capabilities: ["actions"],
+    artifacts: [],
+  },
+  {
     name: "stripe",
     version: "0.0.1",
     description: "Stripe integration for payments, customers, and subscriptions",

--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -23,6 +23,7 @@
     { "path": "../plugin-typefully" },
     { "path": "../plugin-notion" },
     { "path": "../plugin-sentry" },
+    { "path": "../plugin-socket" },
     { "path": "../plugin-slack" },
     { "path": "../plugin-stripe" },
     { "path": "../plugin-telegram" }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,25 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.0.9)(jiti@1.21.7)(tsx@4.21.0)
 
+  packages/plugin-socket:
+    dependencies:
+      '@valet/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      '@valet/shared':
+        specifier: workspace:*
+        version: link:../shared
+      zod:
+        specifier: ^3.22.4
+        version: 3.25.76
+    devDependencies:
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.0.9)(jiti@1.21.7)(tsx@4.21.0)
+
   packages/plugin-stripe:
     dependencies:
       '@valet/sdk':
@@ -430,7 +449,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.12
+        version: 1.3.13
       '@types/diff':
         specifier: ^8.0.0
         version: 8.0.0
@@ -522,6 +541,9 @@ importers:
       '@valet/plugin-slack':
         specifier: workspace:*
         version: link:../plugin-slack
+      '@valet/plugin-socket':
+        specifier: workspace:*
+        version: link:../plugin-socket
       '@valet/plugin-stripe':
         specifier: workspace:*
         version: link:../plugin-stripe
@@ -539,7 +561,7 @@ importers:
         version: link:../shared
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(@cloudflare/workers-types@4.20260118.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.12)
+        version: 0.45.1(@cloudflare/workers-types@4.20260118.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.13)
       hono:
         specifier: ^4.3.0
         version: 4.11.4
@@ -2493,8 +2515,8 @@ packages:
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
-  '@types/bun@1.3.12':
-    resolution: {integrity: sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A==}
+  '@types/bun@1.3.13':
+    resolution: {integrity: sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -2654,6 +2676,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -2835,8 +2858,8 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
-  bun-types@1.3.12:
-    resolution: {integrity: sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA==}
+  bun-types@1.3.13:
+    resolution: {integrity: sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -6430,9 +6453,9 @@ snapshots:
     dependencies:
       '@types/node': 25.0.9
 
-  '@types/bun@1.3.12':
+  '@types/bun@1.3.13':
     dependencies:
-      bun-types: 1.3.12
+      bun-types: 1.3.13
 
   '@types/chai@5.2.3':
     dependencies:
@@ -6822,7 +6845,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bun-types@1.3.12:
+  bun-types@1.3.13:
     dependencies:
       '@types/node': 25.0.9
 
@@ -7201,12 +7224,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260118.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.12):
+  drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260118.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.13):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260118.0
       '@types/better-sqlite3': 7.6.13
       better-sqlite3: 11.10.0
-      bun-types: 1.3.12
+      bun-types: 1.3.13
 
   dunder-proto@1.0.1:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
     { "path": "./packages/plugin-cloudflare" },
     { "path": "./packages/plugin-figma" },
     { "path": "./packages/plugin-sentry" },
+    { "path": "./packages/plugin-socket" },
     { "path": "./packages/plugin-deepwiki" },
     { "path": "./packages/plugin-email-auth" },
     { "path": "./packages/plugin-google-auth" },


### PR DESCRIPTION
## Summary

- Adds `plugin-socket` — a new MCP integration for [Socket.dev](https://socket.dev/) supply chain security scanning
- Uses their public, unauthenticated MCP server at `https://mcp.socket.dev/` (no OAuth/API key needed)
- Follows the exact same pattern as `plugin-deepwiki` (the other no-auth MCP integration)

## Changes

- **New plugin** `packages/plugin-socket/` with `plugin.yaml`, `package.json`, `tsconfig.json`, and action sources (`actions.ts`, `provider.ts`, `index.ts`)
- **Registered** in `packages/worker/package.json`, `packages/worker/tsconfig.json`, and root `tsconfig.json`
- **Auto-generated registries** updated via `make generate-registries` (integration count: 12 → 13)
- **CLAUDE.md** updated with new plugin in project structure listing

## Configuration

| Setting | Value |
|---------|-------|
| MCP URL | `https://mcp.socket.dev/` |
| Auth | None (public server) |
| Default risk level | `low` |
| Service name | `socket` |