### PR TITLE
fix(client): add active state to toolbar tabs and prevent stuck transition overlay

### DIFF
--- a/packages/client/src/components/chat/chat-container.tsx
+++ b/packages/client/src/components/chat/chat-container.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo, lazy, Suspense } from 'react';
+import { cn } from '@/lib/cn';
 import { useNavigate, useRouter } from '@tanstack/react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { useChat } from '@/hooks/use-chat';
@@ -417,27 +418,27 @@ export function ChatContainer({ sessionId, routeSessionId, initialThreadId, init
       {/* Desktop action toolbar */}
       {!isMobile && (
         <div className="flex h-8 shrink-0 items-center gap-0.5 border-b border-neutral-100 bg-surface-0 px-2 dark:border-neutral-800/50 dark:bg-surface-0">
-          <Button variant="ghost" size="sm" onClick={drawer.toggleVscode} className="h-6 gap-1 px-2 text-[11px] font-medium text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200">
+          <Button variant="ghost" size="sm" onClick={drawer.toggleVscode} className={cn("h-6 gap-1 px-2 text-[11px] font-medium", drawer.activePanel === 'vscode' ? "text-accent bg-accent/10" : "text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200")}>
             <EditorIcon className="h-3 w-3" />
             VS Code
           </Button>
-          <Button variant="ghost" size="sm" onClick={drawer.toggleDesktop} className="h-6 gap-1 px-2 text-[11px] font-medium text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200">
+          <Button variant="ghost" size="sm" onClick={drawer.toggleDesktop} className={cn("h-6 gap-1 px-2 text-[11px] font-medium", drawer.activePanel === 'desktop' ? "text-accent bg-accent/10" : "text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200")}>
             <DesktopIcon className="h-3 w-3" />
             Desktop
           </Button>
-          <Button variant="ghost" size="sm" onClick={drawer.toggleTerminal} className="h-6 gap-1 px-2 text-[11px] font-medium text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200">
+          <Button variant="ghost" size="sm" onClick={drawer.toggleTerminal} className={cn("h-6 gap-1 px-2 text-[11px] font-medium", drawer.activePanel === 'terminal' ? "text-accent bg-accent/10" : "text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200")}>
             <TerminalIcon className="h-3 w-3" />
             Terminal
           </Button>
-          <Button variant="ghost" size="sm" onClick={drawer.toggleFiles} className="h-6 gap-1 px-2 text-[11px] font-medium text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200">
+          <Button variant="ghost" size="sm" onClick={drawer.toggleFiles} className={cn("h-6 gap-1 px-2 text-[11px] font-medium", drawer.activePanel === 'files' ? "text-accent bg-accent/10" : "text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200")}>
             <FilesIcon className="h-3 w-3" />
             Files
           </Button>
-          <Button variant="ghost" size="sm" onClick={drawer.toggleReview} className="h-6 gap-1 px-2 text-[11px] font-medium text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200">
+          <Button variant="ghost" size="sm" onClick={drawer.toggleReview} className={cn("h-6 gap-1 px-2 text-[11px] font-medium", drawer.activePanel === 'review' ? "text-accent bg-accent/10" : "text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200")}>
             <ReviewIcon className="h-3 w-3" />
             Review
           </Button>
-          <Button variant="ghost" size="sm" onClick={drawer.toggleLogs} className="h-6 gap-1 px-2 text-[11px] font-medium text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200">
+          <Button variant="ghost" size="sm" onClick={drawer.toggleLogs} className={cn("h-6 gap-1 px-2 text-[11px] font-medium", drawer.activePanel === 'logs' ? "text-accent bg-accent/10" : "text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200")}>
             <LogsIcon className="h-3 w-3" />
             Logs
           </Button>

--- a/packages/client/src/routes/sessions/$sessionId.tsx
+++ b/packages/client/src/routes/sessions/$sessionId.tsx
@@ -1,4 +1,4 @@
-import { createContext, lazy, Suspense, useCallback, useContext, useState } from 'react';
+import { createContext, lazy, Suspense, useCallback, useContext, useEffect, useState } from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { Panel, Group as PanelGroup, Separator as PanelResizeHandle } from 'react-resizable-panels';
 import { useSession } from '@/api/sessions';
@@ -146,6 +146,15 @@ function SessionLayout() {
   const [selectedModel, setSelectedModel] = useState<string | undefined>(undefined);
   const [pendingFilePath, setPendingFilePath] = useState<string | null>(null);
   const [mobileMetadataOpen, setMobileMetadataOpen] = useState(false);
+
+  // Safety: auto-clear transition overlays after 10s to prevent stuck click-blocking states
+  useEffect(() => {
+    if (overlay?.type === 'transition') {
+      const timer = setTimeout(() => setOverlay(null), 10000);
+      return () => clearTimeout(timer);
+    }
+  }, [overlay]);
+
   const [sidebarOpen, setSidebarOpen] = useState(() => {
     try {
       const val = localStorage.getItem(SIDEBAR_STORAGE_KEY);


### PR DESCRIPTION
## Summary

Fixes two UX issues causing session toolbar tabs to appear non-responsive:

- **Active tab styling**: Toolbar buttons (VS Code, Desktop, Terminal, Files, Review, Logs) now show an accent text color and subtle background tint when the corresponding panel is open, using `drawer.activePanel` from the existing context
- **Stuck overlay safety net**: The hibernate transition overlay (`z-50 absolute inset-0`) now auto-clears after 10 seconds via a `useEffect` timeout, preventing it from permanently blocking all clicks if `setOverlay` is called but never cleared

## Changes

### `packages/client/src/components/chat/chat-container.tsx`
- Added `cn` import from `@/lib/cn`
- Updated all 6 toolbar `Button` components to use conditional `cn()` styling:
  - Active: `text-accent bg-accent/10`
  - Inactive: original `text-neutral-500 hover:text-neutral-800 ...` classes

### `packages/client/src/routes/sessions/$sessionId.tsx`
- Added `useEffect` to React imports
- Added safety `useEffect` that sets a 10s timeout to clear transition overlays, with proper cleanup on unmount/re-render

## Testing
- Verified no new TypeScript errors introduced (all pre-existing errors in the codebase are unrelated `@valet/shared` module resolution and `ChildSessionSummaryWithRuntime` type issues)