### PR TITLE
feat(drive): add per-request corpora parameter to Drive list/search actions

### DIFF
--- a/packages/plugin-google-workspace/skills/google-drive.md
+++ b/packages/plugin-google-workspace/skills/google-drive.md
@@ -11,11 +11,11 @@ You have full access to Google Drive through the Google Workspace integration. D
 
 ### Discovery (Finding Files)
 
-- **`drive.list_files`** — List files with optional folder, MIME type, ownership, and date filtering. Supports sorting and pagination. Use MIME type shortcuts: "document", "spreadsheet", "folder", etc.
-- **`drive.search_files`** — Full-text search across all file types by name, content, or both. The fastest way to find any file.
-- **`drive.list_documents`** — List Google Documents only, optionally filtered by name/content.
-- **`drive.search_documents`** — Search specifically within Google Documents by name, content, or both.
-- **`drive.list_folder_contents`** — List files and subfolders within a specific folder. Results are sorted with folders first.
+- **`drive.list_files`** — List files with optional folder, MIME type, ownership, and date filtering. Supports sorting and pagination. Use MIME type shortcuts: "document", "spreadsheet", "folder", etc. Defaults to personal Drive; use `corpora` to widen scope.
+- **`drive.search_files`** — Full-text search across all file types by name, content, or both. The fastest way to find any file. Defaults to personal Drive; use `corpora` to widen scope.
+- **`drive.list_documents`** — List Google Documents only, optionally filtered by name/content. Defaults to personal Drive; use `corpora` to widen scope.
+- **`drive.search_documents`** — Search specifically within Google Documents by name, content, or both. Defaults to personal Drive; use `corpora` to widen scope.
+- **`drive.list_folder_contents`** — List files and subfolders within a specific folder. Results are sorted with folders first. Defaults to personal Drive; use `corpora` to widen scope.
 - **`drive.get_document_info`** — Get metadata for a file: name, type, owner, sharing status, dates, links.
 - **`drive.get_folder_info`** — Get metadata for a folder including child count.
 
@@ -29,6 +29,22 @@ You have full access to Google Drive through the Google Workspace integration. D
 - **`drive.delete_file`** — Permanently delete a file (cannot be undone).
 - **`drive.download_file`** — Download text content of a file. Auto-exports Google Workspace files (Docs to text, Sheets to CSV). Rejects binary files.
 - **`drive.create_from_template`** — Copy a template document and optionally replace placeholder text (e.g. `{{name}}` to `Alice`).
+
+## Searching Across Drives (corpora)
+
+All five discovery tools (`list_files`, `search_files`, `list_documents`, `search_documents`, `list_folder_contents`) accept an optional `corpora` parameter that controls which Drive corpus is searched:
+
+| Value | Scope | When to use |
+|---|---|---|
+| `user` (default) | Files in the authenticated user's My Drive — files they own plus files shared directly with them. | Default for most queries. Use when the user asks about "my files" or you don't need org-wide results. |
+| `domain` | Files shared to the user's Google Workspace domain (visible to anyone in the org). | Use when looking for company-wide or org-shared resources the user may not have in their personal Drive. |
+| `drive` | Files within a specific shared drive. Requires also passing a `driveId` param. | Use when the user asks about a specific shared drive by name or ID. |
+| `allDrives` | Searches across My Drive and all shared drives the user can access. | Use when you want the broadest possible search. **Warning:** on large workspaces, results may be incomplete — check for `incompleteSearch` in the response. |
+
+**Tips:**
+- Start with the default (`user`). Only widen to `domain` or `allDrives` if the user asks for org-wide results or the initial search comes up empty.
+- If using `allDrives` and results seem truncated, try narrowing with a more specific query or switching to `domain` or a specific `drive`.
+- The org admin may also set a default corpora via guard configuration, which overrides `user` unless you pass an explicit value.
 
 ## Common Patterns
 
@@ -68,6 +84,18 @@ Find recently modified files:
 
 ```
 drive.list_files({ modifiedAfter: "2026-01-01", orderBy: "modifiedTime" })
+```
+
+Search across all drives (My Drive + shared drives):
+
+```
+drive.search_files({ query: "quarterly review", corpora: "allDrives" })
+```
+
+Search only organization-shared files:
+
+```
+drive.search_files({ query: "company handbook", corpora: "domain" })
 ```
 
 ### Creating Documents with Markdown

