### PR TITLE
feat(integrations): add Pylon MCP plugin

### DIFF
--- a/packages/plugin-pylon/package.json
+++ b/packages/plugin-pylon/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@valet/plugin-pylon",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./actions": "./src/actions/index.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@valet/sdk": "workspace:*",
+    "@valet/shared": "workspace:*",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/plugin-pylon/plugin.yaml
+++ b/packages/plugin-pylon/plugin.yaml
@@ -1,0 +1,5 @@
+name: pylon
+version: 0.0.1
+description: Pylon customer support integration for issues, accounts, and contacts
+icon: "\U0001F6CE"
+actionType: mcp

--- a/packages/plugin-pylon/src/actions/actions.ts
+++ b/packages/plugin-pylon/src/actions/actions.ts
@@ -1,0 +1,7 @@
+import { McpActionSource } from '@valet/sdk';
+
+export const pylonActions = new McpActionSource({
+  mcpUrl: 'https://mcp.usepylon.com/mcp',
+  serviceName: 'pylon',
+  defaultRiskLevel: 'low',
+});

--- a/packages/plugin-pylon/src/actions/index.ts
+++ b/packages/plugin-pylon/src/actions/index.ts
@@ -1,0 +1,16 @@
+import type { IntegrationPackage } from '@valet/sdk';
+import { pylonProvider } from './provider.js';
+import { pylonActions } from './actions.js';
+
+export { pylonProvider } from './provider.js';
+export { pylonActions } from './actions.js';
+
+const pylonPackage: IntegrationPackage = {
+  name: '@valet/actions-pylon',
+  version: '0.0.1',
+  service: 'pylon',
+  provider: pylonProvider,
+  actions: pylonActions,
+};
+
+export default pylonPackage;

