### PR TITLE
Add manual thread renaming

### DIFF
--- a/packages/client/src/api/threads.ts
+++ b/packages/client/src/api/threads.ts
@@ -116,3 +116,18 @@ export function useReactivateThread(sessionId: string) {
     },
   });
 }
+
+export function useRenameThread(sessionId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ threadId, title }: { threadId: string; title: string }) =>
+      api.patch<{ thread: SessionThread }>(
+        `/sessions/${sessionId}/threads/${threadId}`,
+        { title }
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: threadKeys.list(sessionId) });
+    },
+  });
+}

--- a/packages/client/src/components/chat/thread-sidebar.tsx
+++ b/packages/client/src/components/chat/thread-sidebar.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo, useCallback, useEffect } from 'react';
-import { useThreads, useDismissThread, useReactivateThread } from '@/api/threads';
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { useThreads, useDismissThread, useReactivateThread, useRenameThread } from '@/api/threads';
 import { useQueries } from '@tanstack/react-query';
 import { api } from '@/api/client';
 import { formatChannelLabel } from '@valet/sdk';
@@ -120,16 +120,58 @@ function ThreadItem({
   onSelect,
   onDismiss,
   isDismissed,
+  sessionId,
 }: {
   thread: SessionThread;
   isActive: boolean;
   onSelect: () => void;
   onDismiss?: () => void;
   isDismissed?: boolean;
+  sessionId: string;
 }) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  const renameThread = useRenameThread(sessionId);
+
   const lastViewed = getLastViewed(thread.id);
   const threadLastActive = new Date(thread.lastActiveAt).getTime();
   const hasUnread = !isActive && threadLastActive > lastViewed && thread.messageCount > 0;
+
+  const startEditing = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setEditValue(thread.title || thread.firstMessagePreview || '');
+    setIsEditing(true);
+    setTimeout(() => inputRef.current?.select(), 0);
+  }, [thread.title, thread.firstMessagePreview]);
+
+  const saveTitle = useCallback(() => {
+    const trimmed = editValue.trim();
+    if (trimmed !== (thread.title || '')) {
+      renameThread.mutate({ threadId: thread.id, title: trimmed });
+    }
+    setIsEditing(false);
+  }, [editValue, thread.title, thread.id, renameThread]);
+
+  if (isEditing) {
+    return (
+      <div className="px-2 py-1">
+        <input
+          ref={inputRef}
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') saveTitle();
+            if (e.key === 'Escape') setIsEditing(false);
+          }}
+          onBlur={saveTitle}
+          className="w-full rounded border border-violet-300 bg-white px-1 py-0.5 text-[11px] text-neutral-900 outline-none focus:ring-1 focus:ring-violet-400 dark:border-violet-600 dark:bg-neutral-900 dark:text-neutral-100"
+          autoFocus
+          maxLength={200}
+        />
+      </div>
+    );
+  }
 
   return (
     <button
@@ -148,6 +190,15 @@ function ThreadItem({
       {hasUnread && !isDismissed && (
         <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-violet-500" />
       )}
+      <span
+        role="button"
+        tabIndex={-1}
+        onClick={startEditing}
+        className="shrink-0 rounded p-0.5 text-neutral-400 opacity-0 transition-opacity hover:bg-neutral-200 hover:text-neutral-600 group-hover:opacity-100 dark:hover:bg-neutral-700 dark:hover:text-neutral-300"
+        title="Rename"
+      >
+        <PencilIcon className="h-2.5 w-2.5" />
+      </span>
       {onDismiss && (
         <span
           role="button"
@@ -288,6 +339,7 @@ export function ThreadSidebar({
                 isActive={thread.id === activeThreadId}
                 onSelect={() => onSelectThread(thread.id)}
                 onDismiss={() => handleDismiss(thread.id)}
+                sessionId={sessionId}
               />
             ))}
           </div>
@@ -318,6 +370,7 @@ export function ThreadSidebar({
                   isActive={false}
                   onSelect={() => handleReactivate(thread.id)}
                   isDismissed
+                  sessionId={sessionId}
                 />
               ))}
             </div>
@@ -358,6 +411,14 @@ function ChevronRightIcon({ className }: { className?: string }) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
       <path d="m9 18 6-6-6-6" />
+    </svg>
+  );
+}
+
+function PencilIcon({ className }: { className?: string }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z" /><path d="m15 5 4 4" />
     </svg>
   );
 }

--- a/packages/client/src/routes/sessions/$sessionId/threads/$threadId.tsx
+++ b/packages/client/src/routes/sessions/$sessionId/threads/$threadId.tsx
@@ -1,5 +1,6 @@
+import { useState, useRef, useCallback } from 'react';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
-import { useThread, useContinueThread } from '@/api/threads';
+import { useThread, useContinueThread, useRenameThread } from '@/api/threads';
 import { MessageList } from '@/components/chat/message-list';
 import { setPendingContinuation } from '@/components/chat/chat-container';
 import { formatRelativeTime } from '@/lib/format';