--- a/packages/plugin-google-workspace/src/actions/__tests__/resolve-corpora.test.ts
+++ b/packages/plugin-google-workspace/src/actions/__tests__/resolve-corpora.test.ts
@@ -41,4 +41,38 @@ describe('resolveCorpora', () => {
   it('returns "allDrives" when set to "allDrives"', () => {
     expect(resolveCorpora(makeCtx({ driveCorpora: 'allDrives' }))).toBe('allDrives');
   });
+
+  it('returns "drive" when set to "drive"', () => {
+    expect(resolveCorpora(makeCtx({ driveCorpora: 'drive' }))).toBe('drive');
+  });
+
+  // Per-request override tests
+  describe('per-request override', () => {
+    it('override takes precedence over guardConfig', () => {
+      expect(resolveCorpora(makeCtx({ driveCorpora: 'domain' }), 'user')).toBe('user');
+      expect(resolveCorpora(makeCtx({ driveCorpora: 'user' }), 'domain')).toBe('domain');
+      expect(resolveCorpora(makeCtx({ driveCorpora: 'user' }), 'allDrives')).toBe('allDrives');
+      expect(resolveCorpora(makeCtx({ driveCorpora: 'user' }), 'drive')).toBe('drive');
+    });
+
+    it('falls back to guardConfig when override is undefined', () => {
+      expect(resolveCorpora(makeCtx({ driveCorpora: 'domain' }), undefined)).toBe('domain');
+    });
+
+    it('falls back to guardConfig when override is invalid', () => {
+      expect(resolveCorpora(makeCtx({ driveCorpora: 'domain' }), 'invalid')).toBe('domain');
+      expect(resolveCorpora(makeCtx({ driveCorpora: 'domain' }), '')).toBe('domain');
+    });
+
+    it('falls back to "user" when both override and guardConfig are invalid', () => {
+      expect(resolveCorpora(makeCtx({ driveCorpora: 'invalid' }), 'also-invalid')).toBe('user');
+      expect(resolveCorpora(makeCtx(), 'invalid')).toBe('user');
+    });
+
+    it('override works when guardConfig is missing', () => {
+      expect(resolveCorpora(makeCtx(), 'domain')).toBe('domain');
+      expect(resolveCorpora(makeCtx(), 'drive')).toBe('drive');
+      expect(resolveCorpora(makeCtx(), 'allDrives')).toBe('allDrives');
+    });
+  });
 });

--- a/packages/plugin-google-workspace/src/actions/drive-actions.ts
+++ b/packages/plugin-google-workspace/src/actions/drive-actions.ts
@@ -148,7 +148,9 @@ const listFiles: ActionDefinition = {
   id: 'drive.list_files',
   name: 'List Files',
   description:
-    'Lists files across Google Drive with optional filtering by type, folder, and ownership. ' +
+    'Lists files in Google Drive with optional filtering by type, folder, and ownership. ' +
+    'By default searches the user\'s personal Drive (corpora: "user"). Set corpora to "domain" for org-wide files, ' +
+    '"drive" for a specific shared drive, or "allDrives" to search everywhere. ' +
     'Use mimeType shortcuts: "document", "spreadsheet", "presentation", "folder", "form", "pdf", "zip" ' +
     'or pass any full MIME type string.',
   riskLevel: 'low',
@@ -163,7 +165,7 @@ const listFiles: ActionDefinition = {
     ownedByMe: z.boolean().optional().describe('Only return files owned by the authenticated user'),
     sharedWithMe: z.boolean().optional().describe('Only return files shared with the authenticated user'),
     modifiedAfter: z.string().optional().describe('Only return files modified after this date (ISO 8601)'),
-    corpora: z.enum(['user', 'domain', 'drive', 'allDrives']).optional().describe('Which corpus to search. "user" for personal files (default), "domain" for organization-wide, "drive" for a specific shared drive, "allDrives" for everything.'),
+    corpora: z.enum(['user', 'domain', 'drive', 'allDrives']).optional().describe('Which Drive corpus to search. "user" (default): files in My Drive (owned + shared with me). "domain": files shared to the Google Workspace org. "drive": a specific shared drive (requires driveId). "allDrives": My Drive + all shared drives (may return incomplete results on large workspaces).'),
   }),
 };
 
