### PR TITLE
feat: add plugin-reviews with Reviews CLI installer and pre-PR skill

### DIFF
--- a/packages/plugin-reviews/package.json
+++ b/packages/plugin-reviews/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@valet/plugin-reviews",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/plugin-reviews/plugin.yaml
+++ b/packages/plugin-reviews/plugin.yaml
@@ -1,0 +1,4 @@
+name: reviews
+version: 0.0.1
+description: Reviews integration — push review packets before PRs
+icon: "🔍"

--- a/packages/plugin-reviews/skills/reviews.md
+++ b/packages/plugin-reviews/skills/reviews.md
@@ -1,0 +1,254 @@
+---
+name: reviews
+description: Push review packets to Reviews before creating GitHub PRs. Embeds Reviews platform skills for writing packets and using the CLI.
+---
+
+# Reviews Integration — Pre-PR Review Workflow
+
+## Valet-Specific Requirement
+
+**Before calling `github.create_pull_request`, you MUST:**
+
+1. Write a review packet for the diff (see "Writing Review Packets" below)
+2. Push the review packet to Reviews using the `reviews` CLI
+3. Share the resulting review URL with the user
+4. Wait for the user to review and explicitly approve the packet before proceeding
+
+Only after the user has reviewed and approved the review packet should you proceed to create the GitHub PR.
+
+This applies to all PR creation in Valet sessions. The review packet gives the user a structured, human-readable view of the diff before it becomes a public GitHub PR.
+
+**Workflow:**
+```
+1. Implement the change
+2. Write a review packet (markdown with sections + hunk refs)
+3. Push with: reviews push --packet /path/to/packet.md
+4. Share the review URL with the user
+5. Wait for user approval
+6. Create GitHub PR via github.create_pull_request
+```
+
+---
+
+# Reviews Overview
+
+Use this section to understand Reviews as a code-review platform and decide when to use it in an agent workflow. This is not a repo implementation guide.
+
+## What Reviews Is
+
+Reviews is a review tool for arbitrary code diffs, not only GitHub pull requests. It lets an agent or developer push a diff to a shareable review URL, optionally attach a structured review packet, and iterate through revisions as patchsets.
+
+The core value is making a diff understandable to a human reviewer before, during, or outside a public PR process.
+
+## What Reviews Provides
+
+- **Link-based review pages** for uploaded diffs.
+- **Patchsets** for iterating on the same review as the work changes.
+- **Review packets** that organize a diff into human-readable sections with prose and hunk references.
+- **Lazy hunk rendering** so large diffs can be reviewed without eagerly mounting every diff.
+- **Explicit hunk viewed state** for signed-in reviewers.
+- **Section decisions** such as approve, deny, or ignore for packet sections.
+- **Comment drafting and publishing** so reviewers can batch feedback.
+- **Changes view** for direct file/hunk review outside the packet narrative.
+
+## When To Use Reviews
+
+Use Reviews after a few turns of human-in-the-loop or agent-driven development when there is a coherent diff ready for human review.
+
+Good moments:
+- The agent has implemented a feature and wants a human to inspect the result before public PR creation.
+- The user asks for a review packet, local review, or shareable review link.
+- The work has grown large enough that raw `git diff` is hard to review.
+- The agent wants to explain the review order, risk areas, and tradeoffs alongside the code.
+- The team wants a pre-PR review pass before committing to a public GitHub PR.
+- A project has another review process, but Reviews can provide the structured packet and hunk progress layer.
+
+Avoid using Reviews when:
+- There is no concrete diff yet.
+- The user only wants brainstorming or planning.
+- The change is tiny enough that inline explanation is sufficient.
+- The diff contains secrets or local-only artifacts that should not be uploaded.
+
+## How It Fits A Development Loop
+
+Typical flow:
+
+1. Develop with the user or autonomous agent loop.
+2. Stabilize the diff enough for review.
+3. Write or update a review packet that groups the work logically.
+4. Push the diff and packet to Reviews.
+5. Share the review URL with the human reviewer.
+6. Address feedback.
+7. Push another patchset to the same review.
+8. Optionally create or update a public PR after review confidence is higher.
+
+Reviews can be the review surface of record, or it can be an intermediate review artifact before another system such as GitHub PRs.
+
+## Important Terms
+
+- **Review**: the durable review URL and container for one line of work.
+- **Patchset**: one revision of the uploaded diff within a review.
+- **Review packet**: a markdown or JSON guide that describes how to review the diff.
+- **Section**: a packet `##` grouping with prose and hunk references.
+- **Hunk reference**: a pointer such as `@hunk path/to/file.ex#2` or a slice like `@hunk path/to/file.ex#2:L3-L18`.
+- **Viewed hunk**: explicit reviewer progress; opening a hunk is not the same as marking it viewed.
+- **Section decision**: explicit approve/deny/ignore state for a packet section.
+
+## Agent Guidance
+
+When using Reviews, prefer producing a packet rather than uploading a raw diff alone for substantial work. The packet should tell the human what to review first, why the sections exist, and where tradeoffs or risk live.
+
+When updating a review, preserve packet section titles and hunk groupings if the goal is to keep previous section approvals valid. Create a new packet structure when the review framing has changed enough that prior approvals should not carry forward.
+
+When reporting a Reviews link back to the user, include the URL and the patchset number if the CLI provides one.
+
+---
+
+# Writing Review Packets
+
+Use this section when drafting packet markdown for `reviews push --packet`. A good packet is a reviewer map: it groups related hunks, explains why to look, and avoids rephrasing the diff line-by-line.
+
+## Packet Markdown Format
+
+Use one top-level title and `##` packet sections:
+
+```markdown
+# Packet Title
+
+Short overview of what the review packet covers.
+
+## Section Title
+
+One or two sentences orienting the reviewer.
+
+One sentence of context before the hunk when useful.
+
+@hunk path/to/file.ex#1
+```
+
+Rules:
+- Start with exactly one `#` title.
+- Use `##` for review packet sections.
+- Prose between hunk refs is allowed and encouraged.
+- Hunk refs use `@hunk path#N`.
+- Paths and hunk numbers must match the diff being pushed.
+
+## Writing Method
+
+1. Inspect the diff with `git diff` or the intended CLI range.
+2. Identify logical review areas: persistence/schema, read model, LiveView state, rendering, styling, tests, tooling.
+3. Prefer stable section titles if updating an existing packet and you want approvals to inherit.
+4. Put a 1-2 sentence summary at the top of each `##` section.
+5. Use `###` subheadings sparingly, only when a section truly needs scan landmarks; do not add a stock technical-overview subsection to every section.
+6. Add terse hunk explainers before hunks when they help the reader know what to look for.
+7. Avoid hunk explainers that restate the diff; explain context, dependency order, risk, or review intent.
+8. Keep section decisions independent from hunk viewed progress in wording.
+
+## Hunk Selection
+
+- Cover every changed line exactly once unless intentionally grouping duplicate ref coverage is acceptable for the current tool.
+- Use full hunk refs for small cohesive changes.
+- If one large hunk contains multiple review topics, split the surrounding prose instead of using sliced hunk refs.
+- Keep generated files, lockfiles, or purely mechanical output out of the packet unless they need review.
+- If the packet is only for local review, put it in `/tmp` or another temporary path to avoid accidentally committing it.
+
+## Approval Inheritance
+
+Section approvals inherit across patchsets only when the packet section identity and refs still match well enough.
+
+To preserve approvals:
+- Keep section titles stable.
+- Keep hunk refs in the same conceptual section.
+- Add new sections for new work instead of rewriting the whole packet.
+
+To intentionally invalidate approvals:
+- Restructure sections around a new review strategy.
+- Change section titles and hunk membership.
+
+## Push Workflow
+
+Use the CLI from the git checkout being reviewed:
+
+```bash
+reviews push --packet /path/to/packet.md
+reviews push --update <slug> --packet /path/to/packet.md
+reviews push --update <slug> --range HEAD --packet /path/to/packet.md
+```
+
+Notes:
+- `--range HEAD` captures current working-tree changes.
+- Default capture is usually `HEAD~1..HEAD`; use an explicit range when needed.
+- If validation fails with an uncovered changed line, add or adjust hunk refs until the packet covers the diff.
+- Do not commit local packet files unless the user explicitly wants them tracked.
+
+---
+
+# Using Reviews Locally
+
+Use this section for local Reviews workflows.
+
+## Start the Server
+
+Use the project script:
+
+```bash
+lsof -iTCP:4000 -sTCP:LISTEN
+./bin/server
+```
+
+Do not run `mix phx.server` directly unless you know OAuth/env loading is unnecessary. `./bin/server` sources `.env.local` and runs Phoenix on `http://localhost:4000`.
+
+## Local CLI Config
+
+The CLI reads `~/.config/reviews/config.toml` and currently uses `[default]`.
+
+Expected shape:
+
+```toml
+[default]
+server_url = "http://localhost:4000"
+api_token = "rev_..."
+```
+
+If the user's real default points to a hosted instance, avoid editing it casually. For one-off local pushes, create a temporary home/config:
+
+```bash
+mkdir -p /tmp/reviews-local-home/.config/reviews
+# write /tmp/reviews-local-home/.config/reviews/config.toml
+HOME=/tmp/reviews-local-home reviews push --update <slug>
+```
+
+## Mint Local Tokens
+
+Preferred path:
+1. Open `http://localhost:4000/settings`.
+2. Sign in locally.
+3. Generate an API token.
+4. Use it in the CLI config.
+
+## Push Reviews and Revisions
+
+Create a new review:
+
+```bash
+reviews push --packet /path/to/packet.md
+```
+
+Append a patchset:
+
+```bash
+reviews push --update <slug> --packet /path/to/packet.md
+```
+
+Push current uncommitted work:
+
+```bash
+reviews push --update <slug> --range HEAD --packet /path/to/packet.md
+```
+
+## Valet Agent Workflow
+
+- Write packet files to `/tmp` unless the user asks to commit them.
+- After pushing, return the review URL and patchset number to the user.
+- Wait for explicit user approval before creating a GitHub PR.
+- If the `reviews` binary is not found, it should have been installed at runner startup — check that `installReviewsCli()` ran successfully.

