### PR TITLE
feat(integrations): move add-integration button into card grid

### DIFF
--- a/packages/client/src/components/integrations/integration-list.tsx
+++ b/packages/client/src/components/integrations/integration-list.tsx
@@ -29,7 +29,12 @@ const STATUS_OPTIONS: { value: StatusFilter; label: string }[] = [
   { value: 'disconnected', label: 'Disconnected' },
 ];
 
-export function IntegrationList() {
+interface IntegrationListProps {
+  onAddIntegration?: () => void;
+  addIntegrationLabel?: string;
+}
+
+export function IntegrationList({ onAddIntegration, addIntegrationLabel = 'Connect Integration' }: IntegrationListProps = {}) {
   const [search, setSearch] = React.useState('');
   const [statusFilter, setStatusFilter] = React.useState<StatusFilter>('all');
   const { data, isLoading: integrationsLoading, error } = useIntegrations();
@@ -154,10 +159,17 @@ export function IntegrationList() {
       </div>
 
       {allItems.length === 0 ? (
-        <div className="rounded-lg border border-neutral-200 bg-white p-8 text-center dark:border-neutral-700 dark:bg-neutral-800">
-          <p className="text-sm text-neutral-500 text-pretty dark:text-neutral-400">
-            No integrations configured. Connect your first service to get started.
-          </p>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {onAddIntegration && (
+            <AddIntegrationCard label={addIntegrationLabel} onClick={onAddIntegration} />
+          )}
+          {!onAddIntegration && (
+            <div className="rounded-lg border border-neutral-200 bg-white p-8 text-center dark:border-neutral-700 dark:bg-neutral-800 md:col-span-2 lg:col-span-3">
+              <p className="text-sm text-neutral-500 text-pretty dark:text-neutral-400">
+                No integrations configured. Connect your first service to get started.
+              </p>
+            </div>
+          )}
         </div>
       ) : filteredItems.length === 0 ? (
         <div className="rounded-lg border border-neutral-200 bg-white p-8 text-center dark:border-neutral-700 dark:bg-neutral-800">
@@ -185,9 +197,39 @@ export function IntegrationList() {
             }
             return <IntegrationCard key={item.key} integration={item.integration!} />;
           })}
+          {onAddIntegration && (
+            <AddIntegrationCard label={addIntegrationLabel} onClick={onAddIntegration} />
+          )}
         </div>
       )}
     </div>
+  );
+}
+
+// ─── Add Integration Card ───────────────────────────────────────────────
+
+function AddIntegrationCard({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex min-h-[148px] flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-neutral-300 bg-white p-6 text-neutral-500 transition-colors hover:border-neutral-400 hover:bg-neutral-50 hover:text-neutral-700 focus:outline-none focus:ring-2 focus:ring-neutral-400 focus:ring-offset-2 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-400 dark:hover:border-neutral-600 dark:hover:bg-neutral-750 dark:hover:text-neutral-200"
+    >
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-12 w-12 transition-transform group-hover:scale-110"
+        aria-hidden="true"
+      >
+        <line x1="12" y1="5" x2="12" y2="19" />
+        <line x1="5" y1="12" x2="19" y2="12" />
+      </svg>
+      <span className="text-sm font-medium">{label}</span>
+    </button>
   );
 }
 

--- a/packages/client/src/routes/integrations/index.tsx
+++ b/packages/client/src/routes/integrations/index.tsx
@@ -4,7 +4,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { PageContainer, PageHeader } from '@/components/layout/page-container';
 import { IntegrationList } from '@/components/integrations/integration-list';
 import { ConnectIntegrationDialog } from '@/components/integrations/connect-integration-dialog';
-import { Button } from '@/components/ui/button';
 import { toastSuccess, toastError } from '@/hooks/use-toast';
 import { githubKeys } from '@/api/github';
 
@@ -49,14 +48,12 @@ function IntegrationsPage() {
       <PageHeader
         title="Integrations"
         description="Connect your tools and services"
-        actions={
-          <Button onClick={() => setConnectDialogOpen(true)}>
-            Connect Integration
-          </Button>
-        }
       />
 
-      <IntegrationList />
+      <IntegrationList
+        onAddIntegration={() => setConnectDialogOpen(true)}
+        addIntegrationLabel="Connect Integration"
+      />
 
       <ConnectIntegrationDialog
         open={connectDialogOpen}


### PR DESCRIPTION
Replace the header 'Connect Integration' button with a big plus-icon card rendered inside the integrations grid alongside the enabled integrations. The card opens the same connect dialog and matches the dimensions/styling of the other integration cards (dashed border, centered + icon, label).

THIS IS PURE AI I HAVE NO IDEA IF IT WORKS