@@ -172,6 +174,7 @@ const searchFiles: ActionDefinition = {
   name: 'Search Files',
   description:
     'Searches across all file types in Google Drive by name or content. ' +
+    'By default searches the user\'s personal Drive (corpora: "user"). Set corpora to "domain", "drive", or "allDrives" to widen scope. ' +
     'Supports filtering by MIME type, scoping to a folder subtree, and pagination.',
   riskLevel: 'low',
   params: z.object({
@@ -184,14 +187,16 @@ const searchFiles: ActionDefinition = {
     maxResults: z.number().int().min(1).max(100).optional(),
     modifiedAfter: z.string().optional().describe('Only return files modified after this date (ISO 8601)'),
     pageToken: z.string().optional(),
-    corpora: z.enum(['user', 'domain', 'drive', 'allDrives']).optional().describe('Which corpus to search. "user" for personal files (default), "domain" for organization-wide, "drive" for a specific shared drive, "allDrives" for everything.'),
+    corpora: z.enum(['user', 'domain', 'drive', 'allDrives']).optional().describe('Which Drive corpus to search. "user" (default): files in My Drive (owned + shared with me). "domain": files shared to the Google Workspace org. "drive": a specific shared drive (requires driveId). "allDrives": My Drive + all shared drives (may return incomplete results on large workspaces).'),
   }),
 };
 
 const listDocuments: ActionDefinition = {
   id: 'drive.list_documents',
   name: 'List Google Docs',
-  description: 'Lists Google Documents in your Drive, optionally filtered by name or content.',
+  description:
+    'Lists Google Documents, optionally filtered by name or content. ' +
+    'By default searches the user\'s personal Drive (corpora: "user"). Set corpora to "domain", "drive", or "allDrives" to widen scope.',
   riskLevel: 'low',
   params: z.object({
     query: z.string().optional().describe('Search query to filter documents by name or content'),
@@ -199,14 +204,16 @@ const listDocuments: ActionDefinition = {
     pageToken: z.string().optional(),
     orderBy: z.enum(['name', 'modifiedTime', 'createdTime']).optional(),
     modifiedAfter: z.string().optional().describe('Only return documents modified after this date (ISO 8601)'),
-    corpora: z.enum(['user', 'domain', 'drive', 'allDrives']).optional().describe('Which corpus to search. "user" for personal files (default), "domain" for organization-wide, "drive" for a specific shared drive, "allDrives" for everything.'),
+    corpora: z.enum(['user', 'domain', 'drive', 'allDrives']).optional().describe('Which Drive corpus to search. "user" (default): files in My Drive (owned + shared with me). "domain": files shared to the Google Workspace org. "drive": a specific shared drive (requires driveId). "allDrives": My Drive + all shared drives (may return incomplete results on large workspaces).'),
   }),
 };
 
 const searchDocuments: ActionDefinition = {
   id: 'drive.search_documents',
   name: 'Search Google Docs',
-  description: 'Searches for Google Documents by name, content, or both.',
+  description:
+    'Searches for Google Documents by name, content, or both. ' +
+    'By default searches the user\'s personal Drive (corpora: "user"). Set corpora to "domain", "drive", or "allDrives" to widen scope.',
   riskLevel: 'low',
   params: z.object({
     query: z.string().describe('Search term to find in document names or content'),
@@ -214,20 +221,22 @@ const searchDocuments: ActionDefinition = {
     maxResults: z.number().int().min(1).max(100).optional(),
     pageToken: z.string().optional(),
     modifiedAfter: z.string().optional().describe('Only return documents modified after this date (ISO 8601)'),
-    corpora: z.enum(['user', 'domain', 'drive', 'allDrives']).optional().describe('Which corpus to search. "user" for personal files (default), "domain" for organization-wide, "drive" for a specific shared drive, "allDrives" for everything.'),
+    corpora: z.enum(['user', 'domain', 'drive', 'allDrives']).optional().describe('Which Drive corpus to search. "user" (default): files in My Drive (owned + shared with me). "domain": files shared to the Google Workspace org. "drive": a specific shared drive (requires driveId). "allDrives": My Drive + all shared drives (may return incomplete results on large workspaces).'),
   }),
 };
 
 const listFolderContents: ActionDefinition = {
   id: 'drive.list_folder_contents',
   name: 'List Folder Contents',
-  description: 'Lists files and subfolders within a Drive folder. Use folderId="root" for the top-level.',
+  description:
+    'Lists files and subfolders within a Drive folder. Use folderId="root" for the top-level. ' +
+    'By default searches the user\'s personal Drive (corpora: "user"). Set corpora to "domain", "drive", or "allDrives" to widen scope.',
   riskLevel: 'low',
   params: z.object({
     folderId: z.string().describe('Folder ID (use "root" for the root Drive folder)'),
     maxResults: z.number().int().min(1).max(100).optional(),
     pageToken: z.string().optional(),
-    corpora: z.enum(['user', 'domain', 'drive', 'allDrives']).optional().describe('Which corpus to search. "user" for personal files (default), "domain" for organization-wide, "drive" for a specific shared drive, "allDrives" for everything.'),
+    corpora: z.enum(['user', 'domain', 'drive', 'allDrives']).optional().describe('Which Drive corpus to search. "user" (default): files in My Drive (owned + shared with me). "domain": files shared to the Google Workspace org. "drive": a specific shared drive (requires driveId). "allDrives": My Drive + all shared drives (may return incomplete results on large workspaces).'),
   }),
 };
 

--- a/packages/plugin-google-workspace/src/actions/drive-actions.ts
+++ b/packages/plugin-google-workspace/src/actions/drive-actions.ts
@@ -101,10 +101,14 @@ function getLabelFilter(params: unknown): string | undefined {
   return (params as Record<string, unknown> | null)?.__labelFilter as string | undefined;
 }
 
-const VALID_CORPORA = new Set(['user', 'domain', 'allDrives']);
+const VALID_CORPORA = new Set(['user', 'domain', 'drive', 'allDrives']);
 
-/** Return the org-configured corpora value, falling back to `'user'`. */
-function resolveCorpora(ctx: ActionContext): string {
+/**
+ * Return the corpora value for a Drive API request.
+ * Priority: per-request override > org-configured value > 'user' default.
+ */
+function resolveCorpora(ctx: ActionContext, override?: string): string {
+  if (typeof override === 'string' && VALID_CORPORA.has(override)) return override;
   const value = ctx.guardConfig?.driveCorpora;
   return typeof value === 'string' && VALID_CORPORA.has(value) ? value : 'user';
 }
@@ -159,6 +163,7 @@ const listFiles: ActionDefinition = {
     ownedByMe: z.boolean().optional().describe('Only return files owned by the authenticated user'),
     sharedWithMe: z.boolean().optional().describe('Only return files shared with the authenticated user'),
     modifiedAfter: z.string().optional().describe('Only return files modified after this date (ISO 8601)'),
+    corpora: z.enum(['user', 'domain', 'drive', 'allDrives']).optional().describe('Which corpus to search. "user" for personal files (default), "domain" for organization-wide, "drive" for a specific shared drive, "allDrives" for everything.'),
   }),
 };
 
@@ -179,6 +184,7 @@ const searchFiles: ActionDefinition = {
     maxResults: z.number().int().min(1).max(100).optional(),
     modifiedAfter: z.string().optional().describe('Only return files modified after this date (ISO 8601)'),
     pageToken: z.string().optional(),
+    corpora: z.enum(['user', 'domain', 'drive', 'allDrives']).optional().describe('Which corpus to search. "user" for personal files (default), "domain" for organization-wide, "drive" for a specific shared drive, "allDrives" for everything.'),
   }),
 };
 