@@ -106,10 +107,29 @@ function ThreadDetailPage() {
   const { sessionId, threadId } = Route.useParams();
   const { data, isLoading, isError } = useThread(sessionId, threadId);
   const continueThread = useContinueThread(sessionId);
+  const renameThread = useRenameThread(sessionId);
   const navigate = useNavigate();
+
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [editTitleValue, setEditTitleValue] = useState('');
+  const titleInputRef = useRef<HTMLInputElement>(null);
 
   const thread = data?.thread;
   const messages = data?.messages ?? [];
+
+  const startEditingTitle = useCallback(() => {
+    setEditTitleValue(thread?.title || thread?.firstMessagePreview || '');
+    setIsEditingTitle(true);
+    setTimeout(() => titleInputRef.current?.select(), 0);
+  }, [thread?.title, thread?.firstMessagePreview]);
+
+  const saveTitle = useCallback(() => {
+    const trimmed = editTitleValue.trim();
+    if (trimmed !== (thread?.title || '')) {
+      renameThread.mutate({ threadId, title: trimmed });
+    }
+    setIsEditingTitle(false);
+  }, [editTitleValue, thread?.title, threadId, renameThread]);
 
   const handleContinue = () => {
     continueThread.mutate(threadId, {
@@ -140,9 +160,34 @@ function ThreadDetailPage() {
             &larr; Threads
           </Link>
           <div className="min-w-0">
-            <h1 className="truncate font-mono text-sm font-semibold text-neutral-800 dark:text-neutral-100">
-              {thread?.title || thread?.firstMessagePreview || 'Untitled thread'}
-            </h1>
+            {isEditingTitle ? (
+              <input
+                ref={titleInputRef}
+                value={editTitleValue}
+                onChange={(e) => setEditTitleValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') saveTitle();
+                  if (e.key === 'Escape') setIsEditingTitle(false);
+                }}
+                onBlur={saveTitle}
+                className="w-full rounded border border-violet-300 bg-white px-1 py-0.5 font-mono text-sm font-semibold text-neutral-800 outline-none focus:ring-1 focus:ring-violet-400 dark:border-violet-600 dark:bg-neutral-900 dark:text-neutral-100"
+                autoFocus
+                maxLength={200}
+              />
+            ) : (
+              <h1 className="group flex items-center gap-1.5 truncate font-mono text-sm font-semibold text-neutral-800 dark:text-neutral-100">
+                <span className="truncate">{thread?.title || thread?.firstMessagePreview || 'Untitled thread'}</span>
+                <span
+                  role="button"
+                  tabIndex={-1}
+                  onClick={startEditingTitle}
+                  className="shrink-0 rounded p-0.5 text-neutral-400 opacity-0 transition-opacity hover:bg-neutral-200 hover:text-neutral-600 group-hover:opacity-100 dark:hover:bg-neutral-700 dark:hover:text-neutral-300"
+                  title="Rename"
+                >
+                  <PencilIcon className="h-3 w-3" />
+                </span>
+              </h1>
+            )}
             {thread && (
               <div className="flex items-center gap-2 font-mono text-[10px] text-neutral-400 dark:text-neutral-500">
                 <span>{messages.length} {messages.length === 1 ? 'message' : 'messages'}</span>
@@ -226,5 +271,13 @@ function ThreadDetailPage() {
         </>
       )}
     </div>
+  );
+}
+
+function PencilIcon({ className }: { className?: string }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z" /><path d="m15 5 4 4" />
+    </svg>
   );
 }

--- a/packages/worker/src/routes/threads.ts
+++ b/packages/worker/src/routes/threads.ts
@@ -205,7 +205,7 @@ threadsRouter.post('/:sessionId/threads/:threadId/continue', async (c) => {
 
 /**
  * PATCH /api/sessions/:sessionId/threads/:threadId
- * Update thread status (active/archived).
+ * Update thread status or title.
  *
  * For orchestrator sessions, allows updating threads from any of the
  * user's orchestrator sessions.
@@ -224,13 +224,21 @@ threadsRouter.patch('/:sessionId/threads/:threadId', async (c) => {
 
   await assertOrchestratorThreadAccess(c.get('db'), session, thread, user.id, 'collaborator');
 
-  const body = await c.req.json<{ status?: 'active' | 'archived' }>();
+  const body = await c.req.json<{ status?: 'active' | 'archived'; title?: string | null }>();
   if (body.status && !['active', 'archived'].includes(body.status)) {
     return c.json({ error: 'Invalid status' }, 400);
   }
 
   if (body.status) {
     await db.updateThreadStatus(c.env.DB, threadId, body.status);
+  }
+
+  if (body.title !== undefined) {
+    if (body.title !== null && (typeof body.title !== 'string' || body.title.length > 200)) {
+      return c.json({ error: 'Title must be a string of max 200 characters' }, 400);
+    }
+    const titleValue = body.title === null ? '' : body.title;
+    await db.updateThread(c.env.DB, threadId, { title: titleValue });
   }
 
   const updated = await db.getThread(c.env.DB, threadId);


### PR DESCRIPTION
## Add manual thread renaming

Thread titles exist in the DB and are auto-generated by the AI, but users had no way to manually rename them.

### Changes
- **API**: Extended PATCH /api/sessions/:sessionId/threads/:threadId to accept optional title field (max 200 chars, null to clear)
- **Client hook**: Added useRenameThread mutation that invalidates the thread list on success
- **Thread sidebar**: Added inline rename with pencil icon on hover (Enter to save, Escape to cancel)
- **Thread detail page**: Added same inline rename to the title heading

### How to test
1. Open an orchestrator session with threads in the sidebar
2. Hover a thread — pencil icon appears — click to rename
3. Enter saves, Escape cancels, clicking away saves
4. Navigate to thread detail — title is also editable
5. Setting title to empty reverts to showing the first message preview