--- a/packages/plugin-reviews/src/index.ts
+++ b/packages/plugin-reviews/src/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @valet/plugin-reviews
+ *
+ * Reviews integration plugin — provides a skill that instructs agents to push
+ * review packets to Reviews before creating GitHub PRs, and exports the CLI
+ * installer for runner startup.
+ */
+
+export { installReviewsCli } from './install.js';
+export type { InstallResult } from './install.js';

--- a/packages/plugin-reviews/src/install.ts
+++ b/packages/plugin-reviews/src/install.ts
@@ -1,0 +1,86 @@
+/**
+ * Reviews CLI installer for Valet runner startup.
+ *
+ * Checks if the `reviews` binary is available and installs it if not.
+ * Called during runner startup before OpenCode launches.
+ */
+
+import { execSync, spawnSync } from 'node:child_process';
+
+export interface InstallResult {
+  installed: boolean;
+  version?: string;
+  error?: string;
+}
+
+/**
+ * Get the installed version of the reviews binary, or null if not found.
+ */
+function getInstalledVersion(): string | null {
+  try {
+    const result = spawnSync('reviews', ['--version'], { encoding: 'utf-8', timeout: 5000 });
+    if (result.status === 0 && result.stdout) {
+      return result.stdout.trim();
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if the reviews binary is already installed.
+ */
+function isReviewsInstalled(): boolean {
+  // Check via PATH first
+  const result = spawnSync('which', ['reviews'], { encoding: 'utf-8', timeout: 5000 });
+  if (result.status === 0) return true;
+
+  // Fall back to checking known install location
+  try {
+    const fs = require('node:fs');
+    return fs.existsSync('/usr/local/bin/reviews');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Install the Reviews CLI using the official install script.
+ * Passes --no-skills to skip installing Codex-specific skill symlinks.
+ */
+export async function installReviewsCli(): Promise<InstallResult> {
+  // Check if already installed
+  if (isReviewsInstalled()) {
+    const version = getInstalledVersion();
+    return { installed: true, version: version ?? undefined };
+  }
+
+  console.log('[Reviews] reviews CLI not found — installing via install script...');
+
+  try {
+    execSync(
+      'curl -fsSL https://raw.githubusercontent.com/figitaki/reviews/main/install.sh | sh -s -- --no-skills',
+      {
+        stdio: 'inherit',
+        timeout: 120_000, // 2 minutes
+        shell: '/bin/sh',
+      },
+    );
+
+    // Verify installation succeeded
+    if (isReviewsInstalled()) {
+      const version = getInstalledVersion();
+      console.log(`[Reviews] reviews CLI installed successfully${version ? ` (${version})` : ''}`);
+      return { installed: true, version: version ?? undefined };
+    } else {
+      const msg = 'Install script ran but reviews binary not found afterwards';
+      console.warn(`[Reviews] ${msg}`);
+      return { installed: false, error: msg };
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[Reviews] Failed to install reviews CLI: ${msg}`);
+    return { installed: false, error: msg };
+  }
+}

--- a/packages/plugin-reviews/tsconfig.json
+++ b/packages/plugin-reviews/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": []
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@1password/sdk": "^0.3.1",
     "@llamaindex/liteparse": "^1.1.0",
+    "@valet/plugin-reviews": "workspace:*",
     "@valet/shared": "workspace:*",
     "diff": "^8.0.3",
     "hono": "^4.0.0"

--- a/packages/runner/src/bin.ts
+++ b/packages/runner/src/bin.ts
@@ -15,6 +15,7 @@ import { AgentClient } from "./agent-client.js";
 import { PromptHandler } from "./prompt.js";
 import { startGateway, cleanupAllCloudflared } from "./gateway.js";
 import { OpenCodeManager, type OpenCodeConfig } from "./opencode-manager.js";
+import { installReviewsCli } from "@valet/plugin-reviews";
 
 function mergeOpenCodeConfig(
   current: OpenCodeConfig,
@@ -600,6 +601,17 @@ async function main() {
   console.log(`[Runner] Starting OpenCode with ${Object.keys(currentConfig.providerKeys).length} provider key(s)`);
   await openCodeManager.setDesiredConfig(currentConfig);
   console.log(`[Runner] OpenCode URL: ${openCodeManager.getUrl()}`);
+
+  // Install Reviews CLI in the background — non-blocking, failure is logged but does not halt startup.
+  installReviewsCli().then((result) => {
+    if (result.installed) {
+      console.log(`[Runner] Reviews CLI ready${result.version ? ` (${result.version})` : ''}`);
+    } else {
+      console.warn(`[Runner] Reviews CLI install failed (non-fatal): ${result.error ?? 'unknown error'}`);
+    }
+  }).catch((err) => {
+    console.warn('[Runner] Reviews CLI install threw unexpectedly (non-fatal):', err);
+  });
 
   // Ack config to the DO
   agentClient.sendOpenCodeConfigApplied(true, false);

--- a/packages/worker/src/plugins/content-registry.ts
+++ b/packages/worker/src/plugins/content-registry.ts
@@ -1647,6 +1647,270 @@ You can attach builtin or plugin skills to personas — they don't need to be ma
     artifacts: [],
   },
   {
+    name: "reviews",
+    version: "0.0.1",
+    description: "Reviews integration — push review packets before PRs",
+    icon: "🔍",
+    capabilities: ["skills"],
+    artifacts: [
+      { type: "skill", filename: "reviews.md", content: `---
+name: reviews
+description: Push review packets to Reviews before creating GitHub PRs. Embeds Reviews platform skills for writing packets and using the CLI.
+---
+
+# Reviews Integration — Pre-PR Review Workflow
+
+## Valet-Specific Requirement
+
+**Before calling \`github.create_pull_request\`, you MUST:**
+
+1. Write a review packet for the diff (see "Writing Review Packets" below)
+2. Push the review packet to Reviews using the \`reviews\` CLI
+3. Share the resulting review URL with the user
+4. Wait for the user to review and explicitly approve the packet before proceeding
+
+Only after the user has reviewed and approved the review packet should you proceed to create the GitHub PR.
+
+This applies to all PR creation in Valet sessions. The review packet gives the user a structured, human-readable view of the diff before it becomes a public GitHub PR.
+
+**Workflow:**
+\`\`\`
+1. Implement the change
+2. Write a review packet (markdown with sections + hunk refs)
+3. Push with: reviews push --packet /path/to/packet.md
+4. Share the review URL with the user
+5. Wait for user approval
+6. Create GitHub PR via github.create_pull_request
+\`\`\`
+
+---
+
+# Reviews Overview
+
+Use this section to understand Reviews as a code-review platform and decide when to use it in an agent workflow. This is not a repo implementation guide.
+
+## What Reviews Is
+
+Reviews is a review tool for arbitrary code diffs, not only GitHub pull requests. It lets an agent or developer push a diff to a shareable review URL, optionally attach a structured review packet, and iterate through revisions as patchsets.
+
+The core value is making a diff understandable to a human reviewer before, during, or outside a public PR process.
+
+## What Reviews Provides
+
+- **Link-based review pages** for uploaded diffs.
+- **Patchsets** for iterating on the same review as the work changes.
+- **Review packets** that organize a diff into human-readable sections with prose and hunk references.
+- **Lazy hunk rendering** so large diffs can be reviewed without eagerly mounting every diff.
+- **Explicit hunk viewed state** for signed-in reviewers.
+- **Section decisions** such as approve, deny, or ignore for packet sections.
+- **Comment drafting and publishing** so reviewers can batch feedback.
+- **Changes view** for direct file/hunk review outside the packet narrative.
+
+## When To Use Reviews
+
+Use Reviews after a few turns of human-in-the-loop or agent-driven development when there is a coherent diff ready for human review.
+
+Good moments:
+- The agent has implemented a feature and wants a human to inspect the result before public PR creation.
+- The user asks for a review packet, local review, or shareable review link.
+- The work has grown large enough that raw \`git diff\` is hard to review.
+- The agent wants to explain the review order, risk areas, and tradeoffs alongside the code.
+- The team wants a pre-PR review pass before committing to a public GitHub PR.
+- A project has another review process, but Reviews can provide the structured packet and hunk progress layer.
+
+Avoid using Reviews when:
+- There is no concrete diff yet.
+- The user only wants brainstorming or planning.
+- The change is tiny enough that inline explanation is sufficient.
+- The diff contains secrets or local-only artifacts that should not be uploaded.
+
+## How It Fits A Development Loop
+
+Typical flow:
+
+1. Develop with the user or autonomous agent loop.
+2. Stabilize the diff enough for review.
+3. Write or update a review packet that groups the work logically.
+4. Push the diff and packet to Reviews.
+5. Share the review URL with the human reviewer.
+6. Address feedback.
+7. Push another patchset to the same review.
+8. Optionally create or update a public PR after review confidence is higher.
+
+Reviews can be the review surface of record, or it can be an intermediate review artifact before another system such as GitHub PRs.
+
+## Important Terms
+
+- **Review**: the durable review URL and container for one line of work.
+- **Patchset**: one revision of the uploaded diff within a review.
+- **Review packet**: a markdown or JSON guide that describes how to review the diff.
+- **Section**: a packet \`##\` grouping with prose and hunk references.
+- **Hunk reference**: a pointer such as \`@hunk path/to/file.ex#2\` or a slice like \`@hunk path/to/file.ex#2:L3-L18\`.
+- **Viewed hunk**: explicit reviewer progress; opening a hunk is not the same as marking it viewed.
+- **Section decision**: explicit approve/deny/ignore state for a packet section.
+
+## Agent Guidance
+
+When using Reviews, prefer producing a packet rather than uploading a raw diff alone for substantial work. The packet should tell the human what to review first, why the sections exist, and where tradeoffs or risk live.
+
+When updating a review, preserve packet section titles and hunk groupings if the goal is to keep previous section approvals valid. Create a new packet structure when the review framing has changed enough that prior approvals should not carry forward.
+
+When reporting a Reviews link back to the user, include the URL and the patchset number if the CLI provides one.
+
+---
+
+# Writing Review Packets
+
+Use this section when drafting packet markdown for \`reviews push --packet\`. A good packet is a reviewer map: it groups related hunks, explains why to look, and avoids rephrasing the diff line-by-line.
+
+## Packet Markdown Format
+
+Use one top-level title and \`##\` packet sections:
+
+\`\`\`markdown
+# Packet Title
+
+Short overview of what the review packet covers.
+
+## Section Title
+
+One or two sentences orienting the reviewer.
+
+One sentence of context before the hunk when useful.
+
+@hunk path/to/file.ex#1
+\`\`\`
+
+Rules:
+- Start with exactly one \`#\` title.
+- Use \`##\` for review packet sections.
+- Prose between hunk refs is allowed and encouraged.
+- Hunk refs use \`@hunk path#N\`.
+- Paths and hunk numbers must match the diff being pushed.
+
+## Writing Method
+
+1. Inspect the diff with \`git diff\` or the intended CLI range.
+2. Identify logical review areas: persistence/schema, read model, LiveView state, rendering, styling, tests, tooling.
+3. Prefer stable section titles if updating an existing packet and you want approvals to inherit.
+4. Put a 1-2 sentence summary at the top of each \`##\` section.
+5. Use \`###\` subheadings sparingly, only when a section truly needs scan landmarks; do not add a stock technical-overview subsection to every section.
+6. Add terse hunk explainers before hunks when they help the reader know what to look for.
+7. Avoid hunk explainers that restate the diff; explain context, dependency order, risk, or review intent.
+8. Keep section decisions independent from hunk viewed progress in wording.
+
+## Hunk Selection
+
+- Cover every changed line exactly once unless intentionally grouping duplicate ref coverage is acceptable for the current tool.
+- Use full hunk refs for small cohesive changes.
+- If one large hunk contains multiple review topics, split the surrounding prose instead of using sliced hunk refs.
+- Keep generated files, lockfiles, or purely mechanical output out of the packet unless they need review.
+- If the packet is only for local review, put it in \`/tmp\` or another temporary path to avoid accidentally committing it.
+
+## Approval Inheritance
+
+Section approvals inherit across patchsets only when the packet section identity and refs still match well enough.
+
+To preserve approvals:
+- Keep section titles stable.
+- Keep hunk refs in the same conceptual section.
+- Add new sections for new work instead of rewriting the whole packet.
+
+To intentionally invalidate approvals:
+- Restructure sections around a new review strategy.
+- Change section titles and hunk membership.
+
+## Push Workflow
+
+Use the CLI from the git checkout being reviewed:
+
+\`\`\`bash
+reviews push --packet /path/to/packet.md
+reviews push --update <slug> --packet /path/to/packet.md
+reviews push --update <slug> --range HEAD --packet /path/to/packet.md
+\`\`\`
+
+Notes:
+- \`--range HEAD\` captures current working-tree changes.
+- Default capture is usually \`HEAD~1..HEAD\`; use an explicit range when needed.
+- If validation fails with an uncovered changed line, add or adjust hunk refs until the packet covers the diff.
+- Do not commit local packet files unless the user explicitly wants them tracked.
+
+---
+
+# Using Reviews Locally
+
+Use this section for local Reviews workflows.
+
+## Start the Server
+
+Use the project script:
+
+\`\`\`bash
+lsof -iTCP:4000 -sTCP:LISTEN
+./bin/server
+\`\`\`
+
+Do not run \`mix phx.server\` directly unless you know OAuth/env loading is unnecessary. \`./bin/server\` sources \`.env.local\` and runs Phoenix on \`http://localhost:4000\`.
+
+## Local CLI Config
+
+The CLI reads \`~/.config/reviews/config.toml\` and currently uses \`[default]\`.
+
+Expected shape:
+
+\`\`\`toml
+[default]
+server_url = "http://localhost:4000"
+api_token = "rev_..."
+\`\`\`
+
+If the user's real default points to a hosted instance, avoid editing it casually. For one-off local pushes, create a temporary home/config:
+
+\`\`\`bash
+mkdir -p /tmp/reviews-local-home/.config/reviews
+# write /tmp/reviews-local-home/.config/reviews/config.toml
+HOME=/tmp/reviews-local-home reviews push --update <slug>
+\`\`\`
+
+## Mint Local Tokens
+
+Preferred path:
+1. Open \`http://localhost:4000/settings\`.
+2. Sign in locally.
+3. Generate an API token.
+4. Use it in the CLI config.
+
+## Push Reviews and Revisions
+
+Create a new review:
+
+\`\`\`bash
+reviews push --packet /path/to/packet.md
+\`\`\`
+
+Append a patchset:
+
+\`\`\`bash
+reviews push --update <slug> --packet /path/to/packet.md
+\`\`\`
+
+Push current uncommitted work:
+
+\`\`\`bash
+reviews push --update <slug> --range HEAD --packet /path/to/packet.md
+\`\`\`
+
+## Valet Agent Workflow
+
+- Write packet files to \`/tmp\` unless the user asks to commit them.
+- After pushing, return the review URL and patchset number to the user.
+- Wait for explicit user approval before creating a GitHub PR.
+- If the \`reviews\` binary is not found, it should have been installed at runner startup — check that \`installReviewsCli()\` ran successfully.
+`, sortOrder: 0 },
+    ],
+  },
+  {
     name: "sandbox-tunnels",
     version: "0.0.1",
     description: "Sandbox tunnel management",


### PR DESCRIPTION
- Add packages/plugin-reviews with plugin.yaml, skills/reviews.md, src/install.ts, src/index.ts, package.json, and tsconfig.json
- reviews.md embeds all three Reviews skills (overview, writing packets, using locally) plus Valet-specific instructions requiring agents to push a review packet and get user sign-off before github.create_pull_request
- installReviewsCli() checks for the binary, runs the upstream install.sh with --no-skills if absent, and returns {installed, version, error}
- Wire installReviewsCli() into packages/runner/src/bin.ts at startup as a non-blocking background task (failure is logged, not fatal)
- Add @valet/plugin-reviews to runner dependencies
- Re-run generate-plugin-registry.ts to add reviews entry to content-registry.ts so the skill is automatically pushed to all sessions as an org default