@@ -193,6 +199,7 @@ const listDocuments: ActionDefinition = {
     pageToken: z.string().optional(),
     orderBy: z.enum(['name', 'modifiedTime', 'createdTime']).optional(),
     modifiedAfter: z.string().optional().describe('Only return documents modified after this date (ISO 8601)'),
+    corpora: z.enum(['user', 'domain', 'drive', 'allDrives']).optional().describe('Which corpus to search. "user" for personal files (default), "domain" for organization-wide, "drive" for a specific shared drive, "allDrives" for everything.'),
   }),
 };
 
@@ -207,6 +214,7 @@ const searchDocuments: ActionDefinition = {
     maxResults: z.number().int().min(1).max(100).optional(),
     pageToken: z.string().optional(),
     modifiedAfter: z.string().optional().describe('Only return documents modified after this date (ISO 8601)'),
+    corpora: z.enum(['user', 'domain', 'drive', 'allDrives']).optional().describe('Which corpus to search. "user" for personal files (default), "domain" for organization-wide, "drive" for a specific shared drive, "allDrives" for everything.'),
   }),
 };
 
@@ -219,6 +227,7 @@ const listFolderContents: ActionDefinition = {
     folderId: z.string().describe('Folder ID (use "root" for the root Drive folder)'),
     maxResults: z.number().int().min(1).max(100).optional(),
     pageToken: z.string().optional(),
+    corpora: z.enum(['user', 'domain', 'drive', 'allDrives']).optional().describe('Which corpus to search. "user" for personal files (default), "domain" for organization-wide, "drive" for a specific shared drive, "allDrives" for everything.'),
   }),
 };
 