--- a/packages/plugin-pylon/src/actions/provider.ts
+++ b/packages/plugin-pylon/src/actions/provider.ts
@@ -1,0 +1,39 @@
+import type { IntegrationProvider, IntegrationCredentials } from '@valet/sdk';
+
+export const pylonProvider: IntegrationProvider = {
+  service: 'pylon',
+  displayName: 'Pylon',
+  authType: 'oauth2',
+  supportedEntities: ['issues', 'accounts', 'contacts'],
+  oauthScopes: ['openid', 'profile', 'email', 'offline_access'],
+  mcpServerUrl: 'https://mcp.usepylon.com',
+
+  validateCredentials(credentials: IntegrationCredentials): boolean {
+    return !!credentials.access_token;
+  },
+
+  async testConnection(credentials: IntegrationCredentials): Promise<boolean> {
+    try {
+      const res = await fetch('https://mcp.usepylon.com/mcp', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${credentials.access_token}`,
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-03-26',
+            capabilities: {},
+            clientInfo: { name: 'valet', version: '0.0.1' },
+          },
+        }),
+      });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  },
+};

--- a/packages/plugin-pylon/tsconfig.json
+++ b/packages/plugin-pylon/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": []
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../sdk" }, { "path": "../shared" }]
+}

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -28,6 +28,7 @@
     "@valet/plugin-github": "workspace:*",
     "@valet/plugin-gmail": "workspace:*",
     "@valet/plugin-granola": "workspace:*",
+    "@valet/plugin-pylon": "workspace:*",
     "@valet/plugin-google-auth": "workspace:*",
     "@valet/plugin-google-calendar": "workspace:*",
     "@valet/plugin-google-workspace": "workspace:*",

--- a/packages/worker/src/integrations/packages.ts
+++ b/packages/worker/src/integrations/packages.ts
@@ -10,10 +10,11 @@ import pkg5 from '@valet/plugin-google-workspace/actions';
 import pkg6 from '@valet/plugin-granola/actions';
 import pkg7 from '@valet/plugin-linear/actions';
 import pkg8 from '@valet/plugin-notion/actions';
-import pkg9 from '@valet/plugin-sentry/actions';
-import pkg10 from '@valet/plugin-slack/actions';
-import pkg11 from '@valet/plugin-socket/actions';
-import pkg12 from '@valet/plugin-stripe/actions';
-import pkg13 from '@valet/plugin-typefully/actions';
+import pkg9 from '@valet/plugin-pylon/actions';
+import pkg10 from '@valet/plugin-sentry/actions';
+import pkg11 from '@valet/plugin-slack/actions';
+import pkg12 from '@valet/plugin-socket/actions';
+import pkg13 from '@valet/plugin-stripe/actions';
+import pkg14 from '@valet/plugin-typefully/actions';
 
-export const installedIntegrations: IntegrationPackage[] = [pkg0, pkg1, pkg2, pkg3, pkg4, pkg5, pkg6, pkg7, pkg8, pkg9, pkg10, pkg11, pkg12, pkg13];
+export const installedIntegrations: IntegrationPackage[] = [pkg0, pkg1, pkg2, pkg3, pkg4, pkg5, pkg6, pkg7, pkg8, pkg9, pkg10, pkg11, pkg12, pkg13, pkg14];

--- a/packages/worker/src/plugins/content-registry.ts
+++ b/packages/worker/src/plugins/content-registry.ts
@@ -1630,6 +1630,15 @@ You can attach builtin or plugin skills to personas — they don't need to be ma
     ],
   },
   {
+    name: "pylon",
+    version: "0.0.1",
+    description: "Pylon customer support integration for issues, accounts, and contacts",
+    icon: "🛎",
+    actionType: "mcp",
+    capabilities: ["actions"],
+    artifacts: [],
+  },
+  {
     name: "sandbox-tunnels",
     version: "0.0.1",
     description: "Sandbox tunnel management",

--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -21,6 +21,7 @@
     { "path": "../plugin-google-workspace" },
     { "path": "../plugin-granola" },
     { "path": "../plugin-linear" },
+    { "path": "../plugin-pylon" },
     { "path": "../plugin-typefully" },
     { "path": "../plugin-notion" },
     { "path": "../plugin-sentry" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,6 +346,25 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.0.9)(jiti@1.21.7)(tsx@4.21.0)
 
+  packages/plugin-pylon:
+    dependencies:
+      '@valet/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      '@valet/shared':
+        specifier: workspace:*
+        version: link:../shared
+      zod:
+        specifier: ^3.22.4
+        version: 3.25.76
+    devDependencies:
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.0.9)(jiti@1.21.7)(tsx@4.21.0)
+
   packages/plugin-sentry:
     dependencies:
       '@valet/sdk':
@@ -557,6 +576,9 @@ importers:
       '@valet/plugin-notion':
         specifier: workspace:*
         version: link:../plugin-notion
+      '@valet/plugin-pylon':
+        specifier: workspace:*
+        version: link:../plugin-pylon
       '@valet/plugin-sentry':
         specifier: workspace:*
         version: link:../plugin-sentry

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     { "path": "./packages/plugin-google-workspace" },
     { "path": "./packages/plugin-granola" },
     { "path": "./packages/plugin-linear" },
+    { "path": "./packages/plugin-pylon" },
     { "path": "./packages/plugin-typefully" },
     { "path": "./packages/plugin-notion" },
     { "path": "./packages/plugin-stripe" },


### PR DESCRIPTION
## Summary
- Adds `packages/plugin-pylon/` — MCP-based integration plugin for Pylon customer support, following the same pattern as the Granola MCP plugin
- Connects to Pylon's official MCP server (`https://mcp.usepylon.com`) using OAuth 2.0 via AuthKit with dynamic client registration (PKCE)
- Exposes Pylon's MCP tools to agent sessions: `search_issues`, `get_issue`, `get_issue_messages`, `create_issue`, `update_issue`, `search_accounts`, `get_account`, `update_account`, `get_contact`, `get_user`, `get_me`
- No customer-facing message tools are exposed, aligning with governance (T3: customer responses require human review)

## Test plan
- [ ] Verify `pnpm typecheck` passes across all packages
- [ ] Verify `make generate-registries` includes Pylon in integration and content registries
- [ ] Deploy to dev and confirm Pylon appears in the integrations list
- [ ] Connect a Pylon account via OAuth and verify tool discovery works
- [ ] Test `search_issues` and `get_issue` against live Pylon data

Resolves TKAI-15