@@ -400,7 +409,7 @@ async function executeAction(
           : 'modifiedTime desc';
 
         const qs = new URLSearchParams({
-          corpora: resolveCorpora(ctx),
+          corpora: resolveCorpora(ctx, p.corpora),
           fields: `nextPageToken,files(${LIST_FILE_FIELDS})`,
           pageSize: String(p.maxResults || 20),
           supportsAllDrives: 'true',
@@ -459,7 +468,7 @@ async function executeAction(
           : 'modifiedTime desc';
 
         const qs = new URLSearchParams({
-          corpora: resolveCorpora(ctx),
+          corpora: resolveCorpora(ctx, p.corpora),
           q: finalQuery,
           fields: `nextPageToken,files(${LIST_FILE_FIELDS})`,
           pageSize: String(p.maxResults || 10),
@@ -510,7 +519,7 @@ async function executeAction(
         const orderByParam = p.orderBy || 'modifiedTime';
 
         const qs = new URLSearchParams({
-          corpora: resolveCorpora(ctx),
+          corpora: resolveCorpora(ctx, p.corpora),
           q: finalQuery,
           fields: `nextPageToken,files(id,name,modifiedTime,createdTime,webViewLink,owners(displayName,emailAddress))`,
           pageSize: String(p.maxResults || 20),
@@ -562,7 +571,7 @@ async function executeAction(
         const finalQuery = composeQuery(queryParts.join(' and '), labelFilter);
 
         const qs = new URLSearchParams({
-          corpora: resolveCorpora(ctx),
+          corpora: resolveCorpora(ctx, p.corpora),
           q: finalQuery,
           fields: `nextPageToken,files(id,name,modifiedTime,createdTime,webViewLink,owners(displayName))`,
           pageSize: String(p.maxResults || 10),
@@ -599,7 +608,7 @@ async function executeAction(
         const finalQuery = composeQuery(queryParts.join(' and '), labelFilter);
 
         const qs = new URLSearchParams({
-          corpora: resolveCorpora(ctx),
+          corpora: resolveCorpora(ctx, p.corpora),
           q: finalQuery,
           fields: 'nextPageToken,files(id,name,mimeType,size,modifiedTime,webViewLink,owners(displayName))',
           pageSize: String(p.maxResults || 50),


### PR DESCRIPTION
## Summary

- Adds an optional `corpora` parameter (`user` | `domain` | `drive` | `allDrives`) to all Drive list/search tool definitions: `list_files`, `search_files`, `list_documents`, `search_documents`, and `list_folder_contents`
- Per-request `corpora` overrides the org-level `driveCorpora` setting, falling back to the org default (then `user`) when not provided
- Adds `drive` to `VALID_CORPORA` (was missing from the Google API spec options)

## Problem

When an org configured `driveCorpora: 'domain'`, searching for personal Google Docs via `list_documents` returned no results because it only searched the domain corpus. Users had no way to override this per-request.

## Changes

**`packages/plugin-google-workspace/src/actions/drive-actions.ts`:**
- `VALID_CORPORA`: added `'drive'` to the valid set
- `resolveCorpora()`: accepts optional `override` parameter; priority is override > org config > `'user'` default
- Action definitions: added `corpora` param to `listFiles`, `searchFiles`, `listDocuments`, `searchDocuments`, `listFolderContents`
- Execution handlers: pass `p.corpora` through to `resolveCorpora(ctx, p.corpora)`

**`packages/plugin-google-workspace/src/actions/__tests__/resolve-corpora.test.ts`:**
- Added test for `drive` as a valid org-level corpora value
- Added `per-request override` describe block covering: override precedence, fallback to guardConfig, fallback to default, invalid override handling

## Testing

All 13 tests pass (resolve-corpora.test.ts).

## Ref
https://developers.google.com/workspace/drive/api/reference/rest/v3/files/list