### PR TITLE
Add custom MCP connector support

### DIFF
--- a/docs/plans/2026-05-22-custom-mcp-connectors.md
+++ b/docs/plans/2026-05-22-custom-mcp-connectors.md
@@ -1,0 +1,378 @@
+# Custom Remote MCP Connectors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add admin-managed custom remote MCP connectors with no-auth, OAuth (admin-provided client credentials), and API key/bearer support. Custom connector tools integrate into existing tool discovery, action policy, approval, and audit paths.
+
+**Architecture:** New `custom_mcp_connectors` D1 table stores connector configuration. A worker-side custom connector service builds request-scoped connector context from D1; `IntegrationRegistry` stays a static singleton and only consumes that request context as a fallback. OAuth uses admin-provided `client_id`/`client_secret` instead of dynamic registration. `McpClient` gains static header support, injectable safe fetch, and protocol version updates. Admin UI follows the existing section pattern in settings; user-facing connection flow reuses the existing integration OAuth path.
+
+**Tech Stack:** TypeScript, Hono, Drizzle ORM, Cloudflare D1, React 19, TanStack Query, Vitest, pnpm.
+
+---
+
+## Source Documents
+
+- Spec: `docs/specs/2026-05-22-custom-mcp-connectors-design.md`
+- MCP client: `packages/sdk/src/mcp/client.ts`
+- MCP action source: `packages/sdk/src/mcp/action-source.ts`
+- MCP OAuth: `packages/sdk/src/mcp/oauth.ts`
+- MCP types: `packages/sdk/src/mcp/types.ts`
+- Integration registry: `packages/worker/src/integrations/registry.ts`
+- Integration packages (generated): `packages/worker/src/integrations/packages.ts`
+- Integration routes: `packages/worker/src/routes/integrations.ts`
+- Session tools: `packages/worker/src/services/session-tools.ts`
+- Credentials service: `packages/worker/src/services/credentials.ts`
+- Action policy: `packages/worker/src/services/action-policy.ts`, `actions.ts`
+- Disabled actions: `packages/worker/src/services/disabled-actions.ts`
+- Admin settings UI: `packages/client/src/routes/settings/admin.tsx`
+- Integration dialog: `packages/client/src/components/integrations/connect-integration-dialog.tsx`
+- OAuth callback: `packages/client/src/routes/integrations/callback.tsx`
+
+## File Map
+
+### Migration & Schema
+
+- Create `packages/worker/migrations/0015_custom_mcp_connectors.sql`
+  - Creates `custom_mcp_connectors` table with all columns from spec.
+  - Adds `oauth_token_endpoint_auth_method` with `none | client_secret_basic | client_secret_post`.
+  - Unique index on `service_slug` (global uniqueness). Downstream service-keyed tables are not org-scoped today, so per-org slug reuse would leak cache/policy state.
+  - `created_by` is nullable with `ON DELETE SET NULL`, matching durable admin-owned config patterns.
+  - Additional static request headers are stored in `encrypted_additional_headers`, not plaintext.
+  - Adds cleanup/performance indexes: `idx_custom_mcp_connectors_org_status`, `idx_disabled_actions_service_cleanup`, `idx_action_policies_service_cleanup`, `idx_uapo_service_cleanup`, `idx_ai_policy_id`, `idx_ai_org_policy_id`, and `idx_ai_user_override_id`.
+- Create `packages/worker/src/lib/schema/custom-mcp-connectors.ts`
+  - Drizzle table definition for `customMcpConnectors`.
+  - Export from `schema/index.ts`.
+
+### DB Helpers
+
+- Create `packages/worker/src/lib/db/custom-mcp-connectors.ts`
+  - `listConnectors(db, orgId = 'default')` — all connectors for an org, for admin listing.
+  - `listActiveConnectors(db, orgId = 'default')` — active connectors only, for runtime tool/OAuth paths. MVP callers pass explicit org ID where available and default to `'default'` otherwise.
+  - `getConnector(db, id)` — single connector by ID.
+  - `getConnectorBySlug(db, slug)` — single connector by globally unique slug.
+  - `createConnector(db, data)` — insert with ID generation.
+  - `updateConnector(db, id, data)` — partial update.
+  - `deleteConnector(db, id)` — hard delete for the connector row only. Cleanup cascade is performed by `services/custom-mcp-connectors.ts` using one raw `D1Database.batch()` across all affected tables.
+  - Add delete-by-service helpers for `mcp_tool_cache`, `disabled_actions`, `action_policies`, and `user_action_policy_overrides` instead of embedding route-local SQL.
+  - Export from `lib/db.ts`.
+
+### Worker Service Boundary
+
+- Create `packages/worker/src/services/custom-mcp-connectors.ts`
+  - `resolveOrgIdOrDefault(db): Promise<string>` — returns the current org when available, otherwise `'default'`.
+  - `listConnectorSummaries(db, orgId = 'default')` — redacted admin list data with tool counts.
+  - `loadCustomMcpConnectorContext(env, db, orgId = 'default')` — loads active connectors, decrypts secrets/headers, validates header policy, and returns a request-scoped `CustomMcpConnectorContext`.
+  - `getCustomMcpConnectorBySlug(env, db, slug, orgId = 'default')` — built-in-first slug resolver support for routes/services.
+  - `getCustomMcpOAuthConfig(env, db, slug, orgId = 'default')` — returns OAuth endpoints/client config with decrypted secret and token endpoint auth method.
+  - `createCustomMcpConnector(...)`, `updateCustomMcpConnector(...)`, `deleteCustomMcpConnectorCascade(...)` — centralize validation, encryption, cache invalidation, safe URL validation, and D1 batch cleanup.
+  - Routes, session tools, credential refresh, and DO approval continuation must call this service. Do not duplicate connector decryption/header composition in `session-tools.ts` or route-local helpers.
+
+### Shared Types
+
+- Modify `packages/shared/src/types/index.ts`
+  - Widen integration service fields that can hold runtime custom slugs:
+    - `Integration.service: string`
+    - `ConfigureIntegrationRequest.service: string`
+  - Keep `IntegrationService` as the built-in service union for static-service-specific code.
+  - Add `CustomMcpConnector` type (id, orgId, serviceSlug, displayName, serverUrl, authType, status, toolCount, lastDiscoveredAt, createdBy: string | null, createdAt, updatedAt, oauthClientId, oauthScopes, oauthAuthorizationEndpoint, oauthTokenEndpoint, oauthTokenEndpointAuthMethod, apiKeyHeaderName, apiKeyPrefix, hasClientSecret, hasApiKey, hasAdditionalHeaders).
+  - Add `CustomMcpConnectorAuthType` union: `'none' | 'oauth' | 'api_key' | 'bearer'`.
+  - Add `CustomMcpConnectorTokenEndpointAuthMethod` union: `'none' | 'client_secret_basic' | 'client_secret_post'`.
+  - Add `CreateCustomMcpConnectorRequest` and `UpdateCustomMcpConnectorRequest` types.
+  - Request types include explicit non-secret `authType`, nullable endpoint override fields, `clearClientSecret?: boolean`, and `clearAdditionalHeaders?: boolean`.
+  - Note: sensitive fields (secrets, encrypted values) are excluded from response types. The API returns `hasClientSecret`, `hasApiKey`, and `hasAdditionalHeaders` boolean flags instead.
+- Modify `packages/sdk/src/integrations/index.ts`
+  - Add optional `isCustomConnector?: boolean` metadata to `IntegrationProvider`.
+  - Keep existing required provider fields/methods unchanged; synthetic custom providers must implement them.
+
+### MCP Client Updates
+
+- Modify `packages/sdk/src/mcp/client.ts`
+  - Add `additionalHeaders?: Record<string, string>` for validated non-auth static headers and `staticAuthHeader?: { name: string; value: string }` for generated API-key/bearer auth headers to constructor options.
+  - Add `fetch?: typeof fetch` to constructor options so the worker can inject `safeFetchOutbound()` for custom connector calls.
+  - Merge headers in `buildFetchOpts()` so both `rpc()` and `notify()` include them. Merge order is validated non-auth `additionalHeaders`, client transport defaults, exactly one auth source, then negotiated MCP protocol/session headers.
+  - Header names are case-insensitive. Reject invalid names, duplicate names after normalization, values containing CR/LF/NUL, protected header collisions, and auth ambiguity.
+  - Arbitrary `additionalHeaders` must not set `authorization`, `content-type`, `accept`, `mcp-session-id`, `mcp-protocol-version`, hop-by-hop headers, fetch-controlled headers, or any `proxy-*` / `sec-*` header. API-key/bearer connectors can set `Authorization` only through `staticAuthHeader`.
+  - Update the latest supported protocol version constant from `2025-03-26` to `2025-11-25`.
+  - Add an explicit supported-version set (including `2025-03-26`, `2025-06-18`, and `2025-11-25`).
+  - Store the protocol version returned by `initialize`.
+  - Reject initialization if the server returns an unsupported protocol version.
+  - Send `MCP-Protocol-Version` from `buildFetchOpts()` on post-initialization requests using the negotiated version, not blindly the latest constant. This includes `notifications/initialized`.
+  - In `rpc()`, detect 404 + existing `Mcp-Session-Id` → clear session, re-initialize, retry once.
+- Modify `packages/sdk/src/mcp/action-source.ts`
+  - Add `additionalHeaders?: Record<string, string>`, `staticAuthHeader?: { name: string; value: string }`, and `fetch?: typeof fetch` to `McpActionSourceOptions`.
+  - Pass through to `McpClient` constructor.
+- Modify `packages/sdk/src/mcp/oauth.ts`
+  - Add `exchangeCodeWithClientCredentials()` — code exchange using admin-provided `client_id` + optional `client_secret` + PKCE. Handles both confidential (with secret) and public (PKCE-only) clients, accepts `tokenEndpointAuthMethod`, and accepts optional `resource` so custom MCP OAuth matches the built-in MCP path. Send Basic auth for `client_secret_basic`, form-body `client_secret` for `client_secret_post`, and omit the secret for `none`.
+  - Add `refreshTokenWithClientCredentials()` — token refresh with admin `client_id` + optional `client_secret`, `tokenEndpointAuthMethod`, and `resource`.
+  - Existing functions unchanged (still used by dynamic-registration path).
+
+### Outbound URL Policy + Safe Fetch
+
+- Create `packages/worker/src/services/outbound-url-policy.ts`
+  - Validate every admin-provided or discovery-derived URL before storing and before each outbound fetch: `server_url`, OAuth authorization endpoint, OAuth token endpoint, and redirect targets.
+  - Require `https:` URLs, default port 443 only, no credentials/fragments, no empty or single-label hostnames, and no `localhost`, `*.localhost`, `.local`, `.internal`, or IP-literal hosts.
+  - Do not query DNS directly from the Worker. Admin-configured connector endpoints are trusted org configuration; the URL policy is a guardrail against accidental local/private URL shapes, not a DNS-based SSRF firewall.
+  - Re-validate every redirect target. Do not support private-network/VPC/Tunnel connector targets in this MVP.
+- Create `packages/worker/src/services/safe-fetch-outbound.ts`
+  - Export `safeFetchOutbound()` for connector outbound calls. It wraps `fetch()` with `redirect: 'manual'`, URL policy checks, a timeout that stays active until the returned response body finishes, and redirect-chain caps. Successful MCP responses are not size-capped.
+  - OAuth token exchange and refresh reject redirects.
+  - MCP JSON-RPC requests reject redirects, especially cross-origin redirects carrying Authorization/API-key/additional headers.
+  - OAuth discovery may follow up to 3 redirects only if each target passes the outbound URL policy.
+  - Never forward `Authorization`, API-key, bearer, `Cookie`, or configured additional headers to a different origin.
+
+### Integration Registry
+
+- Modify `packages/worker/src/integrations/registry.ts`
+  - Add optional `customContext?: CustomMcpConnectorContext` parameter to `getActions(service, customContext?)` and `getProvider(service, customContext?)`. No shared mutable state — the context is request-scoped.
+  - Define `ResolvedCustomMcpConnector` as a worker-local runtime type derived from the DB row plus parsed/decrypted `additionalHeaders?: Record<string, string>` and `staticAuthHeader?: { name: string; value: string }`.
+  - `getActions()` fallback: if not in static packages, check `customContext.connectors` and build `McpActionSource`.
+  - `getActions()` passes `connector.additionalHeaders` and `connector.staticAuthHeader` to `McpActionSource`; API-key connector auth headers are pre-composed by `services/custom-mcp-connectors.ts`.
+  - For `McpActionSource`, set `noAuth: connector.authType !== 'oauth'`. In this context `noAuth` means no per-user credential is required; API-key/bearer auth is still sent through `staticAuthHeader`.
+  - `getProvider()` fallback: build a full synthetic `IntegrationProvider` from connector record, with `service`, `displayName`, `supportedEntities: []`, `isCustomConnector: true`, `validateCredentials()`, and `testConnection()`. Map `auth_type` correctly: `'none'` → `'none'`, `'oauth'` → `'oauth2'`, `'api_key'` / `'bearer'` → `'api_key'`.
+  - Add `isBuiltinService(slug): boolean` static helper for slug collision checks.
+
+### Admin Routes
+
+- Create `packages/worker/src/routes/admin-mcp-connectors.ts`
+  - `GET /` — list connectors (strips secrets, adds boolean flags, joins `mcp_tool_cache` for tool count).
+  - `POST /` — create connector. Auto-generate slug from name. Validate slug format + uniqueness + no collision with built-in. Validate explicit `authType` and store as `auth_type`. Encrypt secrets. Validate all configured URLs with the outbound URL policy. For OAuth connectors, require explicit stored authorization/token endpoints in this MVP. Do not use provider-specific runtime defaults or block connector creation on current `discoverAuthServer(server_url)`. Return created record.
+  - `PUT /:id` — update connector. Reject slug changes (400). Require explicit `authType`. Re-encrypt secrets if a non-empty replacement is provided; preserve existing encrypted values if omitted and auth mode is unchanged. Empty string is normalized to omitted, not clear. `clearClientSecret: true` clears OAuth secret while staying in OAuth/public-PKCE mode. `clearAdditionalHeaders: true` or `{}` clears the encrypted headers. Clear obsolete auth-specific fields when auth mode changes. Preserve additional headers across auth mode changes unless explicitly replaced/cleared. Clear `last_error` on URL change.
+  - On URL/auth/status/header changes, delete `mcp_tool_cache` rows for the service so policy/enablement UI cannot show stale or disabled tools.
+  - `DELETE /:id` — call `deleteCustomMcpConnectorCascade()`. Cascade in one raw `D1Database.batch()`: delete from `mcp_tool_cache`, `integrations`, `credentials`, `disabled_actions`, `action_policies`, `user_action_policy_overrides`, then `custom_mcp_connectors`. Preserve historical `action_invocations`.
+  - All routes protected by `adminMiddleware`.
+- Modify `packages/worker/src/index.ts`
+  - Mount admin connector routes at `/api/admin/mcp-connectors`.
+
+### OAuth Flow for Custom Connectors
+
+- Modify `packages/worker/src/routes/integrations.ts`
+  - Resolve service slugs through `services/custom-mcp-connectors.ts` (static packages first, then active custom connectors from D1), not a route-local helper.
+  - Extend `GET /` to filter out integrations whose custom connector has been deleted or disabled, alongside the existing disabled-plugin filtering.
+  - Extend `GET /available` to merge active OAuth custom connectors with built-in integrations. Return `isCustomConnector: true`, `supportedEntities: []`, `hasActions: true`, and `hasTriggers: false`.
+  - Extend `GET /actions` to merge active custom connector display names and exclude cached `mcp_tool_cache` entries for deleted/disabled custom connectors.
+  - In the OAuth initiation handler: when the resolved provider is a custom connector, load connector from D1, use admin's `oauth_client_id` to build auth URL with PKCE (skip dynamic registration). OAuth endpoints come from the connector record (`oauth_authorization_endpoint`, `oauth_token_endpoint`) and are used exactly, even when the authorization server host differs from `connector.serverUrl`. Pass `resource: connector.serverUrl` to `buildAuthorizationUrl()` per MCP/RFC 8707. Continue returning the existing `{ url, state, code_verifier }` shape; the browser already stores `oauth_state`, `oauth_service`, and `oauth_code_verifier`.
+  - In the OAuth callback handler: resolve the service slug against custom connectors when no static MCP client exists, then use `exchangeCodeWithClientCredentials()` with connector's `client_id` + optional decrypted `client_secret` + PKCE verifier + stored `oauth_token_endpoint_auth_method`. Token endpoint comes from the connector record. Pass `resource: connector.serverUrl` to match the authorization request.
+- Modify `packages/worker/src/services/integrations.ts`
+  - Update configure integration validation so `/api/integrations` accepts either a static package service or an active custom OAuth connector service.
+  - For custom OAuth connectors, use the synthetic provider to validate the returned token shape, skip `testConnection()` because the MCP OAuth token is scoped to the MCP server, store credentials with `provider = serviceSlug`, and upsert the user `integrations` row.
+  - If the user already has an integration for the service (popup reauth/reconnect), update credentials/config/status and return the existing integration instead of throwing `INTEGRATION_ALREADY_EXISTS`.
+- Modify `packages/worker/src/routes/integrations.ts` configure schema
+  - Remove the synchronous `integrationRegistry.getPackage(s) !== undefined` Zod refinement. Keep `service` as a string in the schema, then validate it in the handler/service with the async static-or-custom resolver because custom OAuth connectors are D1-backed and not registry packages.
+- Modify `packages/worker/src/services/credentials.ts`
+  - Extend MCP token refresh logic: when refreshing, if the service slug is not a built-in service, query `custom_mcp_connectors` by slug. If found, use the connector's `oauth_token_endpoint` + admin's `client_id` + optional decrypted `client_secret` + stored `oauth_token_endpoint_auth_method` via `refreshTokenWithClientCredentials()`. Pass `resource: connector.serverUrl`. Otherwise fall through to existing `mcp_oauth_clients` lookup.
+
+### Session Tools Integration
+
+- Modify `packages/worker/src/services/session-tools.ts`
+  - Add `orgId?: string` to `ListToolsOpts`, `resolveActionPolicy` options, and `ExecuteActionOpts`, defaulting to `'default'`.
+  - At the top of `listTools()`: call `loadCustomMcpConnectorContext()` and pass this context to all `registry.getActions()` and `registry.getProvider()` calls.
+  - For API-key/bearer connectors, `services/custom-mcp-connectors.ts` decrypts `encrypted_api_key`; decrypts `encrypted_additional_headers`; validates non-auth additional headers; composes the configured header (`api_key_header_name` + optional `api_key_prefix`) into `staticAuthHeader`; and does not pass the decrypted key as `access_token`.
+  - Include custom connector services in the service iteration:
+    - No-auth connectors: always included (no credential needed).
+    - OAuth connectors: included when user has a credential for the slug.
+    - API key / bearer connectors: always included (org-level credential handled through request headers).
+  - In `resolveActionPolicy()`: fetch the same connector context, pass it to registry lookups, and treat active no-auth/API-key connectors as active services even without an `integrations` row. OAuth connectors still require an active user integration row.
+  - In `executeAction()`: fetch the same connector context for provider lookup, set empty credentials for no-auth/API-key connectors, and let the custom `McpActionSource` send API-key/bearer auth via `staticAuthHeader`.
+  - MCP tool cache writes already handle arbitrary service slugs — no schema change needed.
+- Modify `packages/worker/src/durable-objects/session-agent.ts`
+  - Pass `await resolveOrgId() ?? 'default'` into `listTools()`, `resolveActionPolicy()`, and `executeAction()` service calls.
+  - Update the post-approval execution path to re-resolve custom connector action sources before calling `executeActionAndSend()`. The current path calls `integrationRegistry.getActions(service)` directly after approval; it must use the same connector-aware resolver as `resolveActionPolicy()`/`executeAction()`.
+  - Revalidate deleted/disabled custom connector state before executing an approved action; if the connector is no longer active, mark the invocation failed and return an error to the runner.
+
+### Disabled Actions Integration
+
+- No schema changes. The `disabled_actions` table already supports arbitrary service slugs.
+- Do not overload `getDisabledPluginServices()` for connector status; it is plugin-specific. Custom connector `status = 'disabled'` is enforced by only loading active connectors into the request-scoped connector context.
+- Verify service/action-level entries in `disabled_actions` apply to custom connector slugs through the existing `getDisabledActionsIndex()` and `isActionDisabled()` paths.
+
+### Frontend — Admin Section
+
+- Create `packages/client/src/components/settings/add-mcp-connector-dialog.tsx`
+  - Dialog modeled after Claude.ai's "Add custom connector."
+  - Fields: Name, Remote MCP server URL.
+  - Collapsible "Advanced settings":
+    - Auth type selector (None / OAuth / API Key / Bearer, default None).
+    - If OAuth: Client ID, Client Secret (optional), Token endpoint auth method (Auto / Client secret basic / Client secret post), Scopes (optional), Authorization Endpoint, and Token Endpoint.
+    - If API Key: API Key, Header Name, Prefix.
+    - If Bearer: Bearer Token. Backend stores it as `auth_type = 'bearer'`, `api_key_header_name = 'Authorization'`, `api_key_prefix = 'Bearer'`.
+    - Optional additional request headers as static header key/value pairs; values are encrypted and never echoed back.
+  - Read-only helper text showing the OAuth redirect URI.
+  - On edit, password fields are blank and use `(unchanged)` placeholders when the corresponding `has*` flag is true. Typing a new value replaces the secret.
+  - OAuth client secret has a "Remove secret" control when `hasClientSecret` is true. API-key/bearer secrets cannot be cleared while staying in that auth mode; switch auth type or delete the connector.
+  - Additional headers are not pre-populated because values are secret. Show "configured" from `hasAdditionalHeaders`; offer Replace and Clear controls. Replacement submits the complete new header object.
+  - Cancel / Add buttons.
+- Create `packages/client/src/components/settings/custom-mcp-connectors-section.tsx`
+  - Table of connectors: Name, URL, Auth Type, Status, Tool Count, Edit/Delete actions.
+  - "Add Connector" button opens the dialog.
+  - Tool count populated lazily from `mcp_tool_cache`.
+  - Edit opens dialog pre-populated (slug read-only). Delete with AlertDialog confirmation.
+- Create `packages/client/src/api/custom-mcp-connectors.ts`
+  - Query key factory: `mcpConnectorKeys.all`, `mcpConnectorKeys.list()`, `mcpConnectorKeys.detail(id)`.
+  - `useCustomMcpConnectors()` — list query.
+  - `useCreateCustomMcpConnector()` — create mutation.
+  - `useUpdateCustomMcpConnector()` — update mutation.
+  - `useDeleteCustomMcpConnector()` — delete mutation.
+- Modify `packages/client/src/routes/settings/admin.tsx`
+  - Import and render `CustomMcpConnectorsSection` in the admin page.
+
+### Frontend — User Integration Flow
+
+- Modify `packages/client/src/components/integrations/connect-integration-dialog.tsx`
+  - Use the extended `/integrations/available` response that includes OAuth custom connectors.
+  - Update `AvailableService` typing to include `isCustomConnector?: boolean`.
+  - Thread `isCustomConnector` through `ResolvedService` / `resolveService()`, then render OAuth-requiring custom connectors with a "Custom" badge and generic MCP icon.
+  - Connection flow is identical to existing MCP OAuth — the backend handles the branching.
+- No flow changes to `packages/client/src/routes/integrations/callback.tsx` — it already stores the service slug and calls the generic configure endpoint after token exchange. Backend configure validation must be updated as described above.
+
+---
+
+## Implementation Steps
+
+### Step 1: Migration + Schema + DB Helpers
+
+- [x] Write `0015_custom_mcp_connectors.sql` migration
+  - [x] Include `oauth_token_endpoint_auth_method`
+  - [x] Include cleanup/performance indexes for connector status, service cleanup, and action invocation FK columns
+- [x] Write Drizzle schema in `custom-mcp-connectors.ts`, export from `schema/index.ts`
+- [x] Write DB helpers in `db/custom-mcp-connectors.ts`, export from `lib/db.ts`
+- [x] Add shared connector types and widen dynamic integration service fields in `packages/shared/src/types/index.ts`
+- [x] Add optional `isCustomConnector?: boolean` to SDK `IntegrationProvider`
+- [x] Run `pnpm typecheck`
+
+### Step 2: MCP Client + OAuth Updates
+
+- [x] Add `additionalHeaders`, `staticAuthHeader`, and injectable `fetch` support to `McpClient` constructor and `buildFetchOpts()`
+- [x] Implement header validation/merge rules: no protected-header overrides, no duplicate normalized names, no invalid values, exactly one auth source
+- [x] Update latest supported protocol version constant to `2025-11-25`
+- [x] Add supported-version validation for initialize responses, including `2025-03-26`, `2025-06-18`, and `2025-11-25`
+- [x] Store negotiated protocol version from `initialize`
+- [x] Add `MCP-Protocol-Version` header from `buildFetchOpts()` on post-initialization requests using the negotiated version
+- [x] Add 404 session reset + retry logic in `rpc()`
+- [x] Add `additionalHeaders`, `staticAuthHeader`, and `fetch` passthrough to `McpActionSource`
+- [x] Add `exchangeCodeWithClientCredentials()` and `refreshTokenWithClientCredentials()` to `oauth.ts` with `tokenEndpointAuthMethod` support
+- [x] Run `pnpm typecheck`
+
+### Step 3: Worker Service Boundary + Safe Fetch
+
+- [x] Add `services/custom-mcp-connectors.ts` with shared connector CRUD, slug resolution, OAuth config loading, request-scoped context loading, and D1 batch cascade cleanup
+- [x] Add outbound URL policy helpers for public HTTPS-only connector URLs, OAuth endpoints, and redirect targets
+- [x] Add URL-shape validation for bad schemes, credentials, fragments, single-label hosts, localhost/internal suffixes, custom ports, and IP-literal hosts
+- [x] Add `safeFetchOutbound()` with manual redirect handling, timeout-through-body handling, no successful-response size cap, and redirect target revalidation
+- [x] Thread safe fetch into custom connector MCP OAuth helpers and `McpClient`/`McpActionSource` via injected fetch
+- [x] Add tests for bad schemes, credentials in URL, fragments, single-label hosts, non-443 ports, localhost, IP literals, injected resolver results, redirects, large MCP responses, and timeout-through-body behavior
+- [x] Run `pnpm typecheck`
+
+### Step 4: Integration Registry Extension
+
+- [x] Add optional `customContext` parameter to `getActions(service, customContext?)` and `getProvider(service, customContext?)`
+- [x] Implement `getActions()` fallback: check custom connector context, build `McpActionSource`, pass connector `additionalHeaders`/`staticAuthHeader`, and set `noAuth` for non-OAuth connectors
+- [x] Implement `getProvider()` fallback: build full synthetic `IntegrationProvider` with required fields/methods and correct `authType` mapping (`none`/`oauth2`/`api_key`)
+- [x] Add `isBuiltinService(slug)` static helper
+- [x] Run `pnpm typecheck`
+
+### Step 5: Admin CRUD Routes
+
+- [x] Create `routes/admin-mcp-connectors.ts` with GET/POST/PUT/DELETE
+- [x] Implement slug auto-generation from display name + validation (format, global uniqueness, no built-in collision)
+- [x] Validate explicit `authType` and store as `auth_type`
+- [x] Implement secret/header encryption on create/update, preserve-if-omitted only when auth mode is unchanged
+- [x] Implement edit semantics: empty secret means omitted, `clearClientSecret` removes OAuth secret, `clearAdditionalHeaders` or `{}` clears headers, API-key/bearer cannot remain active without an existing or replacement key
+- [x] Clear obsolete encrypted secret fields when auth mode changes
+- [x] Implement slug immutability check on PUT (reject changes)
+- [x] Implement explicit OAuth endpoint/scopes fields without provider-specific runtime presets
+- [x] Store and validate OAuth token endpoint auth method (`none`, `client_secret_basic`, `client_secret_post`) with auto defaulting
+- [x] Clear `mcp_tool_cache` on connector URL/auth/status/header changes
+- [x] Implement update cache invalidation and delete cascade with raw `D1Database.batch()`
+- [x] Add tests that a failed batch leaves all rows intact
+- [x] Mount at `/api/admin/mcp-connectors` in `index.ts`
+- [x] Run `pnpm typecheck`
+
+### Step 6: OAuth + Credentials for Custom Connectors
+
+- [x] Use the shared static-or-custom connector resolver from `services/custom-mcp-connectors.ts` for integration routes
+- [x] Extend `GET /integrations/available` to include active OAuth custom connectors
+- [x] Extend `GET /integrations/actions` to filter deleted/disabled custom connector cached tools and use custom display names
+- [x] Extend OAuth initiation in `routes/integrations.ts`: resolve custom connector by slug, load connector, build auth URL from connector record (not `mcp_oauth_clients`), pass `resource: connector.serverUrl`, return existing `{ url, state, code_verifier }` shape
+- [x] Use stored OAuth endpoints exactly; do not derive them from the MCP `serverUrl`
+- [x] Extend OAuth callback: resolve custom connector by slug, use `exchangeCodeWithClientCredentials()` with connector's credentials, stored token endpoint auth method, and `resource: connector.serverUrl`
+- [x] Extend `/api/integrations` configure schema/service to accept active custom OAuth connector slugs and upsert integration rows for first connect and reconnect
+- [x] Extend credential refresh in `credentials.ts`: query `custom_mcp_connectors` for non-built-in slugs, use `refreshTokenWithClientCredentials()` with connector's token endpoint + credentials + token endpoint auth method + `resource`
+- [x] Run `pnpm typecheck`
+
+### Step 7: Session Tools Integration
+
+- [x] Add `orgId?: string` through `ListToolsOpts`, `resolveActionPolicy` opts, and `ExecuteActionOpts`
+- [x] Fetch custom connector context from `loadCustomMcpConnectorContext()` at top of `listTools()`
+- [x] Compose API-key/bearer connector `staticAuthHeader` and non-auth `additionalHeaders` in `services/custom-mcp-connectors.ts`
+- [x] Thread connector context through all `registry.getActions()` and `registry.getProvider()` calls
+- [x] Include custom connector services in service iteration (no-auth/api_key auto-included, oauth when user has credential)
+- [x] Thread connector context through `resolveActionPolicy()` registry lookups and active-service checks
+- [x] Handle API key connector execution with `staticAuthHeader`, not `access_token`
+- [x] Same connector fetch + context in `executeAction()` path
+- [x] Add connector-aware action-source resolution and deleted/disabled revalidation to `SessionAgentDO` post-approval execution
+- [x] Pass `await resolveOrgId() ?? 'default'` into session-tools service calls from `SessionAgentDO`
+- [x] Verify disabled actions work with custom connector slugs
+- [x] Run `pnpm typecheck`
+
+### Step 8: Frontend — API Layer + Admin Section
+
+- [x] Create `api/custom-mcp-connectors.ts` with query keys, hooks, mutations
+- [x] Create `components/settings/add-mcp-connector-dialog.tsx`
+  - Dialog with Name, URL fields
+  - Collapsible "Advanced settings" with auth type selector (None/OAuth/API Key/Bearer)
+  - Conditional fields per auth type, including OAuth endpoint/scopes fields, token endpoint auth method, and encrypted additional headers
+  - Edit mode with blank secret inputs, `(unchanged)` placeholders, explicit remove OAuth secret, and replace/clear all additional headers
+  - Read-only redirect URI helper text for OAuth
+- [x] Create `components/settings/custom-mcp-connectors-section.tsx`
+  - Table of connectors with auth type, status, tool count
+  - "Add Connector" button opens dialog
+  - Edit (slug read-only) / Delete per row
+- [x] Add section to admin settings page
+- [x] Run `cd packages/client && pnpm build` to verify
+
+### Step 9: Frontend — User Integration Flow
+
+- [x] Update available-integration client type to include `isCustomConnector?: boolean`
+- [x] Thread `isCustomConnector` through `ResolvedService` and extend integration dialog to render custom OAuth connectors with "Custom" badge + generic MCP icon
+- [ ] Verify OAuth connect/disconnect flow works end-to-end
+- [x] Run `cd packages/client && pnpm build` to verify
+
+Note: OAuth initiation, callback exchange, configure/upsert, and refresh behavior are covered by in-process route/service tests. Browser-level OAuth connect/disconnect remains a live-environment E2E check because it requires a real remote MCP OAuth provider and redirect flow.
+
+## Test Strategy
+
+Use in-process tests rather than a local TCP server. SDK MCP protocol tests should use a fetch-compatible fake MCP/OAuth handler. Worker route tests should use Hono route apps plus fetch stubs, following existing route-test patterns.
+
+- SDK `packages/sdk/src/mcp/client.test.ts`: verify API-key/static headers on `initialize`, `notifications/initialized`, `tools/list`, and `tools/call`; negotiated `MCP-Protocol-Version`; unsupported protocol failure; and 404 stale-session reset/retry.
+- SDK `packages/sdk/src/mcp/oauth.test.ts`: verify PKCE auth URLs include `S256` and `resource`, code verifier is not leaked in auth URL, token exchange includes verifier/client ID/optional secret/resource, and `client_secret_basic`/`client_secret_post`/`none` behavior.
+- Worker `routes/integrations.test.ts`: verify custom OAuth initiation/callback skip dynamic registration, use connector endpoints/client ID, return `{ url, state, code_verifier }`, and send `resource = connector.serverUrl`.
+- Worker `services/session-tools.test.ts`: cover no-auth/API-key/OAuth service inclusion, credentials/no credentials behavior, header composition, cache writes, and disabled-action filtering.
+- Worker `session-agent.test.ts`: prove approved custom actions execute through connector-aware resolution, and deleted/disabled connectors fail before post-approval execution.
+- Admin route/service tests: cover URL policy rejection, header policy rejection, explicit authType validation, edit preserve/replace/clear semantics, D1 batch rollback behavior, cache invalidation, and delete cleanup.
+
+### Step 10: End-to-End Verification
+
+- [ ] Test no-auth connector: admin creates, tools appear in agent, tools execute
+- [ ] Test OAuth connector: admin creates with client credentials, user connects via OAuth, tools appear, tools execute, token refresh works
+- [ ] Test OAuth connector sends MCP `resource` during authorization and code exchange
+- [ ] Test provider-specific OAuth endpoint/scopes entry using Salesforce production/sandbox values as manual examples, including PKCE/no-secret flow
+- [ ] Test OAuth client secret modes: public PKCE (`none`), `client_secret_basic`, and `client_secret_post`; verify refresh parity
+- [ ] Test OAuth reconnect/reauth updates the existing integration instead of failing as duplicate
+- [ ] Test API key connector: admin creates with key, tools appear for all users, tools execute
+- [ ] Test action policy: custom connector tools appear in policy UI, can be disabled/policy-controlled
+- [ ] Test approval flow: a custom connector tool requiring approval executes successfully after approval
+- [ ] Test connector disable/update clears stale cached tools from action policy/enablement UI
+- [ ] Test delete: deleting connector removes tools, integration rows, credentials, cache entries, disabled actions, org policies, and user policy overrides
+- [ ] Test slug collision: verify built-in slug is rejected on create
+- [ ] Test slug immutability: verify PUT rejects slug changes
+- [ ] Verify existing plugin-backed MCP integrations are unaffected
+- [x] Run full `pnpm typecheck` from root
+
+Automated verification completed locally:
+
+- [x] `cd packages/sdk && pnpm exec vitest run src/mcp/client.test.ts src/mcp/oauth.test.ts` — 10 tests passed
+- [x] `cd packages/worker && pnpm exec vitest run src/routes/admin-mcp-connectors.test.ts src/routes/integrations.test.ts src/services/custom-mcp-connectors.test.ts src/services/session-tools.test.ts src/services/credentials.test.ts src/services/integrations.test.ts src/integrations/registry.test.ts src/services/outbound-url-policy.test.ts src/services/safe-fetch-outbound.test.ts src/lib/db/custom-mcp-connectors.test.ts` — 54 tests passed
+- [x] `cd packages/client && pnpm build` — passed with existing Vite chunk/dynamic import warnings
+- [x] `pnpm typecheck` — passed
+
+The remaining unchecked items above are live E2E checks against actual connector/provider infrastructure, not local implementation blockers.

--- a/docs/specs/2026-05-22-custom-mcp-connectors-design.md
+++ b/docs/specs/2026-05-22-custom-mcp-connectors-design.md
@@ -1,0 +1,421 @@
+# Custom Remote MCP Connectors
+
+**Status:** Draft
+**Author:** Conner Swann
+**Date:** 2026-05-22
+**Linear:** TKAI-109
+
+## Problem
+
+Valet supports MCP-backed tools only through compile-time plugin packages. Each integration requires a `packages/plugin-*` directory, a build-time registry generation step, and a worker redeploy. Admins cannot add a custom remote MCP server by URL from the admin UI.
+
+The immediate driver is Salesforce's hosted MCP servers (`https://api.salesforce.com/platform/mcp/v1/<server-name>`). Salesforce uses standard OAuth 2.0 with an admin-created External Client App — the admin's consumer key (OAuth Client ID) drives the OAuth flow, and the resulting per-user access token is sent as a standard bearer token on MCP requests. This cannot be wired up through the existing dynamic-registration-only MCP OAuth path because Salesforce does not support RFC 7591 dynamic client registration.
+
+More broadly, any MCP server that uses admin-managed OAuth credentials (as opposed to RFC 7591 dynamic registration) is blocked today. This feature adds a runtime connector path alongside the existing plugin-backed path.
+
+## Goals
+
+- Admin can add a custom remote MCP connector by URL, with no code changes or redeploy.
+- Support three auth modes: no-auth, OAuth (admin-provided client credentials), and API key/bearer.
+- OAuth connectors support admin-provided `client_id`/`client_secret` for the OAuth flow (authorization, token exchange, refresh). The resulting access token is sent as a standard bearer token on MCP requests.
+- Users authenticate per-connector through the existing integration connection flow.
+- Custom connector tools appear in agent tool discovery and execute through the same action policy, approval, audit, and disabled-action paths as built-in tools.
+- Custom connectors appear in action policy and enablement UI.
+- Existing plugin-backed MCP integrations are unaffected.
+
+## Non-Goals
+
+- stdio/local MCP servers. Remote Streamable HTTP only.
+- MCP prompts or resources. Tools only.
+- Old HTTP+SSE transport fallback.
+- Per-user connector creation (admin-only).
+- Connector marketplace or sharing across orgs.
+- Automatic migration of existing plugin-backed MCP integrations to the connector model.
+
+## Current State
+
+### MCP Client Layer (`packages/sdk/src/mcp/`)
+
+`McpClient` implements JSON-RPC 2.0 over Streamable HTTP. It handles session management (`Mcp-Session-Id`), SSE response parsing, and initialization handshake. Auth is bearer token via `Authorization` header, with an `authQueryParam` option for servers that need the token as a query parameter.
+
+Protocol version is hardcoded to `2025-03-26`. The client does not send `MCP-Protocol-Version` on subsequent requests and does not handle 404 session resets.
+
+`McpActionSource` adapts MCP tools to Valet's `ActionSource` interface. It extracts `access_token` from credentials and passes it to `McpClient`. It does not support passing additional auth context (like `client_id`) alongside the token.
+
+`oauth.ts` implements RFC 8414 auth server discovery, RFC 7591 dynamic client registration (public client, no secret), and PKCE (RFC 7636). It does not support admin-provided `client_id`/`client_secret` — it always dynamically registers.
+
+### Integration Registry (`packages/worker/src/integrations/`)
+
+`IntegrationRegistry` is a static `Map<string, IntegrationPackage>` populated at compile time from auto-generated `packages.ts`. There is no runtime registration path. `getActions(service)` and `getProvider(service)` only resolve against this static map.
+
+### Tool Discovery & Execution (`packages/worker/src/services/session-tools.ts`)
+
+`listTools()` iterates all active services, detects MCP-backed sources via `provider.mcpServerUrl`, resolves credentials, calls `actionSource.listActions()`, filters by disabled actions, and returns tool descriptors. MCP tool metadata is cached in `mcp_tool_cache` for the action catalog UI.
+
+`executeAction()` resolves credentials, calls `actionSource.execute()`, handles 401 auto-refresh, and records invocation audit rows. Action policy resolution is connector-agnostic — it operates on `service` + `actionId` strings.
+
+### Existing MCP Tables
+
+- `mcp_oauth_clients`: Stores dynamically registered OAuth client metadata per service (endpoints, client ID, scopes).
+- `mcp_tool_cache`: Caches discovered MCP tools per service for offline catalog display.
+
+### Credentials
+
+Encrypted with PBKDF2 using `ENCRYPTION_KEY`. Stored in `credentials` table with `ownerType` (user/org), `ownerId`, `provider` (service slug), and `encryptedData`. Auto-refresh on expiry via service-specific refresh handlers.
+
+## Design
+
+### Data Model
+
+New table `custom_mcp_connectors`:
+
+```sql
+CREATE TABLE custom_mcp_connectors (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL DEFAULT 'default',
+  service_slug TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  server_url TEXT NOT NULL,
+  auth_type TEXT NOT NULL DEFAULT 'none'
+    CHECK(auth_type IN ('none', 'oauth', 'api_key', 'bearer')),
+
+  -- OAuth fields (used when auth_type = 'oauth')
+  oauth_client_id TEXT,
+  encrypted_oauth_client_secret TEXT,
+  oauth_token_endpoint_auth_method TEXT NOT NULL DEFAULT 'none'
+    CHECK(oauth_token_endpoint_auth_method IN ('none', 'client_secret_basic', 'client_secret_post')),
+  oauth_scopes TEXT,                    -- space-separated scope list
+  oauth_authorization_endpoint TEXT,    -- override if discovery fails
+  oauth_token_endpoint TEXT,            -- override if discovery fails
+
+  -- API key / Bearer fields (used when auth_type IN ('api_key', 'bearer'))
+  encrypted_api_key TEXT,
+  api_key_header_name TEXT DEFAULT 'Authorization',
+  api_key_prefix TEXT DEFAULT 'Bearer', -- e.g. 'Bearer', 'Api-Key', ''
+
+  -- Additional request headers (encrypted JSON object: {"Header-Name": "value"})
+  -- Sent on every MCP request. Escape hatch for servers that require
+  -- custom headers beyond the standard Authorization bearer token.
+  encrypted_additional_headers TEXT,
+
+  -- Metadata
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK(status IN ('active', 'disabled', 'error')),
+  last_discovered_at TEXT,
+  last_error TEXT,
+  created_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+
+  UNIQUE(service_slug)
+);
+```
+
+Migration also adds indexes for runtime/admin listing and cleanup: `idx_custom_mcp_connectors_org_status(org_id, status)`, `idx_disabled_actions_service_cleanup(service)`, `idx_action_policies_service_cleanup(service)`, `idx_uapo_service_cleanup(service)`, `idx_ai_policy_id(policy_id)`, `idx_ai_org_policy_id(org_policy_id)`, and `idx_ai_user_override_id(user_override_id)`.
+
+**Org scoping:** MVP callers pass explicit `orgId` where available and default to `'default'` where auth/session service signatures do not yet carry it. The table keeps `org_id` for future multi-org plumbing, but custom connector slugs are globally unique today because downstream service-keyed tables (`credentials.provider`, `integrations.service`, `mcp_tool_cache.service`, `disabled_actions.service`, `action_policies.service`, and `user_action_policy_overrides.service`) are not org-scoped. Future true multi-org slug reuse would require adding `org_id` to those downstream tables first.
+
+**Slug collision prevention:** On create, validate that `service_slug` does not match any key in the static `installedIntegrations` registry.
+
+**Slug immutability:** `service_slug` is immutable after creation. It is used as a foreign key across `credentials.provider`, `integrations.service`, `mcp_tool_cache.service`, `disabled_actions`, `action_policies`, and `user_action_policy_overrides`. Allowing slug changes would require cascading renames across all of these — not worth the complexity. Admins can delete and recreate a connector if the slug needs to change.
+
+**Encrypted fields:** `encrypted_oauth_client_secret`, `encrypted_api_key`, and `encrypted_additional_headers` use the same PBKDF2 encryption as the `credentials` table. They are never returned in API responses — only `hasClientSecret: boolean`, `hasApiKey: boolean`, and `hasAdditionalHeaders: boolean` flags are exposed. API responses still return non-secret editable config (`authType`, `oauthClientId`, scopes, endpoint overrides, token endpoint auth method, API key header name/prefix, status, and URL).
+
+**Auth mode in API payloads:** The frontend sends explicit non-secret `authType: 'none' | 'oauth' | 'api_key' | 'bearer'` on create and update. The backend validates it against the submitted fields and stores it as `auth_type`. Do not infer update mode from secret presence, because omitted secret fields mean "preserve existing secret" for unchanged modes.
+
+Secret fields use existing admin settings semantics:
+- omitted secret field = preserve existing encrypted value, but only when `authType` stays in the same compatible mode
+- non-empty string = replace encrypted value
+- empty string = normalized to omitted; it is not a clear sentinel
+- explicit clear flags perform clears where clearing is valid
+
+### Outbound URL Policy
+
+Custom MCP connectors may only target public HTTPS endpoints. Apply this policy to every admin-provided or discovery-derived URL before storing and before each outbound fetch: `server_url`, `oauth_authorization_endpoint`, `oauth_token_endpoint`, and every redirect target.
+
+Validation rules:
+- Protocol must be `https:`.
+- Reject username/password, fragments, empty hostnames, single-label hosts, `localhost`, `*.localhost`, `.local`, `.internal`, and IP-literal hosts unless a later explicit allowlist design permits them.
+- MVP allows only default HTTPS port 443. Reject explicit non-443 ports.
+- Do not query DNS directly from the Worker. Admin-configured connector endpoints are trusted org configuration; the URL policy is a guardrail against accidental local/private URL shapes, not a DNS-based SSRF firewall.
+- Re-validate every redirect target with the same URL policy. Do not rely only on create/update-time validation.
+- Do not support private-network/VPC/Tunnel connector targets in this MVP.
+
+### Safe Fetch
+
+All connector outbound calls must use a central Worker-side `safeFetchOutbound()` helper, not raw `fetch()`. The helper uses `redirect: 'manual'`, applies the outbound URL policy before each request, enforces an AbortController timeout through response body consumption, and caps redirect chains. It must not cap successful MCP response sizes.
+
+Redirect policy:
+- OAuth token exchange and refresh: reject all redirects.
+- MCP JSON-RPC requests carrying Authorization/API-key/additional headers: reject redirects; surface a connector error so admins update the URL.
+- OAuth discovery GET: may follow up to 3 redirects only if each target passes the outbound URL policy.
+- Never forward `Authorization`, API-key, bearer, `Cookie`, or configured additional headers to a different origin.
+
+### Dynamic Connector Resolution
+
+`IntegrationRegistry` is a module-level singleton in the CF Worker isolate — it may be shared across concurrent requests for different orgs. Custom connectors are org-scoped, so mutating the singleton with `loadCustomConnectors()` would create cross-request data races.
+
+Instead, `getActions()` and `getProvider()` accept an optional request-scoped `CustomMcpConnectorContext`. The SDK `IntegrationProvider` type gains an optional metadata field `isCustomConnector?: boolean`; synthetic providers still must satisfy the existing contract (`service`, `supportedEntities`, `validateCredentials()`, and `testConnection()`). `ResolvedCustomMcpConnector` is a worker-local runtime type that starts from the connector DB row and adds `additionalHeaders?: Record<string, string>` for validated non-auth static headers plus `staticAuthHeader?: { name: string; value: string }` for generated API-key/bearer auth.
+
+```typescript
+// New overloads on IntegrationRegistry
+getActions(
+  service: string,
+  customContext?: CustomMcpConnectorContext,
+): ActionSource | undefined {
+  const pkg = this.packages.get(service);
+  if (pkg) return pkg.actions;
+
+  const connector = customContext?.connectors.get(service);
+  if (!connector || connector.status !== 'active') return undefined;
+
+  return new McpActionSource({
+    mcpUrl: connector.serverUrl,
+    serviceName: connector.serviceSlug,
+    // noAuth means "do not require a per-user token"; API-key auth is supplied
+    // through staticAuthHeader.
+    noAuth: connector.authType !== 'oauth',
+    additionalHeaders: connector.additionalHeaders,
+    staticAuthHeader: connector.staticAuthHeader,
+    fetch: connector.fetch,
+  });
+}
+
+getProvider(
+  service: string,
+  customContext?: CustomMcpConnectorContext,
+): IntegrationProvider | undefined {
+  const pkg = this.packages.get(service);
+  if (pkg) return pkg.provider;
+
+  const connector = customContext?.connectors.get(service);
+  if (!connector) return undefined;
+
+  return {
+    service: connector.serviceSlug,
+    displayName: connector.displayName,
+    authType: connector.authType === 'none' ? 'none'
+            : connector.authType === 'oauth' ? 'oauth2'
+            : 'api_key',
+    supportedEntities: [],
+    mcpServerUrl: connector.serverUrl,
+    oauthScopes: connector.oauthScopes?.split(' '),
+    isCustomConnector: true,
+    validateCredentials: (credentials) => connector.authType !== 'oauth' || !!credentials.access_token,
+    testConnection: async () => true,
+  };
+}
+
+// Static helper for slug validation
+isBuiltinService(slug: string): boolean {
+  return this.packages.has(slug);
+}
+```
+
+**Loading:** Runtime paths fetch custom connectors from D1 once per request through `packages/worker/src/services/custom-mcp-connectors.ts` and build a `CustomMcpConnectorContext` that is threaded through all registry calls for the duration of that request. This applies to `listTools()`, `resolveActionPolicy()`, `executeAction()`, `SessionAgentDO`'s post-approval execution continuation, OAuth initiation/callback routes, `GET /api/integrations/available`, `GET /api/integrations/actions`, and the integration configure service. The service owns decryption, header composition, safe fetch injection, and built-in-first slug resolution so routes and session tools do not duplicate that logic. The query is cheap (one small table, ~10 rows) and eliminates any caching/staleness concerns. No shared state is mutated.
+
+**Service enumeration:** `listTools()` currently iterates services from user integrations + auto-enabled services. Custom connectors with `authType: 'none'` or `api_key` are auto-included (no per-user credential needed). Custom connectors with `authType: 'oauth'` are included when the user has a credential for that service slug.
+
+**Execution validation:** `resolveActionPolicy()` must treat active no-auth/API-key connectors as active services even without an `integrations` row. OAuth connectors still require an active user integration row. The action source returned from policy resolution and the provider lookup used by `executeAction()` must both use the same request-scoped connector context, otherwise custom tools can be listed but fail before execution.
+
+**`McpActionSource` lifecycle:** A new `McpActionSource` (and underlying `McpClient`) is constructed on each `getActions()` call. This means MCP session IDs are not reused across requests, and the initialization handshake runs each time. This is acceptable for the initial implementation — built-in MCP integrations already create action sources per-package, so the overhead is comparable. Session caching across requests can be added later if latency becomes a concern.
+
+### Auth Modes
+
+#### No-Auth
+
+`McpActionSource` is constructed with `noAuth: true`. No credential resolution. Tools are available to all users immediately after admin creates the connector.
+
+#### OAuth (Admin-Provided Credentials)
+
+This is the Salesforce path. The admin provides the `client_id` (consumer key) from a pre-registered OAuth application (e.g., a Salesforce External Client App). `client_secret` is optional — Salesforce External Client Apps can use PKCE-only (public client) or confidential client flows depending on configuration.
+
+**Salesforce example:** The admin creates an External Client App in their Salesforce org, copies the consumer key, and pastes it as the OAuth Client ID when creating the connector.
+
+Production standard/custom server examples:
+- `https://api.salesforce.com/platform/mcp/v1/platform/sobject-all`
+- `https://api.salesforce.com/platform/mcp/v1/custom/myserver`
+
+Sandbox/scratch examples:
+- `https://api.salesforce.com/platform/mcp/v1/sandbox/platform/sobject-all`
+- `https://api.salesforce.com/platform/mcp/v1/sandbox/custom/myserver`
+
+Salesforce Hosted MCP MVP uses admin-provided OAuth endpoints rather than relying on discovery. Salesforce's documented hosted MCP setup uses:
+- Production: `https://login.salesforce.com/services/oauth2/authorize` and `https://login.salesforce.com/services/oauth2/token`
+- Sandbox/scratch: `https://test.salesforce.com/services/oauth2/authorize` and `https://test.salesforce.com/services/oauth2/token`
+
+Do not derive these endpoints from the MCP `server_url` host (`api.salesforce.com`). For Salesforce, the authorization server host is different from the MCP resource server host.
+
+Salesforce External Client App settings for MVP:
+- Enable OAuth.
+- Callback URL: Valet integration callback URL.
+- OAuth scopes: `mcp_api refresh_token`.
+- Security: enable JWT-based access tokens and require PKCE.
+- Default PKCE/no-secret mode: leave `Require Secret for Web Server Flow` and `Require Secret for Refresh Token Flow` disabled.
+- Optional confidential mode: admins may enable `Require Secret for Web Server Flow`, generate a client secret, and enter it in Valet. Valet should include the secret on code exchange when configured.
+
+**Discovery:** MVP supports explicit `oauth_authorization_endpoint` and `oauth_token_endpoint` fields. The generic connector flow does not derive provider-specific defaults; admins enter provider-specific endpoints manually when the authorization server differs from the MCP resource server. Do not assume `discoverAuthServer(server_url)` works for Salesforce. Future discovery should follow current MCP auth: RFC 9728 protected resource metadata first, then RFC 8414 authorization server metadata. The existing helper that fetches `${server_url}/.well-known/oauth-authorization-server` is not sufficient for pathful MCP resource URLs and should not be the Salesforce dependency.
+
+Discovery results are stored on the connector record itself — custom connectors do NOT write to the `mcp_oauth_clients` table (that table is reserved for dynamically registered clients from the plugin path).
+
+**Token endpoint auth method:** `oauth_token_endpoint_auth_method` controls how the optional client secret is sent to the token endpoint. Defaulting rules:
+- no `client_secret` configured → `none`
+- `client_secret` configured and discovery metadata says only `client_secret_post` → `client_secret_post`
+- `client_secret` configured and discovery is absent, ambiguous, or includes Basic → `client_secret_basic`
+- admins can override to `client_secret_basic` or `client_secret_post` in advanced settings
+
+Code exchange and refresh must use the stored method: send HTTP Basic client authentication for `client_secret_basic`, send form-body `client_secret` for `client_secret_post`, and omit the secret for `none`.
+
+**Redirect URI:** The OAuth redirect URI is `https://<app-host>/integrations/callback` — the same callback used by built-in integrations. The admin form displays this URI in a read-only helper text so admins know what to register with their OAuth provider (e.g., as the callback URL in a Salesforce External Client App).
+
+**User connection flow:**
+
+1. User navigates to Integrations page, sees the custom connector listed.
+2. User clicks "Connect." Frontend calls `GET /api/integrations/{serviceSlug}/oauth`.
+3. The integrations route resolves the service against static packages first, then the active custom connector table. For a custom connector, it builds the authorization URL using the admin's `oauth_client_id` + PKCE challenge. The OAuth endpoints come from the connector record, not from `mcp_oauth_clients`. It passes `resource = connector.serverUrl`, matching the existing MCP OAuth path so resource-scoped MCP tokens have the correct audience.
+4. User is redirected to the provider's authorization server (e.g., their Salesforce org login). If already authenticated, the challenge may be skipped.
+5. Callback hits `/integrations/callback`. Code exchange uses the admin's `client_id` + PKCE verifier. If a `client_secret` is configured, it is included according to the stored token endpoint auth method; otherwise the exchange is public-client PKCE only. It also passes `resource = connector.serverUrl`, matching the authorization request.
+6. The callback returns credentials to the existing frontend callback page, which then calls the generic configure endpoint. That endpoint must accept active custom OAuth connector slugs in addition to static packages, validate the returned token shape with the synthetic provider, store `access_token` + `refresh_token` in `credentials` with `provider = serviceSlug`, and upsert the user's `integrations` row. If the user already has an integration for the slug (popup reauth/reconnect), update credentials/config/status instead of throwing `INTEGRATION_ALREADY_EXISTS`. The access token is sent as a standard `Authorization: Bearer` header on subsequent MCP requests.
+
+**OAuth state format:** Keep the existing browser state shape: random `oauth_state`, `oauth_service`, and optional `oauth_code_verifier` in sessionStorage/localStorage. Do not rely on a browser-provided `customConnector` flag for server-side branching. The backend callback endpoint resolves custom connector behavior from the path service slug and D1 connector lookup.
+
+**Token refresh:** The generic MCP PKCE refresh path in `credentials.ts` already receives the `Env` binding and service slug. When a refresh is needed, it checks whether the slug matches a custom connector by querying `custom_mcp_connectors`. If a connector is found, it uses the connector's `oauth_token_endpoint`, admin's `client_id`, optional decrypted `client_secret`, stored `oauth_token_endpoint_auth_method`, and `resource = connector.serverUrl` in the refresh request. If the slug is not a custom connector, it falls through to the existing `mcp_oauth_clients` lookup and public-client PKCE refresh.
+
+#### API Key / Bearer Token
+
+Admin provides a static API key or bearer token. Stored encrypted in `encrypted_api_key`. The key is sent on every request using the configured `api_key_header_name` (default `Authorization`) with the configured `api_key_prefix` (default `Bearer`).
+
+This is an org-level credential — all users share the same key. No per-user connection step needed. Connector tools are available to all users immediately.
+
+Implementation detail: API-key and bearer connectors must compose the configured auth header into `staticAuthHeader` before constructing `McpActionSource`. Additional static headers go through `additionalHeaders` only after validation as non-auth extension headers. Do not pass the decrypted API key as `access_token`, because `McpClient` treats `access_token` as `Authorization: Bearer <token>` and would ignore custom header names or double-prefix a preformatted bearer value.
+
+### MCP Client Updates
+
+Targeted changes to `McpClient`:
+
+1. **Protocol version:** Update the client's latest supported version constant to `2025-11-25` and maintain an explicit supported-version set (`2025-03-26`, `2025-06-18`, and `2025-11-25`). Store the protocol version returned by `initialize` and send `MCP-Protocol-Version` with that negotiated version on all requests after initialization. If a server negotiates an unsupported version, fail initialization instead of caching a session. If a server negotiates an older supported version, the header must use the negotiated value rather than blindly sending the latest constant.
+
+2. **Session reset on 404:** When a request returns 404 and the client has a cached `Mcp-Session-Id`, clear the session cache for that service and re-initialize. Retry the original request once.
+
+3. **Static headers:** Add `additionalHeaders?: Record<string, string>` for validated non-auth extension headers and `staticAuthHeader?: { name: string; value: string }` for generated API-key/bearer auth to `McpClient` constructor options. Merge these into every outgoing request in `buildFetchOpts()` so both `rpc()` and `notify()` requests include them. `buildFetchOpts()` also owns adding `MCP-Protocol-Version` when a negotiated version exists, so `notifications/initialized` and later requests are versioned consistently.
+
+**Header merge and validation:** `additionalHeaders` are static non-auth extension headers only. Header names are case-insensitive; normalize names for validation, reject duplicates after normalization, reject invalid HTTP field names, and reject values containing CR, LF, or NUL.
+
+Do not allow `additionalHeaders` to set client-owned, auth-owned, hop-by-hop, or fetch-controlled headers. The blocked set includes `authorization`, `content-type`, `accept`, `mcp-session-id`, `mcp-protocol-version`, `connection`, `keep-alive`, `proxy-authenticate`, `proxy-authorization`, `te`, `trailer`, `transfer-encoding`, `upgrade`, `host`, `content-length`, `cookie`, `date`, `dnt`, `expect`, `origin`, `referer`, `accept-charset`, `accept-encoding`, `access-control-request-headers`, `access-control-request-method`, `permissions-policy`, and any `proxy-*` or `sec-*` header.
+
+Generated API-key/bearer auth headers are not arbitrary `additionalHeaders`. Preserve their provenance separately until `McpClient.buildFetchOpts()` merges headers. The generated API-key/bearer header may use `Authorization`, but only from the dedicated connector auth fields. If it collides with an additional header, fail connector resolution/config validation.
+
+`buildFetchOpts()` must fail closed on auth ambiguity. It must not send both an OAuth `access_token` Authorization header and a generated API-key/bearer auth header. It must not let any caller-provided header override `Content-Type`, `Accept`, `Authorization`, `MCP-Session-Id`, or `MCP-Protocol-Version`.
+
+Merge order is: validated non-auth additional headers, client transport defaults, exactly one auth source, then negotiated MCP protocol/session headers.
+
+### Admin CRUD Routes
+
+New routes under `/api/admin/mcp-connectors`, protected by `adminMiddleware`:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/` | List all connectors for the org. Includes `tool_count` from `mcp_tool_cache` join. |
+| `POST` | `/` | Create a connector. Validates slug, explicit auth mode, safe URLs, endpoints, and secrets. |
+| `PUT` | `/:id` | Update a connector. Slug is immutable — rejected if changed. |
+| `DELETE` | `/:id` | Delete a connector + cascade cleanup. |
+
+No test endpoint. Tool discovery happens lazily through the normal `listTools()` path when a user with valid credentials (or no-auth) triggers a session. The `tool_count` shown in the admin table is derived from `mcp_tool_cache` rows for the service slug, updated as a side effect of normal tool discovery.
+
+**Create validation:**
+- `display_name`: required
+- `server_url`: required, passes the outbound URL policy
+- `service_slug`: auto-generated from display name on create, validated as lowercase alphanumeric + hyphens, 3-64 chars, not in static `installedIntegrations` registry
+- `authType`: required by the API and defaulted to `none` by the UI. Backend validates it and stores it as `auth_type`.
+- OAuth requires `oauth_client_id`; `oauth_client_secret` is optional. Authorization/token endpoints are required in the MVP and are stored explicitly. Optional `oauth_scopes` are stored as a space-separated string.
+- `oauth_token_endpoint_auth_method`: stored as `none`, `client_secret_basic`, or `client_secret_post` using the defaulting rules in the OAuth section unless explicitly overridden.
+- API key/bearer requires a non-empty secret on create and encrypts it into `encrypted_api_key`.
+- `additional_headers`: if provided, must be a valid JSON object with string keys/values, pass header policy validation, and is encrypted into `encrypted_additional_headers`. Provided object replaces the whole header object.
+
+**Update validation:**
+- `service_slug` is immutable — return 400 if the request attempts to change it
+- `authType` is required
+- If `authType` is unchanged:
+  - omitted `oauth_client_secret` / `api_key` preserves the current encrypted value
+  - non-empty secret replaces it
+  - `clearClientSecret: true` clears `encrypted_oauth_client_secret` while staying in OAuth/public-PKCE mode
+  - API-key/bearer cannot remain active without an existing or replacement key
+- If `authType` changes:
+  - leaving OAuth clears `encrypted_oauth_client_secret`, `oauth_client_id`, scopes, and OAuth endpoints unless the new mode is OAuth
+  - leaving API-key/bearer clears `encrypted_api_key`, `api_key_header_name`, and `api_key_prefix`
+  - entering API-key/bearer requires a replacement secret
+- Endpoint override fields are non-secret and are returned/pre-populated. Omitted means preserve; explicit `null` or empty string clears.
+- Additional headers are write-only as values. Omitted means preserve the whole encrypted object; provided object replaces the whole object; `{}` or `clearAdditionalHeaders: true` clears it. Individual header value editing is not supported unless header names/metadata are separately stored and returned.
+- Additional headers are auth-mode independent and should be preserved across auth mode changes unless explicitly replaced/cleared.
+- Changing `server_url`, auth mode, status, or additional headers deletes `mcp_tool_cache` rows for the service so policy/enablement UI cannot show stale/deactivated tools
+
+**D1 atomicity:** Admin update/delete cleanup MUST use raw `env.DB.batch()` with prepared statements. Do not use sequential Drizzle deletes for cascade cleanup. If any statement fails, D1 rolls back the entire batch and the route returns an error; no compensating cleanup is attempted.
+
+**Delete cleanup:** First load connector by id to get `service_slug`; then run one D1 batch:
+1. `DELETE FROM mcp_tool_cache WHERE service = ?`
+2. `DELETE FROM integrations WHERE service = ?`
+3. `DELETE FROM credentials WHERE provider = ?`
+4. `DELETE FROM disabled_actions WHERE service = ?`
+5. `DELETE FROM action_policies WHERE service = ?`
+6. `DELETE FROM user_action_policy_overrides WHERE service = ?`
+7. `DELETE FROM custom_mcp_connectors WHERE id = ? AND service_slug = ?`
+
+Historical `action_invocations` rows are preserved. FK `ON DELETE SET NULL` may clear policy/override id references, but denormalized audit fields remain.
+
+### Frontend
+
+#### Add Connector Dialog
+
+Modeled after Claude.ai's "Add custom connector" dialog. A dialog (not an inline form) with minimal fields:
+
+- **Name** (text input)
+- **Remote MCP server URL** (text input, HTTPS)
+- **Advanced settings** (collapsible, collapsed by default):
+  - **Auth type** (radio or select: None / OAuth / API Key / Bearer, default None)
+  - If OAuth: **Client ID** (text), **Client Secret** (password, optional), **Token endpoint auth method** (Auto / Client secret basic / Client secret post), **Scopes** (text, optional), **Authorization Endpoint**, and **Token Endpoint**
+  - If API Key: **API Key** (password), **Header Name** (text), **Prefix** (text, optional)
+  - If Bearer: **Bearer Token** (password), stored as `Authorization: Bearer <token>`
+  - Optional custom request headers are accepted as advanced static headers and stored encrypted. They must not be shown back to the client; only a `hasAdditionalHeaders` flag is returned.
+- Read-only helper text showing the **OAuth redirect URI** (e.g., `https://app.valet.dev/integrations/callback`) so admins know what to register with their OAuth provider
+- **Cancel** / **Add** buttons
+
+The service slug is auto-generated from the display name (lowercased, spaces to hyphens, non-alphanumeric stripped) and is immutable after creation.
+
+On edit, password fields are blank and use `(unchanged)` placeholders when the corresponding `has*` flag is true. Typing a new value replaces the secret. OAuth client secret has a "Remove secret" control when `hasClientSecret` is true. API-key/bearer secrets cannot be cleared while staying in that auth mode; switch auth type or delete the connector.
+
+Additional headers are not pre-populated because values are secret. Show "configured" from `hasAdditionalHeaders`; offer Replace and Clear controls. Replacement submits the complete new header object.
+
+The admin settings page shows a "Custom MCP Connectors" section with a table of existing connectors (Name, URL, Status, Tool Count) and an "Add Connector" button that opens the dialog. Each row has Edit/Delete actions. Tool count is populated lazily — it updates when a user session triggers tool discovery for that connector.
+
+#### User Integrations Page
+
+Custom connectors with `authType: 'oauth'` appear in the integrations list alongside built-in integrations, visually distinguished with a "Custom" badge and a generic MCP icon (no per-connector icon in MVP). The existing `ConnectIntegrationDialog` handles the OAuth flow — the backend routes branch by resolving the requested service slug against active custom connectors. Client-side `AvailableService` and `ResolvedService` types must preserve `isCustomConnector`, and shared integration request/response types must allow arbitrary string service slugs for custom connectors while keeping the built-in `IntegrationService` union available for static services.
+
+Custom connectors with `authType: 'none'` or `api_key` do not appear in the user integrations page (no per-user connection needed).
+
+#### Action Policy UI
+
+Custom connector tools appear in the action policy section after discovery. The existing `mcp_tool_cache` table provides this, but `/api/integrations/actions` must filter cached rows for deleted/disabled custom connectors and use active custom connector display names when merging cache entries. Cache rows are deleted when connector URL/auth/status/header settings change or when a connector is deleted.
+
+### Security
+
+- OAuth client secrets, API keys, bearer tokens, and additional static request headers are encrypted at rest with PBKDF2, same as existing credentials.
+- Secrets are never returned in API responses. The API returns boolean flags such as `hasClientSecret`, `hasApiKey`, and `hasAdditionalHeaders`.
+- Admin-only CRUD. Users can only connect/disconnect their own credentials.
+- Custom connector slugs cannot collide with built-in services (validated at creation), are globally unique, and are immutable after creation.
+- MCP requests to custom server URLs are made server-side from the worker, not from the client browser. No CORS concerns.
+- Connector outbound requests use `safeFetchOutbound()` and the outbound URL policy. Private-network URL shapes, custom ports, unsafe redirects, and raw `fetch()` are not allowed in the MVP; the Worker does not perform direct DNS lookups for connector validation.
+- Additional request headers are treated as static config, not templates. No variable interpolation that could leak user data. They cannot override client-owned, auth-owned, hop-by-hop, or fetch-controlled headers.
+- Deleting a connector invalidates all user credentials and cached tools for that service.
+- Custom connectors do not write to `mcp_oauth_clients` — OAuth metadata lives on the connector record itself. This avoids data duplication and keeps the dynamic-registration table clean.
+
+## Boundary
+
+This spec covers the custom MCP connector data model, admin CRUD, dynamic registry resolution, auth flows (no-auth + OAuth + API key), MCP client protocol updates, and frontend UI for admin and user flows.
+
+This spec does NOT cover:
+- Changes to the plugin package system or auto-generated registries
+- stdio/local MCP transports
+- MCP prompts or resources
+- Connector health monitoring or auto-disable on repeated failures (future enhancement)
+- Bulk import/export of connector configs

--- a/packages/client/src/api/custom-mcp-connectors.ts
+++ b/packages/client/src/api/custom-mcp-connectors.ts
@@ -1,0 +1,55 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type {
+  CreateCustomMcpConnectorRequest,
+  CustomMcpConnector,
+  UpdateCustomMcpConnectorRequest,
+} from '@valet/shared';
+import { api } from './client';
+
+export const mcpConnectorKeys = {
+  all: ['custom-mcp-connectors'] as const,
+  list: () => [...mcpConnectorKeys.all, 'list'] as const,
+  detail: (id: string) => [...mcpConnectorKeys.all, 'detail', id] as const,
+};
+
+export function useCustomMcpConnectors() {
+  return useQuery({
+    queryKey: mcpConnectorKeys.list(),
+    queryFn: () => api
+      .get<{ connectors: CustomMcpConnector[] }>('/admin/mcp-connectors')
+      .then((r) => r.connectors),
+  });
+}
+
+export function useCreateCustomMcpConnector() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateCustomMcpConnectorRequest) =>
+      api.post<{ connector: CustomMcpConnector }>('/admin/mcp-connectors', data).then((r) => r.connector),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: mcpConnectorKeys.all });
+    },
+  });
+}
+
+export function useUpdateCustomMcpConnector() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateCustomMcpConnectorRequest }) =>
+      api.put<{ connector: CustomMcpConnector }>(`/admin/mcp-connectors/${id}`, data).then((r) => r.connector),
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries({ queryKey: mcpConnectorKeys.all });
+      queryClient.invalidateQueries({ queryKey: mcpConnectorKeys.detail(id) });
+    },
+  });
+}
+
+export function useDeleteCustomMcpConnector() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.delete<{ ok: boolean }>(`/admin/mcp-connectors/${id}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: mcpConnectorKeys.all });
+    },
+  });
+}

--- a/packages/client/src/api/integrations.ts
+++ b/packages/client/src/api/integrations.ts
@@ -25,6 +25,7 @@ export interface AvailableService {
   supportedEntities: string[];
   hasActions: boolean;
   hasTriggers: boolean;
+  isCustomConnector?: boolean;
 }
 
 interface AvailableServicesResponse {

--- a/packages/client/src/components/integrations/connect-integration-dialog.tsx
+++ b/packages/client/src/components/integrations/connect-integration-dialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { api } from '@/api/client';
 import { useAvailableIntegrations, useIntegrations, useConfigureIntegration, type AvailableService } from '@/api/integrations';
 import { useSetUserCredential } from '@/api/auth';
@@ -133,6 +134,7 @@ interface ResolvedService {
   fromRegistry?: boolean;
   /** Entities to configure when creating the integration (from registry). */
   supportedEntities?: string[];
+  isCustomConnector?: boolean;
 }
 
 function resolveService(svc: AvailableService): ResolvedService {
@@ -149,6 +151,7 @@ function resolveService(svc: AvailableService): ResolvedService {
     credentialProvider: meta.credentialProvider,
     fromRegistry: true,
     supportedEntities: svc.supportedEntities,
+    isCustomConnector: svc.isCustomConnector,
   };
 }
 
@@ -289,7 +292,10 @@ export function ConnectIntegrationDialog({
                       <service.icon className="h-5 w-5" />
                     </div>
                     <div className="flex-1">
-                      <p className="font-medium text-neutral-900 dark:text-neutral-100">{service.name}</p>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="font-medium text-neutral-900 dark:text-neutral-100">{service.name}</p>
+                        {service.isCustomConnector && <Badge variant="secondary">Custom</Badge>}
+                      </div>
                       <p className="mt-0.5 text-sm text-neutral-500 dark:text-neutral-400">
                         {service.description}
                       </p>

--- a/packages/client/src/components/settings/add-mcp-connector-dialog.tsx
+++ b/packages/client/src/components/settings/add-mcp-connector-dialog.tsx
@@ -1,0 +1,349 @@
+import * as React from 'react';
+import type {
+  CreateCustomMcpConnectorRequest,
+  CustomMcpConnector,
+  CustomMcpConnectorAuthType,
+  CustomMcpConnectorTokenEndpointAuthMethod,
+  UpdateCustomMcpConnectorRequest,
+} from '@valet/shared';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  useCreateCustomMcpConnector,
+  useUpdateCustomMcpConnector,
+} from '@/api/custom-mcp-connectors';
+
+interface AddMcpConnectorDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  connector?: CustomMcpConnector | null;
+}
+
+interface HeaderRow {
+  key: string;
+  value: string;
+}
+
+const fieldClass = 'space-y-1.5';
+const labelClass = 'text-sm font-medium text-neutral-700 dark:text-neutral-300';
+
+export function AddMcpConnectorDialog({ open, onOpenChange, connector }: AddMcpConnectorDialogProps) {
+  const createConnector = useCreateCustomMcpConnector();
+  const updateConnector = useUpdateCustomMcpConnector();
+  const isEditing = !!connector;
+  const redirectOrigin = typeof window === 'undefined' ? '' : window.location.origin;
+  const [displayName, setDisplayName] = React.useState('');
+  const [serverUrl, setServerUrl] = React.useState('');
+  const [advancedOpen, setAdvancedOpen] = React.useState(false);
+  const [authType, setAuthType] = React.useState<CustomMcpConnectorAuthType>('none');
+  const [status, setStatus] = React.useState<'active' | 'disabled'>('active');
+  const [oauthClientId, setOauthClientId] = React.useState('');
+  const [oauthClientSecret, setOauthClientSecret] = React.useState('');
+  const [clearClientSecret, setClearClientSecret] = React.useState(false);
+  const [oauthTokenEndpointAuthMethod, setOauthTokenEndpointAuthMethod] =
+    React.useState<CustomMcpConnectorTokenEndpointAuthMethod | 'auto'>('auto');
+  const [oauthScopes, setOauthScopes] = React.useState('');
+  const [oauthAuthorizationEndpoint, setOauthAuthorizationEndpoint] = React.useState('');
+  const [oauthTokenEndpoint, setOauthTokenEndpoint] = React.useState('');
+  const [apiKey, setApiKey] = React.useState('');
+  const [apiKeyHeaderName, setApiKeyHeaderName] = React.useState('X-API-Key');
+  const [apiKeyPrefix, setApiKeyPrefix] = React.useState('');
+  const [replaceAdditionalHeaders, setReplaceAdditionalHeaders] = React.useState(false);
+  const [clearAdditionalHeaders, setClearAdditionalHeaders] = React.useState(false);
+  const [additionalHeaders, setAdditionalHeaders] = React.useState<HeaderRow[]>([{ key: '', value: '' }]);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    setDisplayName(connector?.displayName ?? '');
+    setServerUrl(connector?.serverUrl ?? '');
+    setAdvancedOpen(!!connector && (connector.authType !== 'none' || connector.hasAdditionalHeaders));
+    setAuthType(connector?.authType ?? 'none');
+    setStatus(connector?.status === 'disabled' ? 'disabled' : 'active');
+    setOauthClientId(connector?.oauthClientId ?? '');
+    setOauthClientSecret('');
+    setClearClientSecret(false);
+    setOauthTokenEndpointAuthMethod(connector?.oauthTokenEndpointAuthMethod ?? 'auto');
+    setOauthScopes(connector?.oauthScopes ?? '');
+    setOauthAuthorizationEndpoint(connector?.oauthAuthorizationEndpoint ?? '');
+    setOauthTokenEndpoint(connector?.oauthTokenEndpoint ?? '');
+    setApiKey('');
+    setApiKeyHeaderName(connector?.apiKeyHeaderName ?? (connector?.authType === 'bearer' ? 'Authorization' : 'X-API-Key'));
+    setApiKeyPrefix(connector?.apiKeyPrefix ?? '');
+    setReplaceAdditionalHeaders(false);
+    setClearAdditionalHeaders(false);
+    setAdditionalHeaders([{ key: '', value: '' }]);
+    setError(null);
+  }, [open, connector]);
+
+  const isPending = createConnector.isPending || updateConnector.isPending;
+
+  function collectAdditionalHeaders(): Record<string, string> | undefined {
+    const pairs = additionalHeaders
+      .map((h) => ({ key: h.key.trim(), value: h.value }))
+      .filter((h) => h.key || h.value);
+    if (pairs.length === 0) return undefined;
+    return Object.fromEntries(pairs.map((h) => [h.key, h.value]));
+  }
+
+  function buildPayload(): CreateCustomMcpConnectorRequest | UpdateCustomMcpConnectorRequest {
+    const additionalHeadersPayload = collectAdditionalHeaders();
+    const base = {
+      displayName: displayName.trim(),
+      serverUrl: serverUrl.trim(),
+      authType,
+      status,
+    };
+
+    if (authType === 'oauth') {
+      return {
+        ...base,
+        oauthClientId: oauthClientId.trim() || null,
+        oauthClientSecret: oauthClientSecret.trim() || undefined,
+        clearClientSecret: isEditing ? clearClientSecret : undefined,
+        oauthTokenEndpointAuthMethod,
+        oauthScopes: oauthScopes.trim() || null,
+        oauthAuthorizationEndpoint: oauthAuthorizationEndpoint.trim() || null,
+        oauthTokenEndpoint: oauthTokenEndpoint.trim() || null,
+        additionalHeaders: !isEditing || replaceAdditionalHeaders ? additionalHeadersPayload : undefined,
+        clearAdditionalHeaders: isEditing ? clearAdditionalHeaders : undefined,
+      };
+    }
+
+    if (authType === 'api_key' || authType === 'bearer') {
+      return {
+        ...base,
+        apiKey: apiKey.trim() || undefined,
+        apiKeyHeaderName: authType === 'bearer' ? 'Authorization' : apiKeyHeaderName.trim(),
+        apiKeyPrefix: authType === 'bearer' ? 'Bearer' : apiKeyPrefix.trim() || null,
+        additionalHeaders: !isEditing || replaceAdditionalHeaders ? additionalHeadersPayload : undefined,
+        clearAdditionalHeaders: isEditing ? clearAdditionalHeaders : undefined,
+      };
+    }
+
+    return {
+      ...base,
+      additionalHeaders: !isEditing || replaceAdditionalHeaders ? additionalHeadersPayload : undefined,
+      clearAdditionalHeaders: isEditing ? clearAdditionalHeaders : undefined,
+    };
+  }
+
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setError(null);
+    const payload = buildPayload();
+    const callbacks = {
+      onSuccess: () => onOpenChange(false),
+      onError: (err: unknown) => setError(err instanceof Error ? err.message : 'Failed to save connector'),
+    };
+    if (connector) {
+      updateConnector.mutate({ id: connector.id, data: payload as UpdateCustomMcpConnectorRequest }, callbacks);
+    } else {
+      createConnector.mutate(payload as CreateCustomMcpConnectorRequest, callbacks);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{isEditing ? 'Edit MCP Connector' : 'Add MCP Connector'}</DialogTitle>
+          <DialogDescription>
+            Configure a remote MCP server and its org-level authentication.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="mt-5 space-y-5" onSubmit={handleSubmit}>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field label="Name">
+              <Input value={displayName} onChange={(e) => setDisplayName(e.target.value)} required />
+            </Field>
+            <Field label="Status">
+              <select value={status} onChange={(e) => setStatus(e.target.value as 'active' | 'disabled')} className={selectClassName}>
+                <option value="active">Active</option>
+                <option value="disabled">Disabled</option>
+              </select>
+            </Field>
+          </div>
+
+          <Field label="Remote MCP server URL">
+            <Input value={serverUrl} onChange={(e) => setServerUrl(e.target.value)} required placeholder="https://mcp.example.com/server" />
+          </Field>
+
+          {connector && (
+            <div className="rounded-md bg-neutral-50 px-3 py-2 text-xs text-neutral-500 dark:bg-neutral-800 dark:text-neutral-400">
+              Service slug: <span className="font-mono text-neutral-700 dark:text-neutral-200">{connector.serviceSlug}</span>
+            </div>
+          )}
+
+          <details
+            open={advancedOpen}
+            onToggle={(event) => setAdvancedOpen(event.currentTarget.open)}
+            className="rounded-md border border-neutral-200 dark:border-neutral-700"
+          >
+            <summary className="cursor-pointer px-4 py-3 text-sm font-medium text-neutral-800 dark:text-neutral-100">
+              Advanced settings
+            </summary>
+            <div className="space-y-4 border-t border-neutral-200 p-4 dark:border-neutral-700">
+              <Field label="Auth type">
+                <select value={authType} onChange={(e) => setAuthType(e.target.value as CustomMcpConnectorAuthType)} className={selectClassName}>
+                  <option value="none">None</option>
+                  <option value="oauth">OAuth</option>
+                  <option value="api_key">API Key</option>
+                  <option value="bearer">Bearer</option>
+                </select>
+              </Field>
+
+              {authType === 'oauth' && (
+                <div className="space-y-4 border-t border-neutral-200 pt-4 dark:border-neutral-700">
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <Field label="Client ID">
+                      <Input value={oauthClientId} onChange={(e) => setOauthClientId(e.target.value)} required />
+                    </Field>
+                    <Field label="Client secret">
+                      <Input
+                        type="password"
+                        value={oauthClientSecret}
+                        onChange={(e) => setOauthClientSecret(e.target.value)}
+                        placeholder={connector?.hasClientSecret ? '(unchanged)' : ''}
+                      />
+                    </Field>
+                  </div>
+                  {connector?.hasClientSecret && (
+                    <label className="flex items-center gap-2 text-sm text-neutral-700 dark:text-neutral-300">
+                      <Checkbox checked={clearClientSecret} onChange={(e) => setClearClientSecret(e.target.checked)} />
+                      Remove client secret
+                    </label>
+                  )}
+                  <Field label="Token endpoint auth">
+                    <select value={oauthTokenEndpointAuthMethod} onChange={(e) => setOauthTokenEndpointAuthMethod(e.target.value as CustomMcpConnectorTokenEndpointAuthMethod | 'auto')} className={selectClassName}>
+                      <option value="auto">Auto</option>
+                      <option value="none">None</option>
+                      <option value="client_secret_basic">Client secret basic</option>
+                      <option value="client_secret_post">Client secret post</option>
+                    </select>
+                  </Field>
+                  <Field label="Scopes">
+                    <Input value={oauthScopes} onChange={(e) => setOauthScopes(e.target.value)} placeholder="openid profile offline_access" />
+                  </Field>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <Field label="Authorization endpoint">
+                      <Input value={oauthAuthorizationEndpoint} onChange={(e) => setOauthAuthorizationEndpoint(e.target.value)} required />
+                    </Field>
+                    <Field label="Token endpoint">
+                      <Input value={oauthTokenEndpoint} onChange={(e) => setOauthTokenEndpoint(e.target.value)} required />
+                    </Field>
+                  </div>
+                  {redirectOrigin && (
+                    <div className="text-xs text-neutral-500 dark:text-neutral-400">
+                      Redirect URI: <span className="font-mono">{`${redirectOrigin}/integrations/callback`}</span>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {(authType === 'api_key' || authType === 'bearer') && (
+                <div className="space-y-4 border-t border-neutral-200 pt-4 dark:border-neutral-700">
+                  <Field label={authType === 'bearer' ? 'Bearer token' : 'API key'}>
+                    <Input
+                      type="password"
+                      value={apiKey}
+                      onChange={(e) => setApiKey(e.target.value)}
+                      required={!connector?.hasApiKey}
+                      placeholder={connector?.hasApiKey ? '(unchanged)' : ''}
+                    />
+                  </Field>
+                  {authType === 'api_key' && (
+                    <div className="grid gap-4 sm:grid-cols-2">
+                      <Field label="Header name">
+                        <Input value={apiKeyHeaderName} onChange={(e) => setApiKeyHeaderName(e.target.value)} required />
+                      </Field>
+                      <Field label="Prefix">
+                        <Input value={apiKeyPrefix} onChange={(e) => setApiKeyPrefix(e.target.value)} placeholder="Token" />
+                      </Field>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              <div className="space-y-3 border-t border-neutral-200 pt-4 dark:border-neutral-700">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <div className={labelClass}>Additional request headers</div>
+                    {connector?.hasAdditionalHeaders && (
+                      <div className="text-xs text-neutral-500 dark:text-neutral-400">Configured values are hidden.</div>
+                    )}
+                  </div>
+                  {isEditing && (
+                    <div className="flex items-center gap-3">
+                      <label className="flex items-center gap-2 text-sm text-neutral-700 dark:text-neutral-300">
+                        <Checkbox checked={replaceAdditionalHeaders} onChange={(e) => setReplaceAdditionalHeaders(e.target.checked)} />
+                        Replace
+                      </label>
+                      <label className="flex items-center gap-2 text-sm text-neutral-700 dark:text-neutral-300">
+                        <Checkbox checked={clearAdditionalHeaders} onChange={(e) => setClearAdditionalHeaders(e.target.checked)} />
+                        Clear
+                      </label>
+                    </div>
+                  )}
+                </div>
+                {(!isEditing || replaceAdditionalHeaders) && (
+                  <div className="space-y-2">
+                    {additionalHeaders.map((header, index) => (
+                      <div key={index} className="grid gap-2 sm:grid-cols-[1fr_1fr_auto]">
+                        <Input value={header.key} onChange={(e) => updateHeader(index, 'key', e.target.value)} placeholder="X-Tenant" />
+                        <Input value={header.value} onChange={(e) => updateHeader(index, 'value', e.target.value)} placeholder="Value" />
+                        <Button type="button" variant="secondary" onClick={() => removeHeader(index)} disabled={additionalHeaders.length === 1}>
+                          Remove
+                        </Button>
+                      </div>
+                    ))}
+                    <Button type="button" variant="secondary" onClick={() => setAdditionalHeaders([...additionalHeaders, { key: '', value: '' }])}>
+                      Add Header
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </div>
+          </details>
+
+          {error && <div className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-950/30 dark:text-red-300">{error}</div>}
+
+          <DialogFooter>
+            <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>Cancel</Button>
+            <Button type="submit" disabled={isPending}>{isPending ? 'Saving...' : isEditing ? 'Save' : 'Add'}</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+
+  function updateHeader(index: number, field: keyof HeaderRow, value: string) {
+    setAdditionalHeaders((headers) => headers.map((header, i) => i === index ? { ...header, [field]: value } : header));
+  }
+
+  function removeHeader(index: number) {
+    setAdditionalHeaders((headers) => headers.filter((_, i) => i !== index));
+  }
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className={fieldClass}>
+      <div className={labelClass}>{label}</div>
+      {children}
+    </label>
+  );
+}
+
+const selectClassName =
+  'h-9 w-full rounded-md border border-neutral-300 bg-white px-3 text-sm text-neutral-900 focus:border-neutral-500 focus:outline-none focus:ring-1 focus:ring-neutral-500 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:focus:border-neutral-400 dark:focus:ring-neutral-400';

--- a/packages/client/src/components/settings/custom-mcp-connectors-section.tsx
+++ b/packages/client/src/components/settings/custom-mcp-connectors-section.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import type { CustomMcpConnector } from '@valet/shared';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  useCustomMcpConnectors,
+  useDeleteCustomMcpConnector,
+} from '@/api/custom-mcp-connectors';
+import { AddMcpConnectorDialog } from './add-mcp-connector-dialog';
+
+export function CustomMcpConnectorsSection() {
+  const { data: connectors, isLoading } = useCustomMcpConnectors();
+  const deleteConnector = useDeleteCustomMcpConnector();
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [editing, setEditing] = React.useState<CustomMcpConnector | null>(null);
+  const [deleting, setDeleting] = React.useState<CustomMcpConnector | null>(null);
+
+  return (
+    <div className="rounded-lg border border-neutral-200 bg-white p-6 dark:border-neutral-700 dark:bg-neutral-800">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-medium text-neutral-900 dark:text-neutral-100">Custom MCP Connectors</h2>
+          <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
+            Add remote MCP servers for org-managed tools.
+          </p>
+        </div>
+        <Button onClick={() => { setEditing(null); setDialogOpen(true); }}>Add Connector</Button>
+      </div>
+
+      <div className="mt-4">
+        {isLoading ? (
+          <div className="space-y-3">
+            {[1, 2].map((i) => <div key={i} className="h-12 animate-pulse rounded-md bg-neutral-100 dark:bg-neutral-700" />)}
+          </div>
+        ) : connectors && connectors.length > 0 ? (
+          <div className="overflow-x-auto rounded-md border border-neutral-200 dark:border-neutral-700">
+            <table className="w-full min-w-[760px] text-sm">
+              <thead>
+                <tr className="border-b border-neutral-200 bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800/50">
+                  <th className="px-3 py-2 text-left font-medium text-neutral-600 dark:text-neutral-400">Name</th>
+                  <th className="px-3 py-2 text-left font-medium text-neutral-600 dark:text-neutral-400">URL</th>
+                  <th className="px-3 py-2 text-left font-medium text-neutral-600 dark:text-neutral-400">Auth</th>
+                  <th className="px-3 py-2 text-left font-medium text-neutral-600 dark:text-neutral-400">Status</th>
+                  <th className="px-3 py-2 text-left font-medium text-neutral-600 dark:text-neutral-400">Tools</th>
+                  <th className="px-3 py-2 text-right font-medium text-neutral-600 dark:text-neutral-400">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {connectors.map((connector) => (
+                  <tr key={connector.id} className="border-b border-neutral-100 last:border-0 dark:border-neutral-700/50">
+                    <td className="px-3 py-2">
+                      <div className="font-medium text-neutral-900 dark:text-neutral-100">{connector.displayName}</div>
+                      <div className="font-mono text-xs text-neutral-500 dark:text-neutral-400">{connector.serviceSlug}</div>
+                    </td>
+                    <td className="max-w-[280px] truncate px-3 py-2 text-neutral-500 dark:text-neutral-400">{connector.serverUrl}</td>
+                    <td className="px-3 py-2 text-neutral-700 dark:text-neutral-300">{formatAuth(connector)}</td>
+                    <td className="px-3 py-2">
+                      <Badge variant={connector.status === 'active' ? 'success' : connector.status === 'error' ? 'error' : 'secondary'}>
+                        {connector.status}
+                      </Badge>
+                    </td>
+                    <td className="px-3 py-2 text-neutral-700 dark:text-neutral-300">{connector.toolCount ?? 0}</td>
+                    <td className="px-3 py-2 text-right">
+                      <div className="flex items-center justify-end gap-2">
+                        <Button variant="secondary" onClick={() => { setEditing(connector); setDialogOpen(true); }}>Edit</Button>
+                        <Button variant="secondary" onClick={() => setDeleting(connector)}>Delete</Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="rounded-md border border-dashed border-neutral-300 px-4 py-6 text-sm text-neutral-500 dark:border-neutral-700 dark:text-neutral-400">
+            No custom MCP connectors configured.
+          </div>
+        )}
+      </div>
+
+      <AddMcpConnectorDialog
+        open={dialogOpen}
+        connector={editing}
+        onOpenChange={(open) => {
+          setDialogOpen(open);
+          if (!open) setEditing(null);
+        }}
+      />
+
+      <AlertDialog open={!!deleting} onOpenChange={(open) => !open && setDeleting(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Connector</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the connector, cached tools, user connections, credentials, and action policies for this service.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (!deleting) return;
+                deleteConnector.mutate(deleting.id, { onSuccess: () => setDeleting(null) });
+              }}
+              disabled={deleteConnector.isPending}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+function formatAuth(connector: CustomMcpConnector): string {
+  if (connector.authType === 'none') return 'None';
+  if (connector.authType === 'oauth') return connector.hasClientSecret ? 'OAuth secret' : 'OAuth PKCE';
+  if (connector.authType === 'bearer') return 'Bearer';
+  return connector.apiKeyHeaderName || 'API key';
+}

--- a/packages/client/src/routes/settings/admin.tsx
+++ b/packages/client/src/routes/settings/admin.tsx
@@ -33,6 +33,7 @@ import type { ProviderModels } from '@/api/sessions';
 import { useSlackInstallStatus, useInstallSlack, useUninstallSlack } from '@/api/slack';
 import { GitHubConfigSection } from '@/components/settings/github-config';
 import { ActionPoliciesSection } from '@/components/settings/action-policies-section';
+import { CustomMcpConnectorsSection } from '@/components/settings/custom-mcp-connectors-section';
 import { usePlugins, usePluginDetail, usePluginSettings, useUpdatePluginStatus, useSyncPlugins, useUpdatePluginSettings } from '@/api/plugins';
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -96,6 +97,7 @@ function AdminSettingsPage() {
         <GitHubConfigSection />
         <OrchestratorsSection />
         <ActionLogSection />
+        <CustomMcpConnectorsSection />
         <CustomProvidersSection />
         <AccessControlSection />
         <LoginProvidersSection />

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -20,9 +20,11 @@ export {
   generatePkceChallenge,
   buildAuthorizationUrl,
   exchangeCodePkce,
+  exchangeCodeWithClientCredentials,
   refreshTokenPkce,
+  refreshTokenWithClientCredentials,
 } from './mcp/oauth.js';
-export type { AuthServerMetadata, RegisteredClient, TokenResponse } from './mcp/oauth.js';
+export type { AuthServerMetadata, RegisteredClient, TokenResponse, TokenEndpointAuthMethod } from './mcp/oauth.js';
 
 // NOTE: React UI components are exported from '@valet/sdk/ui'
 // to avoid pulling React into backend bundles.

--- a/packages/sdk/src/integrations/index.ts
+++ b/packages/sdk/src/integrations/index.ts
@@ -101,6 +101,7 @@ export interface IntegrationProvider {
   /** Base URL of the MCP server (e.g. 'https://mcp.notion.com').
    *  When set, uses MCP OAuth (dynamic client registration + PKCE) instead of env-var OAuth. */
   readonly mcpServerUrl?: string;
+  readonly isCustomConnector?: boolean;
 
   validateCredentials(credentials: IntegrationCredentials): boolean;
   testConnection(credentials: IntegrationCredentials): Promise<boolean>;

--- a/packages/sdk/src/mcp/action-source.ts
+++ b/packages/sdk/src/mcp/action-source.ts
@@ -18,6 +18,9 @@ export interface McpActionSourceOptions {
   noAuth?: boolean;
   /** When set, token is sent as this URL query parameter instead of Authorization header. */
   authQueryParam?: string;
+  additionalHeaders?: Record<string, string>;
+  staticAuthHeader?: { name: string; value: string };
+  fetch?: typeof fetch;
 }
 
 /**
@@ -35,7 +38,14 @@ export class McpActionSource implements ActionSource {
   private noAuth: boolean;
 
   constructor(opts: McpActionSourceOptions) {
-    this.client = new McpClient({ url: opts.mcpUrl, serviceName: opts.serviceName, authQueryParam: opts.authQueryParam });
+    this.client = new McpClient({
+      url: opts.mcpUrl,
+      serviceName: opts.serviceName,
+      authQueryParam: opts.authQueryParam,
+      additionalHeaders: opts.additionalHeaders,
+      staticAuthHeader: opts.staticAuthHeader,
+      fetch: opts.fetch,
+    });
     this.serviceName = opts.serviceName;
     this.defaultRiskLevel = opts.defaultRiskLevel ?? 'medium';
     this.noAuth = opts.noAuth ?? false;

--- a/packages/sdk/src/mcp/client.test.ts
+++ b/packages/sdk/src/mcp/client.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { McpClient } from './client.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json', ...init.headers },
+    ...init,
+  });
+}
+
+async function readRpc(req: RequestInit): Promise<{ method: string; params?: Record<string, unknown> }> {
+  return JSON.parse(String(req.body));
+}
+
+describe('McpClient', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses injected fetch and sends static headers plus negotiated protocol/session headers', async () => {
+    const requests: Array<{ url: string; init: RequestInit; rpc: { method: string; params?: Record<string, unknown> } }> = [];
+    const fakeFetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const requestInit = init ?? {};
+      const rpc = await readRpc(requestInit);
+      requests.push({ url: String(url), init: requestInit, rpc });
+
+      if (rpc.method === 'initialize') {
+        expect(rpc.params?.protocolVersion).toBe('2025-11-25');
+        return jsonResponse({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            protocolVersion: '2025-11-25',
+            capabilities: {},
+            serverInfo: { name: 'fake', version: '1.0.0' },
+          },
+        }, { headers: { 'mcp-session-id': 'session-1' } });
+      }
+
+      if (rpc.method === 'notifications/initialized') {
+        return new Response(null, { status: 202 });
+      }
+
+      return jsonResponse({
+        jsonrpc: '2.0',
+        id: 2,
+        result: { tools: [{ name: 'query', description: 'Query data', inputSchema: { type: 'object' } }] },
+      });
+    });
+    vi.stubGlobal('fetch', vi.fn(() => {
+      throw new Error('global fetch should not be used');
+    }));
+
+    const client = new McpClient({
+      url: 'https://mcp.example.com',
+      serviceName: 'custom',
+      additionalHeaders: { 'X-Tenant': 'acme' },
+      staticAuthHeader: { name: 'X-API-Key', value: 'secret' },
+      fetch: fakeFetch,
+    });
+
+    await expect(client.listTools()).resolves.toHaveLength(1);
+
+    expect(fakeFetch).toHaveBeenCalledTimes(3);
+    expect(requests[0].init.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      'X-Tenant': 'acme',
+      'X-API-Key': 'secret',
+    });
+    expect(requests[1].init.headers).toMatchObject({
+      'MCP-Protocol-Version': '2025-11-25',
+      'Mcp-Session-Id': 'session-1',
+    });
+    expect(requests[2].init.headers).toMatchObject({
+      'MCP-Protocol-Version': '2025-11-25',
+      'Mcp-Session-Id': 'session-1',
+      'X-Tenant': 'acme',
+      'X-API-Key': 'secret',
+    });
+  });
+
+  it('rejects unsupported negotiated protocol versions instead of falling back to no-session mode', async () => {
+    const fakeFetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const rpc = await readRpc(init ?? {});
+      if (rpc.method !== 'initialize') throw new Error('should not call tools/list after unsupported initialize');
+      return jsonResponse({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          protocolVersion: '1900-01-01',
+          capabilities: {},
+          serverInfo: { name: 'fake', version: '1.0.0' },
+        },
+      }, { headers: { 'mcp-session-id': 'bad-session' } });
+    });
+
+    const client = new McpClient({ url: 'https://mcp.example.com', serviceName: 'custom', fetch: fakeFetch });
+
+    await expect(client.listTools()).rejects.toThrow(/unsupported MCP protocol/i);
+    expect(fakeFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears a stale session and retries once when a request returns 404', async () => {
+    const calls: string[] = [];
+    const fakeFetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const rpc = await readRpc(init ?? {});
+      calls.push(rpc.method);
+
+      if (rpc.method === 'initialize') {
+        const sessionId = calls.length === 1 ? 'session-1' : 'session-2';
+        return jsonResponse({
+          jsonrpc: '2.0',
+          id: calls.length,
+          result: {
+            protocolVersion: '2025-11-25',
+            capabilities: {},
+            serverInfo: { name: 'fake', version: '1.0.0' },
+          },
+        }, { headers: { 'mcp-session-id': sessionId } });
+      }
+
+      if (rpc.method === 'notifications/initialized') {
+        return new Response(null, { status: 202 });
+      }
+
+      if (rpc.method === 'tools/list' && calls.filter((m) => m === 'tools/list').length === 1) {
+        return new Response('stale session', { status: 404 });
+      }
+
+      return jsonResponse({ jsonrpc: '2.0', id: 99, result: { tools: [] } });
+    });
+
+    const client = new McpClient({ url: 'https://mcp.example.com', serviceName: 'custom', fetch: fakeFetch });
+
+    await expect(client.listTools()).resolves.toEqual([]);
+    expect(calls).toEqual([
+      'initialize',
+      'notifications/initialized',
+      'tools/list',
+      'initialize',
+      'notifications/initialized',
+      'tools/list',
+    ]);
+  });
+
+  it('rejects additional headers that collide with client-owned headers', async () => {
+    const client = new McpClient({
+      url: 'https://mcp.example.com',
+      serviceName: 'custom',
+      additionalHeaders: { Authorization: 'Bearer bad' },
+      fetch: vi.fn(),
+    });
+
+    await expect(client.listTools()).rejects.toThrow(/protected header/i);
+  });
+});

--- a/packages/sdk/src/mcp/client.ts
+++ b/packages/sdk/src/mcp/client.ts
@@ -1,5 +1,48 @@
 import type { McpTool, McpToolResult, JsonRpcRequest, JsonRpcResponse } from './types.js';
 
+const LATEST_MCP_PROTOCOL_VERSION = '2025-11-25';
+const SUPPORTED_MCP_PROTOCOL_VERSIONS = new Set(['2025-03-26', '2025-06-18', '2025-11-25']);
+
+const PROTECTED_ADDITIONAL_HEADERS = new Set([
+  'authorization',
+  'content-type',
+  'accept',
+  'mcp-session-id',
+  'mcp-protocol-version',
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'host',
+  'content-length',
+  'cookie',
+  'date',
+  'dnt',
+  'expect',
+  'origin',
+  'referer',
+  'accept-charset',
+  'accept-encoding',
+  'access-control-request-headers',
+  'access-control-request-method',
+  'permissions-policy',
+]);
+
+const HTTP_FIELD_NAME_RE = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+export interface McpClientOptions {
+  url: string;
+  serviceName: string;
+  authQueryParam?: string;
+  additionalHeaders?: Record<string, string>;
+  staticAuthHeader?: { name: string; value: string };
+  fetch?: typeof fetch;
+}
+
 /**
  * Lightweight MCP client using JSON-RPC over HTTP (streamable HTTP transport).
  *
@@ -16,29 +59,49 @@ export class McpClient {
   private nextId = 1;
   /** When set, token is sent as a URL query parameter instead of Authorization header. */
   private authQueryParam?: string;
+  private additionalHeaders?: Record<string, string>;
+  private staticAuthHeader?: { name: string; value: string };
+  private fetchFn: typeof fetch;
 
   /** Per-service session IDs to avoid re-initializing on every call. */
   private sessions = new Map<string, string | null>();
+  private protocolVersions = new Map<string, string>();
 
-  constructor(opts: { url: string; serviceName: string; authQueryParam?: string }) {
+  constructor(opts: McpClientOptions) {
     this.url = opts.url;
     this.serviceName = opts.serviceName;
     this.authQueryParam = opts.authQueryParam;
+    this.additionalHeaders = opts.additionalHeaders;
+    this.staticAuthHeader = opts.staticAuthHeader;
+    this.fetchFn = opts.fetch ?? fetch;
   }
 
   /** Build fetch URL and headers with auth + session. */
   private buildFetchOpts(token?: string, sessionId?: string | null): { url: string; headers: Record<string, string> } {
     const headers: Record<string, string> = {
+      ...this.validateAdditionalHeaders(this.additionalHeaders),
       'Content-Type': 'application/json',
       Accept: 'application/json, text/event-stream',
     };
 
     let url = this.url;
+    if (token && this.staticAuthHeader) {
+      throw new Error(`MCP ${this.serviceName}: ambiguous auth sources; cannot send both access token and static auth header`);
+    }
+
     if (token && this.authQueryParam) {
       const sep = this.url.includes('?') ? '&' : '?';
       url = `${this.url}${sep}${this.authQueryParam}=${encodeURIComponent(token)}`;
     } else if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    } else if (this.staticAuthHeader) {
+      const header = this.validateStaticAuthHeader(this.staticAuthHeader);
+      headers[header.name] = header.value;
+    }
+
+    const protocolVersion = this.protocolVersions.get(this.serviceName);
+    if (protocolVersion) {
+      headers['MCP-Protocol-Version'] = protocolVersion;
     }
     if (sessionId) {
       headers['Mcp-Session-Id'] = sessionId;
@@ -53,6 +116,7 @@ export class McpClient {
     params: Record<string, unknown> | undefined,
     token: string | undefined,
     sessionId?: string | null,
+    retryOnStaleSession = true,
   ): Promise<{ result: T; sessionId: string | null }> {
     const req: JsonRpcRequest = {
       jsonrpc: '2.0',
@@ -63,13 +127,21 @@ export class McpClient {
 
     const { url: fetchUrl, headers } = this.buildFetchOpts(token, sessionId);
 
-    const res = await fetch(fetchUrl, {
+    const res = await this.fetchFn(fetchUrl, {
       method: 'POST',
       headers,
       body: JSON.stringify(req),
     });
 
     if (!res.ok) {
+      if (res.status === 404 && sessionId && retryOnStaleSession) {
+        this.sessions.delete(this.serviceName);
+        this.protocolVersions.delete(this.serviceName);
+        const nextSessionId = await this.ensureInitialized(token);
+        const retry = await this.rpc<T>(method, params, token, nextSessionId, false);
+        return retry;
+      }
+
       const body = await res.text().catch(() => '');
       throw new Error(`MCP ${this.serviceName} ${method} failed: HTTP ${res.status}${body ? ` — ${body.slice(0, 200)}` : ''}`);
     }
@@ -131,7 +203,7 @@ export class McpClient {
     const { url: fetchUrl, headers } = this.buildFetchOpts(token, sessionId);
 
     // Fire and forget — notifications don't have responses
-    await fetch(fetchUrl, {
+    await this.fetchFn(fetchUrl, {
       method: 'POST',
       headers,
       body: JSON.stringify(req),
@@ -160,15 +232,21 @@ export class McpClient {
       }>(
         'initialize',
         {
-          protocolVersion: '2025-03-26',
+          protocolVersion: LATEST_MCP_PROTOCOL_VERSION,
           capabilities: {},
           clientInfo: { name: 'valet', version: '1.0.0' },
         },
         token,
       );
 
+      const protocolVersion = result?.protocolVersion;
+      if (!SUPPORTED_MCP_PROTOCOL_VERSIONS.has(protocolVersion)) {
+        throw new Error(`Unsupported MCP protocol version negotiated by ${this.serviceName}: ${protocolVersion}`);
+      }
+
       console.log(`[McpClient] ${this.serviceName} initialized: protocol=${result?.protocolVersion}, sessionId=${sessionId}, server=${result?.serverInfo?.name}/${result?.serverInfo?.version}`);
 
+      this.protocolVersions.set(cacheKey, protocolVersion);
       this.sessions.set(cacheKey, sessionId);
 
       // Send initialized notification
@@ -176,6 +254,10 @@ export class McpClient {
 
       return sessionId;
     } catch (err) {
+      if (err instanceof Error && /Unsupported MCP protocol version/i.test(err.message)) {
+        throw err;
+      }
+
       console.warn(
         `[McpClient] ${this.serviceName} initialize failed, falling back to no-session mode:`,
         err instanceof Error ? err.message : String(err),
@@ -198,5 +280,50 @@ export class McpClient {
     const sessionId = await this.ensureInitialized(token);
     const { result } = await this.rpc<McpToolResult>('tools/call', { name, arguments: args }, token, sessionId);
     return result;
+  }
+
+  private validateAdditionalHeaders(headers?: Record<string, string>): Record<string, string> {
+    if (!headers) return {};
+
+    const normalized = new Set<string>();
+    const validated: Record<string, string> = {};
+    for (const [name, value] of Object.entries(headers)) {
+      const lowerName = this.validateHeaderName(name);
+      if (normalized.has(lowerName)) {
+        throw new Error(`MCP ${this.serviceName}: duplicate additional header "${name}"`);
+      }
+      normalized.add(lowerName);
+      if (PROTECTED_ADDITIONAL_HEADERS.has(lowerName) || lowerName.startsWith('proxy-') || lowerName.startsWith('sec-')) {
+        throw new Error(`MCP ${this.serviceName}: protected header "${name}" cannot be configured as an additional header`);
+      }
+      this.validateHeaderValue(name, value);
+      validated[name] = value;
+    }
+    return validated;
+  }
+
+  private validateStaticAuthHeader(header: { name: string; value: string }): { name: string; value: string } {
+    const lowerName = this.validateHeaderName(header.name);
+    if (
+      lowerName !== 'authorization'
+      && (PROTECTED_ADDITIONAL_HEADERS.has(lowerName) || lowerName.startsWith('proxy-') || lowerName.startsWith('sec-'))
+    ) {
+      throw new Error(`MCP ${this.serviceName}: protected header "${header.name}" cannot be used as a static auth header`);
+    }
+    this.validateHeaderValue(header.name, header.value);
+    return header;
+  }
+
+  private validateHeaderName(name: string): string {
+    if (!HTTP_FIELD_NAME_RE.test(name)) {
+      throw new Error(`MCP ${this.serviceName}: invalid header name "${name}"`);
+    }
+    return name.toLowerCase();
+  }
+
+  private validateHeaderValue(name: string, value: string): void {
+    if (/[\r\n\0]/.test(value)) {
+      throw new Error(`MCP ${this.serviceName}: invalid value for header "${name}"`);
+    }
   }
 }

--- a/packages/sdk/src/mcp/oauth.test.ts
+++ b/packages/sdk/src/mcp/oauth.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildAuthorizationUrl,
+  exchangeCodeWithClientCredentials,
+  refreshTokenWithClientCredentials,
+} from './oauth.js';
+
+async function readForm(init?: RequestInit): Promise<URLSearchParams> {
+  return init?.body as URLSearchParams;
+}
+
+describe('MCP OAuth helpers', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('builds PKCE authorization URLs with S256 and resource without leaking the verifier', () => {
+    const url = new URL(buildAuthorizationUrl({
+      authorizationEndpoint: 'https://login.salesforce.com/services/oauth2/authorize',
+      clientId: 'client-123',
+      redirectUri: 'https://app.example.com/integrations/callback',
+      codeChallenge: 'challenge-abc',
+      state: 'state-123',
+      scopes: ['mcp_api', 'refresh_token'],
+      resource: 'https://api.salesforce.com/platform/mcp/v1/platform/sobject-all',
+    }));
+
+    expect(url.searchParams.get('client_id')).toBe('client-123');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(url.searchParams.get('code_challenge')).toBe('challenge-abc');
+    expect(url.searchParams.get('scope')).toBe('mcp_api refresh_token');
+    expect(url.searchParams.get('resource')).toBe('https://api.salesforce.com/platform/mcp/v1/platform/sobject-all');
+    expect(url.searchParams.has('code_verifier')).toBe(false);
+  });
+
+  it('exchanges codes with client_secret_basic and matching resource', async () => {
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const form = await readForm(init);
+      expect(init?.headers).toMatchObject({
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization: `Basic ${btoa('client-123:secret-456')}`,
+      });
+      expect(form.get('grant_type')).toBe('authorization_code');
+      expect(form.get('client_id')).toBe('client-123');
+      expect(form.get('client_secret')).toBeNull();
+      expect(form.get('code_verifier')).toBe('verifier-789');
+      expect(form.get('resource')).toBe('https://api.salesforce.com/platform/mcp/v1/platform/sobject-all');
+      return new Response(JSON.stringify({ access_token: 'access', refresh_token: 'refresh' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(exchangeCodeWithClientCredentials({
+      tokenEndpoint: 'https://login.salesforce.com/services/oauth2/token',
+      clientId: 'client-123',
+      clientSecret: 'secret-456',
+      tokenEndpointAuthMethod: 'client_secret_basic',
+      code: 'code-abc',
+      redirectUri: 'https://app.example.com/integrations/callback',
+      codeVerifier: 'verifier-789',
+      resource: 'https://api.salesforce.com/platform/mcp/v1/platform/sobject-all',
+    })).resolves.toMatchObject({ access_token: 'access', refresh_token: 'refresh' });
+  });
+
+  it('form-encodes client credentials before building client_secret_basic auth', async () => {
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      expect(init?.headers).toMatchObject({
+        Authorization: `Basic ${btoa('client%3A123:s%C3%ABcret%2B456')}`,
+      });
+      return new Response(JSON.stringify({ access_token: 'access' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    await exchangeCodeWithClientCredentials({
+      tokenEndpoint: 'https://login.example.com/token',
+      clientId: 'client:123',
+      clientSecret: 'sëcret+456',
+      tokenEndpointAuthMethod: 'client_secret_basic',
+      code: 'code-abc',
+      redirectUri: 'https://app.example.com/integrations/callback',
+      codeVerifier: 'verifier-789',
+      fetch: fetchMock,
+    });
+  });
+
+  it('exchanges and refreshes with client_secret_post', async () => {
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const form = await readForm(init);
+      expect(init?.headers).not.toHaveProperty('Authorization');
+      expect(form.get('client_id')).toBe('client-123');
+      expect(form.get('client_secret')).toBe('secret-456');
+      return new Response(JSON.stringify({ access_token: 'access' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await exchangeCodeWithClientCredentials({
+      tokenEndpoint: 'https://example.com/token',
+      clientId: 'client-123',
+      clientSecret: 'secret-456',
+      tokenEndpointAuthMethod: 'client_secret_post',
+      code: 'code-abc',
+      redirectUri: 'https://app.example.com/integrations/callback',
+      codeVerifier: 'verifier-789',
+    });
+
+    await refreshTokenWithClientCredentials({
+      tokenEndpoint: 'https://example.com/token',
+      clientId: 'client-123',
+      clientSecret: 'secret-456',
+      tokenEndpointAuthMethod: 'client_secret_post',
+      refreshToken: 'refresh-123',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('omits client secrets for public PKCE refreshes', async () => {
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const form = await readForm(init);
+      expect(init?.headers).not.toHaveProperty('Authorization');
+      expect(form.get('client_id')).toBe('client-123');
+      expect(form.get('client_secret')).toBeNull();
+      expect(form.get('resource')).toBe('https://mcp.example.com');
+      return new Response(JSON.stringify({ access_token: 'access' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await refreshTokenWithClientCredentials({
+      tokenEndpoint: 'https://example.com/token',
+      clientId: 'client-123',
+      tokenEndpointAuthMethod: 'none',
+      refreshToken: 'refresh-123',
+      resource: 'https://mcp.example.com',
+    });
+  });
+
+  it('uses injected fetch for client-credential exchange and refresh', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('global fetch should not be used');
+    }));
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ access_token: 'access' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+
+    await exchangeCodeWithClientCredentials({
+      tokenEndpoint: 'https://example.com/token',
+      clientId: 'client-123',
+      tokenEndpointAuthMethod: 'none',
+      code: 'code-abc',
+      redirectUri: 'https://app.example.com/integrations/callback',
+      codeVerifier: 'verifier-789',
+      fetch: fetchMock,
+    });
+
+    await refreshTokenWithClientCredentials({
+      tokenEndpoint: 'https://example.com/token',
+      clientId: 'client-123',
+      tokenEndpointAuthMethod: 'none',
+      refreshToken: 'refresh-123',
+      fetch: fetchMock,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/sdk/src/mcp/oauth.ts
+++ b/packages/sdk/src/mcp/oauth.ts
@@ -26,13 +26,15 @@ export interface TokenResponse {
   token_type?: string;
 }
 
+export type TokenEndpointAuthMethod = 'none' | 'client_secret_basic' | 'client_secret_post';
+
 // ─── RFC 8414: Authorization Server Metadata Discovery ──────────────────────
 
 /** Discover authorization server metadata from an MCP server URL. */
-export async function discoverAuthServer(mcpServerUrl: string): Promise<AuthServerMetadata> {
+export async function discoverAuthServer(mcpServerUrl: string, opts?: { fetch?: typeof fetch }): Promise<AuthServerMetadata> {
   const base = mcpServerUrl.replace(/\/+$/, '');
   const url = `${base}/.well-known/oauth-authorization-server`;
-  const res = await fetch(url);
+  const res = await (opts?.fetch ?? fetch)(url);
   if (!res.ok) {
     throw new Error(`MCP OAuth discovery failed: ${res.status} from ${url}`);
   }
@@ -44,9 +46,9 @@ export async function discoverAuthServer(mcpServerUrl: string): Promise<AuthServ
 /** Register a dynamic OAuth client with the authorization server. */
 export async function registerClient(
   registrationEndpoint: string,
-  params: { clientName: string; redirectUris: string[] },
+  params: { clientName: string; redirectUris: string[]; fetch?: typeof fetch },
 ): Promise<RegisteredClient> {
-  const res = await fetch(registrationEndpoint, {
+  const res = await (params.fetch ?? fetch)(registrationEndpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -118,6 +120,7 @@ export async function exchangeCodePkce(params: {
   codeVerifier: string;
   /** MCP resource server URL (RFC 8707). Must match the value sent in the authorization request. */
   resource?: string;
+  fetch?: typeof fetch;
 }): Promise<TokenResponse> {
   const body = new URLSearchParams({
     grant_type: 'authorization_code',
@@ -129,7 +132,7 @@ export async function exchangeCodePkce(params: {
   if (params.resource) {
     body.set('resource', params.resource);
   }
-  const res = await fetch(params.tokenEndpoint, {
+  const res = await (params.fetch ?? fetch)(params.tokenEndpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body,
@@ -141,13 +144,51 @@ export async function exchangeCodePkce(params: {
   return (await res.json()) as TokenResponse;
 }
 
+/** Exchange authorization code for tokens using PKCE and admin-provided client credentials. */
+export async function exchangeCodeWithClientCredentials(params: {
+  tokenEndpoint: string;
+  clientId: string;
+  clientSecret?: string;
+  tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
+  code: string;
+  redirectUri: string;
+  codeVerifier: string;
+  /** MCP resource server URL (RFC 8707). Must match the value sent in the authorization request. */
+  resource?: string;
+  fetch?: typeof fetch;
+}): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: params.clientId,
+    code: params.code,
+    redirect_uri: params.redirectUri,
+    code_verifier: params.codeVerifier,
+  });
+  if (params.resource) {
+    body.set('resource', params.resource);
+  }
+
+  const headers = buildTokenRequestAuth(params.clientId, params.clientSecret, params.tokenEndpointAuthMethod ?? 'none', body);
+  const res = await (params.fetch ?? fetch)(params.tokenEndpoint, {
+    method: 'POST',
+    headers,
+    body,
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`MCP client-credentials token exchange failed: ${res.status} ${body.slice(0, 200)}`);
+  }
+  return (await res.json()) as TokenResponse;
+}
+
 /** Refresh a token for a public client. */
 export async function refreshTokenPkce(params: {
   tokenEndpoint: string;
   clientId: string;
   refreshToken: string;
+  fetch?: typeof fetch;
 }): Promise<TokenResponse> {
-  const res = await fetch(params.tokenEndpoint, {
+  const res = await (params.fetch ?? fetch)(params.tokenEndpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
@@ -163,7 +204,65 @@ export async function refreshTokenPkce(params: {
   return (await res.json()) as TokenResponse;
 }
 
+/** Refresh a token using admin-provided client credentials. */
+export async function refreshTokenWithClientCredentials(params: {
+  tokenEndpoint: string;
+  clientId: string;
+  clientSecret?: string;
+  tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
+  refreshToken: string;
+  /** MCP resource server URL (RFC 8707). */
+  resource?: string;
+  fetch?: typeof fetch;
+}): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    client_id: params.clientId,
+    refresh_token: params.refreshToken,
+  });
+  if (params.resource) {
+    body.set('resource', params.resource);
+  }
+
+  const headers = buildTokenRequestAuth(params.clientId, params.clientSecret, params.tokenEndpointAuthMethod ?? 'none', body);
+  const res = await (params.fetch ?? fetch)(params.tokenEndpoint, {
+    method: 'POST',
+    headers,
+    body,
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`MCP client-credentials token refresh failed: ${res.status} ${body.slice(0, 200)}`);
+  }
+  return (await res.json()) as TokenResponse;
+}
+
 // ─── Helpers ────────────────────────────────────────────────────────────────
+
+function buildTokenRequestAuth(
+  clientId: string,
+  clientSecret: string | undefined,
+  method: TokenEndpointAuthMethod,
+  body: URLSearchParams,
+): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/x-www-form-urlencoded' };
+  if (!clientSecret || method === 'none') {
+    return headers;
+  }
+
+  if (method === 'client_secret_basic') {
+    headers.Authorization = `Basic ${btoa(`${formEncodeComponent(clientId)}:${formEncodeComponent(clientSecret)}`)}`;
+    return headers;
+  }
+
+  body.set('client_secret', clientSecret);
+  return headers;
+}
+
+function formEncodeComponent(value: string): string {
+  const params = new URLSearchParams([['value', value]]);
+  return params.toString().slice('value='.length);
+}
 
 function base64UrlEncode(bytes: Uint8Array): string {
   let binary = '';

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -533,7 +533,7 @@ export interface CreateCustomMcpConnectorRequest {
 export interface UpdateCustomMcpConnectorRequest {
   displayName?: string;
   serverUrl?: string;
-  authType: CustomMcpConnectorAuthType;
+  authType?: CustomMcpConnectorAuthType;
   oauthClientId?: string | null;
   oauthClientSecret?: string;
   clearClientSecret?: boolean;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -17,7 +17,7 @@ export type IntegrationService =
 export interface Integration {
   id: string;
   userId: string;
-  service: IntegrationService;
+  service: string;
   config: IntegrationConfig;
   status: 'active' | 'error' | 'pending' | 'disconnected';
   scope: 'user' | 'org';
@@ -475,9 +475,78 @@ export interface ListSessionsResponse {
 }
 
 export interface ConfigureIntegrationRequest {
-  service: IntegrationService;
+  service: string;
   credentials: Record<string, string>;
   config: IntegrationConfig;
+}
+
+export type CustomMcpConnectorAuthType = 'none' | 'oauth' | 'api_key' | 'bearer';
+
+export type CustomMcpConnectorTokenEndpointAuthMethod =
+  | 'none'
+  | 'client_secret_basic'
+  | 'client_secret_post';
+
+export interface CustomMcpConnector {
+  id: string;
+  orgId: string;
+  serviceSlug: string;
+  displayName: string;
+  serverUrl: string;
+  authType: CustomMcpConnectorAuthType;
+  oauthClientId: string | null;
+  oauthTokenEndpointAuthMethod: CustomMcpConnectorTokenEndpointAuthMethod;
+  oauthScopes: string | null;
+  oauthAuthorizationEndpoint: string | null;
+  oauthTokenEndpoint: string | null;
+  apiKeyHeaderName: string | null;
+  apiKeyPrefix: string | null;
+  status: 'active' | 'disabled' | 'error';
+  toolCount?: number;
+  lastDiscoveredAt: string | null;
+  lastError: string | null;
+  createdBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  hasClientSecret: boolean;
+  hasApiKey: boolean;
+  hasAdditionalHeaders: boolean;
+}
+
+export interface CreateCustomMcpConnectorRequest {
+  displayName: string;
+  serverUrl: string;
+  authType: CustomMcpConnectorAuthType;
+  oauthClientId?: string | null;
+  oauthClientSecret?: string;
+  oauthTokenEndpointAuthMethod?: CustomMcpConnectorTokenEndpointAuthMethod | 'auto';
+  oauthScopes?: string | null;
+  oauthAuthorizationEndpoint?: string | null;
+  oauthTokenEndpoint?: string | null;
+  apiKey?: string;
+  apiKeyHeaderName?: string | null;
+  apiKeyPrefix?: string | null;
+  additionalHeaders?: Record<string, string>;
+  status?: 'active' | 'disabled';
+}
+
+export interface UpdateCustomMcpConnectorRequest {
+  displayName?: string;
+  serverUrl?: string;
+  authType: CustomMcpConnectorAuthType;
+  oauthClientId?: string | null;
+  oauthClientSecret?: string;
+  clearClientSecret?: boolean;
+  oauthTokenEndpointAuthMethod?: CustomMcpConnectorTokenEndpointAuthMethod | 'auto';
+  oauthScopes?: string | null;
+  oauthAuthorizationEndpoint?: string | null;
+  oauthTokenEndpoint?: string | null;
+  apiKey?: string;
+  apiKeyHeaderName?: string | null;
+  apiKeyPrefix?: string | null;
+  additionalHeaders?: Record<string, string>;
+  clearAdditionalHeaders?: boolean;
+  status?: 'active' | 'disabled' | 'error';
 }
 
 // Custom LLM provider types

--- a/packages/worker/migrations/0015_custom_mcp_connectors.sql
+++ b/packages/worker/migrations/0015_custom_mcp_connectors.sql
@@ -1,0 +1,54 @@
+CREATE TABLE custom_mcp_connectors (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL DEFAULT 'default',
+  service_slug TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  server_url TEXT NOT NULL,
+  auth_type TEXT NOT NULL DEFAULT 'none'
+    CHECK(auth_type IN ('none', 'oauth', 'api_key', 'bearer')),
+
+  oauth_client_id TEXT,
+  encrypted_oauth_client_secret TEXT,
+  oauth_token_endpoint_auth_method TEXT NOT NULL DEFAULT 'none'
+    CHECK(oauth_token_endpoint_auth_method IN ('none', 'client_secret_basic', 'client_secret_post')),
+  oauth_scopes TEXT,
+  oauth_authorization_endpoint TEXT,
+  oauth_token_endpoint TEXT,
+
+  encrypted_api_key TEXT,
+  api_key_header_name TEXT DEFAULT 'Authorization',
+  api_key_prefix TEXT DEFAULT 'Bearer',
+
+  encrypted_additional_headers TEXT,
+
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK(status IN ('active', 'disabled', 'error')),
+  last_discovered_at TEXT,
+  last_error TEXT,
+  created_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+
+  UNIQUE(service_slug)
+);
+
+CREATE INDEX idx_custom_mcp_connectors_org_status
+  ON custom_mcp_connectors(org_id, status);
+
+CREATE INDEX idx_disabled_actions_service_cleanup
+  ON disabled_actions(service);
+
+CREATE INDEX idx_action_policies_service_cleanup
+  ON action_policies(service);
+
+CREATE INDEX idx_uapo_service_cleanup
+  ON user_action_policy_overrides(service);
+
+CREATE INDEX idx_ai_policy_id
+  ON action_invocations(policy_id);
+
+CREATE INDEX idx_ai_org_policy_id
+  ON action_invocations(org_policy_id);
+
+CREATE INDEX idx_ai_user_override_id
+  ON action_invocations(user_override_id);

--- a/packages/worker/src/durable-objects/session-agent.ts
+++ b/packages/worker/src/durable-objects/session-agent.ts
@@ -31,6 +31,7 @@ import { handleSkillAction } from '../services/session-skills.js';
 import { handlePersonaAction, listPersonasForRunner } from '../services/session-personas.js';
 import { spawnChild, sendSessionMessage, getSessionMessages, forwardMessages, terminateChild, listChildSessions, getSessionStatus, listChannels } from '../services/session-cross.js';
 import { listTools as listToolsSvc, resolveActionPolicy, executeAction as executeActionSvc, type CredentialCache } from '../services/session-tools.js';
+import { loadCustomMcpConnectorContext } from '../services/custom-mcp-connectors.js';
 import {
   workflowList as workflowListSvc,
   workflowSync as workflowSyncSvc,
@@ -6075,10 +6076,12 @@ export class SessionAgentDO {
         return;
       }
 
+      const orgId = await this.resolveOrgId() ?? 'default';
       const result = await listToolsSvc(this.appDb, this.env.DB, this.env, userId, {
         service,
         query,
         credentialCache: this.credentialCacheAdapter,
+        orgId,
       });
 
       // Update DO-level caches from service result
@@ -6148,12 +6151,14 @@ export class SessionAgentDO {
         return;
       }
 
+      const orgId = await this.resolveOrgId() ?? 'default';
       // Resolve policy (validates toolId, checks disabled status, resolves risk level)
       const policyResult = await resolveActionPolicy(this.appDb, this.env.DB, this.env, userId, toolId, params, {
         sessionId: sessionId || '',
         discoveredToolRiskLevels: this.discoveredToolRiskLevels,
         credentialCache: this.credentialCacheAdapter,
         disabledPluginServicesCache: this.disabledPluginServicesCache,
+        orgId,
       });
 
       // Update the disabled plugin services cache from the policy resolution
@@ -6278,7 +6283,7 @@ export class SessionAgentDO {
       }
 
       // ─── Allow — execute immediately ───────────────────────────────────
-      await this.executeActionAndSend(requestId, toolId, service, actionId, params, userId, actionSource, invocationId);
+      await this.executeActionAndSend(requestId, toolId, service, actionId, params, userId, actionSource, invocationId, orgId);
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
       if (shouldFailInvocationOnCatch && invocationIdForCleanup) {
@@ -6310,6 +6315,7 @@ export class SessionAgentDO {
     userId: string,
     actionSource: ReturnType<typeof integrationRegistry.getActions>,
     invocationId: string,
+    orgId?: string,
   ): Promise<{ success: boolean; error?: string }> {
     const spawnRequest = this.sessionState.spawnRequest;
     const spawnEnvVars = spawnRequest?.envVars as Record<string, string> | undefined;
@@ -6320,7 +6326,7 @@ export class SessionAgentDO {
       result = await executeActionSvc(
         this.appDb, this.env, userId, toolId, service, actionId, params,
         actionSource, invocationId,
-        { credentialCache: this.credentialCacheAdapter, spawnEnvVars, guardConfig },
+        { credentialCache: this.credentialCacheAdapter, spawnEnvVars, guardConfig, orgId: orgId ?? 'default' },
       );
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
@@ -6673,11 +6679,13 @@ export class SessionAgentDO {
           }
         }
 
-        const actionSource = integrationRegistry.getActions(service);
+        const orgId = await this.resolveOrgId() ?? 'default';
+        const customContext = await loadCustomMcpConnectorContext(this.env, this.appDb, orgId);
+        const actionSource = integrationRegistry.getActions(service, customContext);
         let executionResult: { success: boolean; error?: string } = { success: true };
         if (requestId) {
           try {
-            executionResult = await this.executeActionAndSend(requestId, toolId, service, actionId, params, userId, actionSource, promptId);
+            executionResult = await this.executeActionAndSend(requestId, toolId, service, actionId, params, userId, actionSource, promptId, orgId);
           } catch (err) {
             const error = err instanceof Error ? err.message : String(err);
             await markFailed(this.appDb, promptId, error).catch((markErr) => {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -51,6 +51,7 @@ import { avatarsRouter } from './routes/avatars.js';
 import { repoProviderRouter } from './routes/repo-providers.js';
 import { githubMeRouter } from './routes/github-me.js';
 import { githubAuthRouter } from './routes/github-auth.js';
+import { adminMcpConnectorsRouter } from './routes/admin-mcp-connectors.js';
 import {
   enqueueWorkflowApprovalNotificationIfMissing,
   markWorkflowApprovalNotificationsRead,
@@ -197,6 +198,7 @@ app.route('/api', channelsRouter);
 app.route('/api/me/telegram', telegramApiRouter);
 app.route('/api/admin/slack', slackAdminRouter);
 app.route('/api/admin/github', adminGitHubRouter);
+app.route('/api/admin/mcp-connectors', adminMcpConnectorsRouter);
 app.route('/api/admin/action-policies', actionPoliciesRouter);
 app.route('/api/action-policy-overrides', actionPolicyOverridesRouter);
 app.route('/api/admin/disabled-actions', disabledActionsRouter);

--- a/packages/worker/src/integrations/registry.test.ts
+++ b/packages/worker/src/integrations/registry.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import { IntegrationRegistry, type CustomMcpConnectorContext } from './registry.js';
+
+function buildContext(authType: 'none' | 'oauth' | 'api_key' | 'bearer'): CustomMcpConnectorContext {
+  const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body));
+    if (body.method === 'initialize') {
+      return new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        id: body.id,
+        result: {
+          protocolVersion: '2025-11-25',
+          capabilities: {},
+          serverInfo: { name: 'custom-mcp', version: '1.0.0' },
+        },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json', 'mcp-session-id': 'session-1' },
+      });
+    }
+    if (body.method === 'notifications/initialized') {
+      return new Response(null, { status: 202 });
+    }
+    return new Response(JSON.stringify({
+      jsonrpc: '2.0',
+      id: body.id,
+      result: {
+        tools: [{
+          name: 'query',
+          description: 'Query records',
+          inputSchema: { type: 'object' },
+          annotations: { readOnlyHint: true },
+        }],
+      },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  });
+
+  return {
+    orgId: 'default',
+    fetch: fetchMock as unknown as typeof fetch,
+    connectors: new Map([
+      ['salesforce', {
+        id: 'connector-1',
+        orgId: 'default',
+        serviceSlug: 'salesforce',
+        displayName: 'Salesforce',
+        serverUrl: 'https://mcp.salesforce.com/platform/mcp',
+        authType,
+        oauthClientId: authType === 'oauth' ? 'client-id' : null,
+        oauthTokenEndpointAuthMethod: 'none',
+        oauthScopes: 'mcp_api',
+        oauthAuthorizationEndpoint: authType === 'oauth' ? 'https://login.salesforce.com/auth' : null,
+        oauthTokenEndpoint: authType === 'oauth' ? 'https://login.salesforce.com/token' : null,
+        additionalHeaders: { 'X-Tenant': 'acme' },
+        staticAuthHeader: authType === 'api_key' ? { name: 'X-API-Key', value: 'secret' } : undefined,
+      }],
+    ]),
+  };
+}
+
+describe('IntegrationRegistry custom MCP fallback', () => {
+  it('resolves built-in services before custom connector context', () => {
+    const registry = new IntegrationRegistry();
+    registry.init();
+
+    const builtInProvider = registry.getProvider('github');
+    const provider = registry.getProvider('github', {
+      ...buildContext('none'),
+      connectors: new Map([['github', {
+        ...buildContext('none').connectors.get('salesforce')!,
+        serviceSlug: 'github',
+        displayName: 'Custom GitHub',
+      }]]),
+    });
+
+    expect(provider).toBe(builtInProvider);
+    expect(registry.isBuiltinService('github')).toBe(true);
+    expect(registry.isBuiltinService('salesforce')).toBe(false);
+  });
+
+  it('synthesizes provider metadata for custom connectors', () => {
+    const registry = new IntegrationRegistry();
+    registry.init();
+
+    expect(registry.getProvider('salesforce', buildContext('none'))).toMatchObject({
+      service: 'salesforce',
+      displayName: 'Salesforce',
+      authType: 'none',
+      supportedEntities: [],
+      mcpServerUrl: 'https://mcp.salesforce.com/platform/mcp',
+      isCustomConnector: true,
+    });
+    expect(registry.getProvider('salesforce', buildContext('oauth'))).toMatchObject({
+      authType: 'oauth2',
+      oauthScopes: ['mcp_api'],
+    });
+    expect(registry.getProvider('salesforce', buildContext('api_key'))).toMatchObject({
+      authType: 'api_key',
+    });
+  });
+
+  it('builds custom MCP action sources with injected fetch and static auth', async () => {
+    const registry = new IntegrationRegistry();
+    registry.init();
+    const context = buildContext('api_key');
+
+    const actionSource = registry.getActions('salesforce', context);
+    const actions = await actionSource?.listActions();
+
+    expect(actions).toMatchObject([{ id: 'salesforce.query', riskLevel: 'low' }]);
+    const calls = vi.mocked(context.fetch).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const toolsListHeaders = new Headers((calls.at(-1)?.[1] as RequestInit).headers);
+    expect(toolsListHeaders.get('X-API-Key')).toBe('secret');
+    expect(toolsListHeaders.get('X-Tenant')).toBe('acme');
+  });
+});

--- a/packages/worker/src/integrations/registry.ts
+++ b/packages/worker/src/integrations/registry.ts
@@ -4,12 +4,16 @@ import type {
   ActionSource,
   TriggerSource,
 } from '@valet/sdk';
+import { McpActionSource } from '@valet/sdk';
 import type { Env } from '../env.js';
 import type { CredentialResult } from '../services/credentials.js';
+import type { CustomMcpConnectorContext, ResolvedCustomMcpConnector } from '../services/custom-mcp-connectors.js';
 import { installedIntegrations } from './packages.js';
 import { defaultCredentialResolver } from './resolvers/default.js';
 import { slackCredentialResolver } from './resolvers/slack.js';
 import { githubCredentialResolver } from './resolvers/github.js';
+
+export type { CustomMcpConnectorContext } from '../services/custom-mcp-connectors.js';
 
 // ─── Credential Resolver ────────────────────────────────────────────────────
 
@@ -51,12 +55,32 @@ export class IntegrationRegistry {
     return this.packages.get(service);
   }
 
-  getProvider(service: string): IntegrationProvider | undefined {
-    return this.packages.get(service)?.provider;
+  getProvider(service: string, customContext?: CustomMcpConnectorContext): IntegrationProvider | undefined {
+    const builtIn = this.packages.get(service)?.provider;
+    if (builtIn) return builtIn;
+
+    if (!customContext) return undefined;
+
+    const connector = customContext.connectors.get(service);
+    return connector ? buildCustomProvider(connector) : undefined;
   }
 
-  getActions(service: string): ActionSource | undefined {
-    return this.packages.get(service)?.actions;
+  getActions(service: string, customContext?: CustomMcpConnectorContext): ActionSource | undefined {
+    const builtIn = this.packages.get(service)?.actions;
+    if (builtIn) return builtIn;
+
+    if (!customContext) return undefined;
+
+    const connector = customContext.connectors.get(service);
+    if (!connector) return undefined;
+    return new McpActionSource({
+      mcpUrl: connector.serverUrl,
+      serviceName: connector.serviceSlug,
+      noAuth: connector.authType !== 'oauth',
+      additionalHeaders: connector.additionalHeaders,
+      staticAuthHeader: connector.staticAuthHeader,
+      fetch: customContext.fetch,
+    });
   }
 
   getTriggers(service: string): TriggerSource | undefined {
@@ -69,6 +93,10 @@ export class IntegrationRegistry {
 
   listPackages(): IntegrationPackage[] {
     return Array.from(this.packages.values());
+  }
+
+  isBuiltinService(service: string): boolean {
+    return this.packages.has(service);
   }
 
   // ─── Credential Resolution ──────────────────────────────────────────────
@@ -94,3 +122,28 @@ export class IntegrationRegistry {
 
 export const integrationRegistry = new IntegrationRegistry();
 integrationRegistry.init();
+
+function buildCustomProvider(connector: ResolvedCustomMcpConnector): IntegrationProvider {
+  return {
+    service: connector.serviceSlug,
+    displayName: connector.displayName,
+    authType: mapCustomAuthType(connector.authType),
+    supportedEntities: [],
+    oauthScopes: connector.oauthScopes?.split(/\s+/).filter(Boolean) ?? undefined,
+    mcpServerUrl: connector.serverUrl,
+    isCustomConnector: true,
+    validateCredentials(credentials) {
+      if (connector.authType !== 'oauth') return true;
+      return typeof credentials.access_token === 'string' && credentials.access_token.length > 0;
+    },
+    async testConnection() {
+      return true;
+    },
+  };
+}
+
+function mapCustomAuthType(authType: ResolvedCustomMcpConnector['authType']): IntegrationProvider['authType'] {
+  if (authType === 'none') return 'none';
+  if (authType === 'oauth') return 'oauth2';
+  return 'api_key';
+}

--- a/packages/worker/src/lib/db.ts
+++ b/packages/worker/src/lib/db.ts
@@ -36,3 +36,4 @@ export * from './db/channel-threads.js';
 export * from './db/mcp-tool-cache.js';
 export * from './db/service-configs.js';
 export * from './db/github-installations.js';
+export * from './db/custom-mcp-connectors.js';

--- a/packages/worker/src/lib/db/custom-mcp-connectors.test.ts
+++ b/packages/worker/src/lib/db/custom-mcp-connectors.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { createTestDb } from '../../test-utils/db.js';
+import { users } from '../schema/users.js';
+import { customMcpConnectors } from '../schema/custom-mcp-connectors.js';
+import {
+  createConnector,
+  deleteConnector,
+  getConnector,
+  getConnectorBySlug,
+  listActiveConnectors,
+  listConnectors,
+  updateConnector,
+} from './custom-mcp-connectors.js';
+
+describe('custom MCP connector DB helpers', () => {
+  let db: ReturnType<typeof createTestDb>['db'];
+
+  beforeEach(() => {
+    db = createTestDb().db;
+    db.insert(users).values({
+      id: 'admin-1',
+      email: 'admin@example.com',
+      name: 'Admin',
+    }).run();
+  });
+
+  it('creates and redacts connector metadata while preserving non-secret config', async () => {
+    const connector = await createConnector(db, {
+      orgId: 'default',
+      serviceSlug: 'salesforce-mcp',
+      displayName: 'Salesforce MCP',
+      serverUrl: 'https://api.salesforce.com/platform/mcp/v1/platform/sobject-all',
+      authType: 'oauth',
+      oauthClientId: 'client-123',
+      encryptedOauthClientSecret: 'encrypted-secret',
+      oauthTokenEndpointAuthMethod: 'client_secret_basic',
+      oauthScopes: 'mcp_api refresh_token',
+      oauthAuthorizationEndpoint: 'https://login.salesforce.com/services/oauth2/authorize',
+      oauthTokenEndpoint: 'https://login.salesforce.com/services/oauth2/token',
+      encryptedApiKey: null,
+      apiKeyHeaderName: null,
+      apiKeyPrefix: null,
+      encryptedAdditionalHeaders: 'encrypted-headers',
+      status: 'active',
+      createdBy: 'admin-1',
+    });
+
+    expect(connector).toMatchObject({
+      orgId: 'default',
+      serviceSlug: 'salesforce-mcp',
+      displayName: 'Salesforce MCP',
+      authType: 'oauth',
+      oauthClientId: 'client-123',
+      oauthTokenEndpointAuthMethod: 'client_secret_basic',
+      hasClientSecret: true,
+      hasApiKey: false,
+      hasAdditionalHeaders: true,
+      createdBy: 'admin-1',
+    });
+    expect('encryptedOauthClientSecret' in connector).toBe(false);
+    expect('encryptedAdditionalHeaders' in connector).toBe(false);
+  });
+
+  it('lists active connectors by org and resolves by slug', async () => {
+    await createConnector(db, {
+      orgId: 'default',
+      serviceSlug: 'active-one',
+      displayName: 'Active One',
+      serverUrl: 'https://mcp.example.com',
+      authType: 'none',
+      status: 'active',
+      createdBy: null,
+    });
+    await createConnector(db, {
+      orgId: 'default',
+      serviceSlug: 'disabled-one',
+      displayName: 'Disabled One',
+      serverUrl: 'https://disabled.example.com',
+      authType: 'none',
+      status: 'disabled',
+      createdBy: null,
+    });
+    await createConnector(db, {
+      orgId: 'other-org',
+      serviceSlug: 'other-org-one',
+      displayName: 'Other Org',
+      serverUrl: 'https://other.example.com',
+      authType: 'none',
+      status: 'active',
+      createdBy: null,
+    });
+
+    const allDefault = await listConnectors(db, 'default');
+    expect(allDefault.map((c) => c.serviceSlug).sort()).toEqual(['active-one', 'disabled-one']);
+
+    const activeDefault = await listActiveConnectors(db, 'default');
+    expect(activeDefault.map((c) => c.serviceSlug)).toEqual(['active-one']);
+
+    const bySlug = await getConnectorBySlug(db, 'active-one');
+    expect(bySlug?.displayName).toBe('Active One');
+  });
+
+  it('updates connector fields without exposing encrypted values', async () => {
+    const created = await createConnector(db, {
+      orgId: 'default',
+      serviceSlug: 'configurable',
+      displayName: 'Configurable',
+      serverUrl: 'https://mcp.example.com',
+      authType: 'api_key',
+      encryptedApiKey: 'old-key',
+      apiKeyHeaderName: 'X-API-Key',
+      apiKeyPrefix: '',
+      status: 'active',
+      createdBy: null,
+    });
+
+    const updated = await updateConnector(db, created.id, {
+      displayName: 'Updated',
+      encryptedApiKey: 'new-key',
+      encryptedAdditionalHeaders: 'encrypted-headers',
+      status: 'disabled',
+    });
+
+    expect(updated?.displayName).toBe('Updated');
+    expect(updated?.status).toBe('disabled');
+    expect(updated?.hasApiKey).toBe(true);
+    expect(updated?.hasAdditionalHeaders).toBe(true);
+    expect('encryptedApiKey' in updated!).toBe(false);
+
+    const row = db.select().from(customMcpConnectors).where(eq(customMcpConnectors.id, created.id)).get();
+    expect(row?.encryptedApiKey).toBe('new-key');
+  });
+
+  it('deletes connector rows without touching service cleanup tables', async () => {
+    const created = await createConnector(db, {
+      orgId: 'default',
+      serviceSlug: 'delete-me',
+      displayName: 'Delete Me',
+      serverUrl: 'https://mcp.example.com',
+      authType: 'none',
+      status: 'active',
+      createdBy: null,
+    });
+
+    await deleteConnector(db, created.id);
+
+    await expect(getConnector(db, created.id)).resolves.toBeNull();
+    await expect(getConnectorBySlug(db, 'delete-me')).resolves.toBeNull();
+  });
+
+  it('keeps createdBy nullable when admin user is deleted', async () => {
+    const created = await createConnector(db, {
+      orgId: 'default',
+      serviceSlug: 'admin-owned',
+      displayName: 'Admin Owned',
+      serverUrl: 'https://mcp.example.com',
+      authType: 'none',
+      status: 'active',
+      createdBy: 'admin-1',
+    });
+
+    db.delete(users).where(eq(users.id, 'admin-1')).run();
+
+    const connector = await getConnector(db, created.id);
+    expect(connector?.createdBy).toBeNull();
+  });
+});

--- a/packages/worker/src/lib/db/custom-mcp-connectors.ts
+++ b/packages/worker/src/lib/db/custom-mcp-connectors.ts
@@ -1,0 +1,149 @@
+import type { CustomMcpConnector } from '@valet/shared';
+import { eq, desc, sql } from 'drizzle-orm';
+import type { AppDb } from '../drizzle.js';
+import { toDate } from '../drizzle.js';
+import { customMcpConnectors } from '../schema/index.js';
+
+type ConnectorRow = typeof customMcpConnectors.$inferSelect;
+type ConnectorStatus = CustomMcpConnector['status'];
+type ConnectorAuthType = CustomMcpConnector['authType'];
+type TokenEndpointAuthMethod = CustomMcpConnector['oauthTokenEndpointAuthMethod'];
+
+export interface CreateCustomMcpConnectorData {
+  id?: string;
+  orgId?: string;
+  serviceSlug: string;
+  displayName: string;
+  serverUrl: string;
+  authType: ConnectorAuthType;
+  oauthClientId?: string | null;
+  encryptedOauthClientSecret?: string | null;
+  oauthTokenEndpointAuthMethod?: TokenEndpointAuthMethod;
+  oauthScopes?: string | null;
+  oauthAuthorizationEndpoint?: string | null;
+  oauthTokenEndpoint?: string | null;
+  encryptedApiKey?: string | null;
+  apiKeyHeaderName?: string | null;
+  apiKeyPrefix?: string | null;
+  encryptedAdditionalHeaders?: string | null;
+  status?: ConnectorStatus;
+  lastDiscoveredAt?: string | null;
+  lastError?: string | null;
+  createdBy?: string | null;
+}
+
+export type UpdateCustomMcpConnectorData = Partial<Omit<CreateCustomMcpConnectorData, 'id' | 'orgId' | 'serviceSlug' | 'createdBy'>> & {
+  orgId?: string;
+  createdBy?: string | null;
+};
+
+function rowToConnector(row: ConnectorRow): CustomMcpConnector {
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    serviceSlug: row.serviceSlug,
+    displayName: row.displayName,
+    serverUrl: row.serverUrl,
+    authType: row.authType,
+    oauthClientId: row.oauthClientId,
+    oauthTokenEndpointAuthMethod: row.oauthTokenEndpointAuthMethod,
+    oauthScopes: row.oauthScopes,
+    oauthAuthorizationEndpoint: row.oauthAuthorizationEndpoint,
+    oauthTokenEndpoint: row.oauthTokenEndpoint,
+    apiKeyHeaderName: row.apiKeyHeaderName,
+    apiKeyPrefix: row.apiKeyPrefix,
+    status: row.status,
+    lastDiscoveredAt: row.lastDiscoveredAt,
+    lastError: row.lastError,
+    createdBy: row.createdBy,
+    createdAt: toDate(row.createdAt),
+    updatedAt: toDate(row.updatedAt),
+    hasClientSecret: !!row.encryptedOauthClientSecret,
+    hasApiKey: !!row.encryptedApiKey,
+    hasAdditionalHeaders: !!row.encryptedAdditionalHeaders,
+  };
+}
+
+export async function listConnectors(db: AppDb, orgId = 'default'): Promise<CustomMcpConnector[]> {
+  const rows = await db
+    .select()
+    .from(customMcpConnectors)
+    .where(eq(customMcpConnectors.orgId, orgId))
+    .orderBy(desc(customMcpConnectors.createdAt));
+
+  return rows.map(rowToConnector);
+}
+
+export async function listActiveConnectors(db: AppDb, orgId = 'default'): Promise<CustomMcpConnector[]> {
+  const rows = await db
+    .select()
+    .from(customMcpConnectors)
+    .where(sql`${customMcpConnectors.orgId} = ${orgId} AND ${customMcpConnectors.status} = 'active'`)
+    .orderBy(desc(customMcpConnectors.createdAt));
+
+  return rows.map(rowToConnector);
+}
+
+export async function getConnector(db: AppDb, id: string): Promise<CustomMcpConnector | null> {
+  const row = await db.select().from(customMcpConnectors).where(eq(customMcpConnectors.id, id)).get();
+  return row ? rowToConnector(row) : null;
+}
+
+export async function getConnectorBySlug(db: AppDb, slug: string): Promise<CustomMcpConnector | null> {
+  const row = await db.select().from(customMcpConnectors).where(eq(customMcpConnectors.serviceSlug, slug)).get();
+  return row ? rowToConnector(row) : null;
+}
+
+export async function createConnector(
+  db: AppDb,
+  data: CreateCustomMcpConnectorData,
+): Promise<CustomMcpConnector> {
+  const id = data.id ?? crypto.randomUUID();
+
+  await db.insert(customMcpConnectors).values({
+    id,
+    orgId: data.orgId ?? 'default',
+    serviceSlug: data.serviceSlug,
+    displayName: data.displayName,
+    serverUrl: data.serverUrl,
+    authType: data.authType,
+    oauthClientId: data.oauthClientId ?? null,
+    encryptedOauthClientSecret: data.encryptedOauthClientSecret ?? null,
+    oauthTokenEndpointAuthMethod: data.oauthTokenEndpointAuthMethod ?? 'none',
+    oauthScopes: data.oauthScopes ?? null,
+    oauthAuthorizationEndpoint: data.oauthAuthorizationEndpoint ?? null,
+    oauthTokenEndpoint: data.oauthTokenEndpoint ?? null,
+    encryptedApiKey: data.encryptedApiKey ?? null,
+    apiKeyHeaderName: data.apiKeyHeaderName ?? null,
+    apiKeyPrefix: data.apiKeyPrefix ?? null,
+    encryptedAdditionalHeaders: data.encryptedAdditionalHeaders ?? null,
+    status: data.status ?? 'active',
+    lastDiscoveredAt: data.lastDiscoveredAt ?? null,
+    lastError: data.lastError ?? null,
+    createdBy: data.createdBy ?? null,
+  });
+
+  const connector = await getConnector(db, id);
+  if (!connector) throw new Error(`Failed to create custom MCP connector ${id}`);
+  return connector;
+}
+
+export async function updateConnector(
+  db: AppDb,
+  id: string,
+  data: UpdateCustomMcpConnectorData,
+): Promise<CustomMcpConnector | null> {
+  await db
+    .update(customMcpConnectors)
+    .set({
+      ...data,
+      updatedAt: sql`datetime('now')`,
+    })
+    .where(eq(customMcpConnectors.id, id));
+
+  return getConnector(db, id);
+}
+
+export async function deleteConnector(db: AppDb, id: string): Promise<void> {
+  await db.delete(customMcpConnectors).where(eq(customMcpConnectors.id, id));
+}

--- a/packages/worker/src/lib/db/integrations.ts
+++ b/packages/worker/src/lib/db/integrations.ts
@@ -99,6 +99,30 @@ export async function updateIntegrationStatus(
     .where(eq(integrations.id, id));
 }
 
+export async function updateIntegration(
+  db: AppDb,
+  id: string,
+  updates: {
+    config?: Integration['config'];
+    status?: Integration['status'];
+    errorMessage?: string | null;
+  },
+): Promise<Integration | null> {
+  const setValues: Record<string, unknown> = {
+    updatedAt: sql`datetime('now')`,
+  };
+  if (updates.config !== undefined) setValues.config = updates.config;
+  if (updates.status !== undefined) setValues.status = updates.status;
+  if (updates.errorMessage !== undefined) setValues.errorMessage = updates.errorMessage;
+
+  await db
+    .update(integrations)
+    .set(setValues)
+    .where(eq(integrations.id, id));
+
+  return getIntegration(db, id);
+}
+
 export async function deleteIntegration(db: AppDb, id: string): Promise<void> {
   await db.delete(integrations).where(eq(integrations.id, id));
 }

--- a/packages/worker/src/lib/schema/custom-mcp-connectors.ts
+++ b/packages/worker/src/lib/schema/custom-mcp-connectors.ts
@@ -1,0 +1,37 @@
+import { sql } from 'drizzle-orm';
+import { index, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { users } from './users.js';
+
+export const customMcpConnectors = sqliteTable('custom_mcp_connectors', {
+  id: text().primaryKey(),
+  orgId: text('org_id').notNull().default('default'),
+  serviceSlug: text('service_slug').notNull().unique(),
+  displayName: text('display_name').notNull(),
+  serverUrl: text('server_url').notNull(),
+  authType: text('auth_type').notNull().default('none').$type<'none' | 'oauth' | 'api_key' | 'bearer'>(),
+
+  oauthClientId: text('oauth_client_id'),
+  encryptedOauthClientSecret: text('encrypted_oauth_client_secret'),
+  oauthTokenEndpointAuthMethod: text('oauth_token_endpoint_auth_method')
+    .notNull()
+    .default('none')
+    .$type<'none' | 'client_secret_basic' | 'client_secret_post'>(),
+  oauthScopes: text('oauth_scopes'),
+  oauthAuthorizationEndpoint: text('oauth_authorization_endpoint'),
+  oauthTokenEndpoint: text('oauth_token_endpoint'),
+
+  encryptedApiKey: text('encrypted_api_key'),
+  apiKeyHeaderName: text('api_key_header_name').default('Authorization'),
+  apiKeyPrefix: text('api_key_prefix').default('Bearer'),
+
+  encryptedAdditionalHeaders: text('encrypted_additional_headers'),
+
+  status: text().notNull().default('active').$type<'active' | 'disabled' | 'error'>(),
+  lastDiscoveredAt: text('last_discovered_at'),
+  lastError: text('last_error'),
+  createdBy: text('created_by').references(() => users.id, { onDelete: 'set null' }),
+  createdAt: text('created_at').notNull().default(sql`(datetime('now'))`),
+  updatedAt: text('updated_at').notNull().default(sql`(datetime('now'))`),
+}, (table) => [
+  index('idx_custom_mcp_connectors_org_status').on(table.orgId, table.status),
+]);

--- a/packages/worker/src/lib/schema/index.ts
+++ b/packages/worker/src/lib/schema/index.ts
@@ -25,3 +25,4 @@ export * from './channel-threads.js';
 export * from './mcp-tool-cache.js';
 export * from './service-configs.js';
 export * from './github-installations.js';
+export * from './custom-mcp-connectors.js';

--- a/packages/worker/src/routes/admin-mcp-connectors.test.ts
+++ b/packages/worker/src/routes/admin-mcp-connectors.test.ts
@@ -1,0 +1,339 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { D1Database } from '@cloudflare/workers-types';
+import { eq } from 'drizzle-orm';
+import type { CustomMcpConnector } from '@valet/shared';
+import type { Env, Variables } from '../env.js';
+import type { AppDb } from '../lib/drizzle.js';
+import { errorHandler } from '../middleware/error-handler.js';
+import { createTestDb } from '../test-utils/db.js';
+import { users } from '../lib/schema/users.js';
+import {
+  actionPolicies,
+  credentials,
+  customMcpConnectors,
+  disabledActions,
+  integrations,
+  mcpToolCache,
+  userActionPolicyOverrides,
+} from '../lib/schema/index.js';
+import { adminMcpConnectorsRouter } from './admin-mcp-connectors.js';
+
+const ADMIN_ID = 'admin-user';
+const ENCRYPTION_KEY = 'test-encryption-key';
+
+type TestBatchStatement = {
+  run: () => Promise<unknown>;
+  runSync: () => void;
+};
+
+type RedactedConnector = CustomMcpConnector & {
+  apiKey?: unknown;
+  additionalHeaders?: unknown;
+};
+type ConnectorResponse = { connector: RedactedConnector };
+type ConnectorListResponse = { connectors: RedactedConnector[] };
+
+async function readJson<T>(response: Response): Promise<T> {
+  return await response.json() as T;
+}
+
+function makeD1Batch(
+  sqlite: ReturnType<typeof createTestDb>['sqlite'],
+  options: { failOnSql?: string } = {},
+): D1Database {
+  return {
+    prepare: vi.fn((sql: string) => ({
+      bind: vi.fn((...params: unknown[]) => ({
+        runSync: () => {
+          if (options.failOnSql && sql.includes(options.failOnSql)) {
+            throw new Error(`Simulated D1 batch failure for ${options.failOnSql}`);
+          }
+          sqlite.prepare(sql).run(...params);
+        },
+        run: vi.fn(function run(this: TestBatchStatement) {
+          this.runSync();
+          return Promise.resolve({ success: true });
+        }),
+      })),
+    })),
+    batch: vi.fn(async (statements: Array<TestBatchStatement>) => {
+      const runBatch = sqlite.transaction((batchStatements: TestBatchStatement[]) => {
+        for (const statement of batchStatements) {
+          statement.runSync();
+        }
+      });
+      runBatch(statements);
+      return [];
+    }),
+  } as unknown as D1Database;
+}
+
+function buildApp(
+  db: AppDb,
+  role: 'admin' | 'member' = 'admin',
+) {
+  const app = new Hono<{ Bindings: Env; Variables: Variables }>();
+  app.onError(errorHandler);
+  app.use('*', async (c, next) => {
+    c.set('user', { id: ADMIN_ID, email: 'admin@example.com', role });
+    c.set('db', db);
+    c.set('requestId', 'req-admin-mcp-connectors');
+    await next();
+  });
+  app.route('/', adminMcpConnectorsRouter);
+  return app;
+}
+
+function jsonRequest(path: string, method: string, body: unknown) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('adminMcpConnectorsRouter', () => {
+  let db: ReturnType<typeof createTestDb>['db'];
+  let sqlite: ReturnType<typeof createTestDb>['sqlite'];
+  let app: ReturnType<typeof buildApp>;
+  let env: Env;
+
+  beforeEach(() => {
+    ({ db, sqlite } = createTestDb());
+    db.insert(users).values({ id: ADMIN_ID, email: 'admin@example.com' }).run();
+    app = buildApp(db);
+    env = {
+      DB: makeD1Batch(sqlite),
+      ENCRYPTION_KEY,
+    } as Env;
+  });
+
+  it('creates connectors and lists redacted summaries with tool counts', async () => {
+    const createRes = await app.fetch(jsonRequest('/', 'POST', {
+      displayName: 'Linear Custom MCP',
+      serverUrl: 'https://mcp.linear.example.com/sse',
+      authType: 'api_key',
+      apiKey: 'linear-secret',
+      apiKeyHeaderName: 'X-Linear-Key',
+      apiKeyPrefix: 'Token',
+      additionalHeaders: { 'X-Tenant': 'acme' },
+    }), env);
+
+    expect(createRes.status).toBe(201);
+    const created = await readJson<ConnectorResponse>(createRes);
+    expect(created.connector).toMatchObject({
+      orgId: 'default',
+      serviceSlug: 'linear-custom-mcp',
+      displayName: 'Linear Custom MCP',
+      authType: 'api_key',
+      hasApiKey: true,
+      hasAdditionalHeaders: true,
+      createdBy: ADMIN_ID,
+    });
+    expect(created.connector.apiKey).toBeUndefined();
+    expect(created.connector.additionalHeaders).toBeUndefined();
+
+    db.insert(mcpToolCache).values([
+      { service: 'linear-custom-mcp', actionId: 'issue.create', name: 'Create issue', description: '', riskLevel: 'medium' },
+      { service: 'linear-custom-mcp', actionId: 'issue.read', name: 'Read issue', description: '', riskLevel: 'low' },
+    ]).run();
+
+    const listRes = await app.fetch(new Request('http://localhost/'), env);
+
+    expect(listRes.status).toBe(200);
+    const list = await readJson<ConnectorListResponse>(listRes);
+    expect(list.connectors).toHaveLength(1);
+    expect(list.connectors[0]).toMatchObject({
+      serviceSlug: 'linear-custom-mcp',
+      toolCount: 2,
+      hasApiKey: true,
+      hasAdditionalHeaders: true,
+    });
+    expect(list.connectors[0].apiKey).toBeUndefined();
+    expect(list.connectors[0].additionalHeaders).toBeUndefined();
+  });
+
+  it('updates OAuth connectors while preserving and clearing client secrets explicitly', async () => {
+    const createRes = await app.fetch(jsonRequest('/', 'POST', {
+      displayName: 'OAuth MCP',
+      serverUrl: 'https://oauth.example.com/mcp',
+      authType: 'oauth',
+      oauthClientId: 'client-id',
+      oauthClientSecret: 'client-secret',
+      oauthTokenEndpointAuthMethod: 'client_secret_basic',
+      oauthAuthorizationEndpoint: 'https://oauth.example.com/authorize',
+      oauthTokenEndpoint: 'https://oauth.example.com/token',
+    }), env);
+    const created = await readJson<ConnectorResponse>(createRes);
+
+    const preserveRes = await app.fetch(jsonRequest(`/${created.connector.id}`, 'PUT', {
+      displayName: 'OAuth MCP Renamed',
+      authType: 'oauth',
+    }), env);
+
+    expect(preserveRes.status).toBe(200);
+    expect((await readJson<ConnectorResponse>(preserveRes)).connector).toMatchObject({
+      displayName: 'OAuth MCP Renamed',
+      serviceSlug: 'oauth-mcp',
+      hasClientSecret: true,
+    });
+
+    const clearRes = await app.fetch(jsonRequest(`/${created.connector.id}`, 'PUT', {
+      authType: 'oauth',
+      clearClientSecret: true,
+    }), env);
+
+    expect(clearRes.status).toBe(200);
+    expect((await readJson<ConnectorResponse>(clearRes)).connector).toMatchObject({
+      serviceSlug: 'oauth-mcp',
+      hasClientSecret: false,
+    });
+  });
+
+  it('rejects update requests that try to change the service slug', async () => {
+    const createRes = await app.fetch(jsonRequest('/', 'POST', {
+      displayName: 'Slug Guard MCP',
+      serverUrl: 'https://slug.example.com/mcp',
+      authType: 'none',
+    }), env);
+    const created = await readJson<ConnectorResponse>(createRes);
+
+    const res = await app.fetch(jsonRequest(`/${created.connector.id}`, 'PUT', {
+      authType: 'none',
+      serviceSlug: 'new-slug',
+    }), env);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      code: 'VALIDATION_ERROR',
+      error: expect.stringMatching(/service slug/i),
+    });
+  });
+
+  it('deletes connectors and their owned runtime state', async () => {
+    db.insert(users).values({ id: 'user-1', email: 'user@example.com' }).run();
+    const createRes = await app.fetch(jsonRequest('/', 'POST', {
+      displayName: 'Delete MCP',
+      serverUrl: 'https://delete.example.com/mcp',
+      authType: 'none',
+    }), env);
+    const created = await readJson<ConnectorResponse>(createRes);
+
+    db.insert(integrations).values({
+      id: 'integration-1',
+      userId: 'user-1',
+      service: created.connector.serviceSlug,
+      config: { entities: [] },
+      status: 'active',
+    }).run();
+    db.insert(credentials).values({
+      id: 'credential-1',
+      ownerType: 'user',
+      ownerId: 'user-1',
+      provider: created.connector.serviceSlug,
+      credentialType: 'oauth2',
+      encryptedData: 'encrypted',
+    }).run();
+    db.insert(mcpToolCache).values({
+      service: created.connector.serviceSlug,
+      actionId: 'tool',
+      name: 'Tool',
+      description: '',
+      riskLevel: 'low',
+    }).run();
+    db.insert(disabledActions).values({
+      id: 'disabled-1',
+      service: created.connector.serviceSlug,
+      actionId: null,
+      disabledBy: 'user-1',
+    }).run();
+    db.insert(actionPolicies).values({
+      id: 'policy-1',
+      service: created.connector.serviceSlug,
+      actionId: null,
+      riskLevel: null,
+      mode: 'deny',
+      createdBy: 'user-1',
+    }).run();
+    db.insert(userActionPolicyOverrides).values({
+      id: 'override-1',
+      userId: 'user-1',
+      service: created.connector.serviceSlug,
+      actionId: null,
+      riskLevel: null,
+      mode: 'allow',
+    }).run();
+
+    const res = await app.fetch(new Request(`http://localhost/${created.connector.id}`, { method: 'DELETE' }), env);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(db.select().from(customMcpConnectors).where(eq(customMcpConnectors.id, created.connector.id)).all()).toEqual([]);
+    expect(db.select().from(integrations).all()).toEqual([]);
+    expect(db.select().from(credentials).all()).toEqual([]);
+    expect(db.select().from(mcpToolCache).all()).toEqual([]);
+    expect(db.select().from(disabledActions).all()).toEqual([]);
+    expect(db.select().from(actionPolicies).all()).toEqual([]);
+    expect(db.select().from(userActionPolicyOverrides).all()).toEqual([]);
+  });
+
+  it('keeps owned runtime state intact when cascade batch fails', async () => {
+    db.insert(users).values({ id: 'user-1', email: 'user@example.com' }).run();
+    const createRes = await app.fetch(jsonRequest('/', 'POST', {
+      displayName: 'Rollback MCP',
+      serverUrl: 'https://rollback.example.com/mcp',
+      authType: 'none',
+    }), env);
+    const created = await readJson<ConnectorResponse>(createRes);
+    const service = created.connector.serviceSlug;
+
+    db.insert(integrations).values({
+      id: 'integration-1',
+      userId: 'user-1',
+      service,
+      config: { entities: [] },
+      status: 'active',
+    }).run();
+    db.insert(credentials).values({
+      id: 'credential-1',
+      ownerType: 'user',
+      ownerId: 'user-1',
+      provider: service,
+      credentialType: 'oauth2',
+      encryptedData: 'encrypted',
+    }).run();
+    db.insert(mcpToolCache).values({
+      service,
+      actionId: 'tool',
+      name: 'Tool',
+      description: '',
+      riskLevel: 'low',
+    }).run();
+
+    env = {
+      ...env,
+      DB: makeD1Batch(sqlite, { failOnSql: 'DELETE FROM credentials' }),
+    };
+
+    const res = await app.fetch(new Request(`http://localhost/${created.connector.id}`, { method: 'DELETE' }), env);
+
+    expect(res.status).toBe(500);
+    expect(db.select().from(customMcpConnectors).where(eq(customMcpConnectors.id, created.connector.id)).all()).toHaveLength(1);
+    expect(db.select().from(integrations).where(eq(integrations.service, service)).all()).toHaveLength(1);
+    expect(db.select().from(credentials).where(eq(credentials.provider, service)).all()).toHaveLength(1);
+    expect(db.select().from(mcpToolCache).where(eq(mcpToolCache.service, service)).all()).toHaveLength(1);
+  });
+
+  it('requires an admin user', async () => {
+    const memberApp = buildApp(db, 'member');
+
+    const res = await memberApp.fetch(new Request('http://localhost/'), env);
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({
+      code: 'FORBIDDEN',
+      error: 'Admin access required',
+    });
+  });
+});

--- a/packages/worker/src/routes/admin-mcp-connectors.ts
+++ b/packages/worker/src/routes/admin-mcp-connectors.ts
@@ -46,7 +46,7 @@ const createConnectorSchema = z.object({
 const updateConnectorSchema = z.object({
   displayName: z.string().trim().min(1).optional(),
   serverUrl: z.string().trim().min(1).optional(),
-  authType: authTypeSchema,
+  authType: authTypeSchema.optional(),
   oauthClientId: z.string().trim().min(1).nullable().optional(),
   oauthClientSecret: z.string().optional(),
   clearClientSecret: z.boolean().optional(),

--- a/packages/worker/src/routes/admin-mcp-connectors.ts
+++ b/packages/worker/src/routes/admin-mcp-connectors.ts
@@ -1,0 +1,143 @@
+import { Hono, type Context } from 'hono';
+import { z, type ZodType } from 'zod';
+import {
+  NotFoundError,
+  ValidationError,
+  type CreateCustomMcpConnectorRequest,
+  type UpdateCustomMcpConnectorRequest,
+} from '@valet/shared';
+import type { Env, Variables } from '../env.js';
+import { adminMiddleware } from '../middleware/admin.js';
+import {
+  createCustomMcpConnector,
+  deleteCustomMcpConnectorCascade,
+  listConnectorSummaries,
+  updateCustomMcpConnector,
+} from '../services/custom-mcp-connectors.js';
+
+type AdminMcpConnectorsContext = Context<{ Bindings: Env; Variables: Variables }>;
+
+const authTypeSchema = z.enum(['none', 'oauth', 'api_key', 'bearer']);
+const tokenEndpointAuthMethodSchema = z.enum([
+  'none',
+  'client_secret_basic',
+  'client_secret_post',
+  'auto',
+]);
+const additionalHeadersSchema = z.record(z.string().min(1), z.string());
+
+const createConnectorSchema = z.object({
+  displayName: z.string().trim().min(1),
+  serverUrl: z.string().trim().min(1),
+  authType: authTypeSchema,
+  oauthClientId: z.string().trim().min(1).nullable().optional(),
+  oauthClientSecret: z.string().optional(),
+  oauthTokenEndpointAuthMethod: tokenEndpointAuthMethodSchema.optional(),
+  oauthScopes: z.string().nullable().optional(),
+  oauthAuthorizationEndpoint: z.string().trim().min(1).nullable().optional(),
+  oauthTokenEndpoint: z.string().trim().min(1).nullable().optional(),
+  apiKey: z.string().optional(),
+  apiKeyHeaderName: z.string().trim().min(1).nullable().optional(),
+  apiKeyPrefix: z.string().nullable().optional(),
+  additionalHeaders: additionalHeadersSchema.optional(),
+  status: z.enum(['active', 'disabled']).optional(),
+}).strict() satisfies ZodType<CreateCustomMcpConnectorRequest>;
+
+const updateConnectorSchema = z.object({
+  displayName: z.string().trim().min(1).optional(),
+  serverUrl: z.string().trim().min(1).optional(),
+  authType: authTypeSchema,
+  oauthClientId: z.string().trim().min(1).nullable().optional(),
+  oauthClientSecret: z.string().optional(),
+  clearClientSecret: z.boolean().optional(),
+  oauthTokenEndpointAuthMethod: tokenEndpointAuthMethodSchema.optional(),
+  oauthScopes: z.string().nullable().optional(),
+  oauthAuthorizationEndpoint: z.string().trim().min(1).nullable().optional(),
+  oauthTokenEndpoint: z.string().trim().min(1).nullable().optional(),
+  apiKey: z.string().optional(),
+  apiKeyHeaderName: z.string().trim().min(1).nullable().optional(),
+  apiKeyPrefix: z.string().nullable().optional(),
+  additionalHeaders: additionalHeadersSchema.optional(),
+  clearAdditionalHeaders: z.boolean().optional(),
+  status: z.enum(['active', 'disabled', 'error']).optional(),
+}).strict() satisfies ZodType<UpdateCustomMcpConnectorRequest>;
+
+export const adminMcpConnectorsRouter = new Hono<{ Bindings: Env; Variables: Variables }>();
+adminMcpConnectorsRouter.use('*', adminMiddleware);
+
+/**
+ * GET /api/admin/mcp-connectors
+ * List custom MCP connector summaries with secret fields redacted.
+ */
+adminMcpConnectorsRouter.get('/', async (c) => {
+  const connectors = await listConnectorSummaries(c.get('db'), 'default');
+  return c.json({ connectors });
+});
+
+/**
+ * POST /api/admin/mcp-connectors
+ * Create a custom MCP connector owned by the current admin.
+ */
+adminMcpConnectorsRouter.post('/', async (c) => {
+  const body = await parseJsonBody(c, createConnectorSchema);
+  const user = c.get('user');
+  const connector = await createCustomMcpConnector(c.env, c.get('db'), body, {
+    orgId: 'default',
+    createdBy: user.id,
+  });
+
+  return c.json({ connector }, 201);
+});
+
+/**
+ * PUT /api/admin/mcp-connectors/:id
+ * Update mutable connector metadata and credentials. Service slugs are immutable.
+ */
+adminMcpConnectorsRouter.put('/:id', async (c) => {
+  const { id } = c.req.param();
+  const body = await parseJsonBody(c, updateConnectorSchema, { rejectServiceSlugChange: true });
+  const connector = await updateCustomMcpConnector(c.env, c.get('db'), id, body);
+  if (!connector) throw new NotFoundError('Custom MCP connector', id);
+  return c.json({ connector });
+});
+
+/**
+ * DELETE /api/admin/mcp-connectors/:id
+ * Delete a connector and connector-owned runtime state.
+ */
+adminMcpConnectorsRouter.delete('/:id', async (c) => {
+  const { id } = c.req.param();
+  await deleteCustomMcpConnectorCascade(c.env.DB, c.get('db'), id);
+  return c.json({ ok: true });
+});
+
+async function parseJsonBody<T>(
+  c: AdminMcpConnectorsContext,
+  schema: ZodType<T>,
+  options: { rejectServiceSlugChange?: boolean } = {},
+): Promise<T> {
+  let raw: unknown;
+  try {
+    raw = await c.req.json();
+  } catch {
+    throw new ValidationError('Invalid JSON body');
+  }
+
+  if (options.rejectServiceSlugChange && isRecord(raw) && 'serviceSlug' in raw) {
+    throw new ValidationError('Custom MCP connector service slug cannot be changed.');
+  }
+
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    throw new ValidationError(
+      parsed.error.issues[0]?.message ?? 'Invalid custom MCP connector request',
+      parsed.error.flatten(),
+    );
+  }
+
+  return parsed.data;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/worker/src/routes/integrations.test.ts
+++ b/packages/worker/src/routes/integrations.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { Env, Variables } from '../env.js';
+import { errorHandler } from '../middleware/error-handler.js';
+import { createTestDb } from '../test-utils/db.js';
+import { users } from '../lib/schema/users.js';
+import { integrations, mcpToolCache } from '../lib/schema/index.js';
+import { createCustomMcpConnector } from '../services/custom-mcp-connectors.js';
+import { integrationsRouter } from './integrations.js';
+import type { AppDb } from '../lib/drizzle.js';
+
+const holder = vi.hoisted(() => ({
+  db: null as AppDb | null,
+}));
+
+vi.mock('../lib/drizzle.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/drizzle.js')>();
+  return {
+    ...actual,
+    getDb: vi.fn(() => holder.db),
+  };
+});
+
+const USER_ID = 'user-1';
+const ENCRYPTION_KEY = 'test-encryption-key';
+
+function buildApp(db: AppDb) {
+  const app = new Hono<{ Bindings: Env; Variables: Variables }>();
+  app.onError(errorHandler);
+  app.use('*', async (c, next) => {
+    c.set('user', { id: USER_ID, email: 'user@example.com', role: 'member' });
+    c.set('db', db);
+    c.set('requestId', 'req-integrations-test');
+    await next();
+  });
+  app.route('/', integrationsRouter);
+  return app;
+}
+
+function makeEnv(): Env {
+  return {
+    DB: {
+      prepare: vi.fn(() => ({
+        bind: vi.fn(() => ({
+          all: vi.fn(async () => ({ results: [] })),
+        })),
+      })),
+    } as unknown as D1Database,
+    ENCRYPTION_KEY,
+  } as Env;
+}
+
+describe('integrationsRouter custom MCP OAuth', () => {
+  let db: AppDb;
+  let app: ReturnType<typeof buildApp>;
+  let env: Env;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    const testDb = createTestDb();
+    db = testDb.db;
+    holder.db = db;
+    db.insert(users).values({ id: USER_ID, email: 'user@example.com' }).run();
+    env = makeEnv();
+    app = buildApp(db);
+
+    await createCustomMcpConnector(env, db, {
+      displayName: 'Salesforce MCP',
+      serverUrl: 'https://mcp.salesforce.example.com/platform/mcp',
+      authType: 'oauth',
+      oauthClientId: 'sf-client-id',
+      oauthClientSecret: 'sf-client-secret',
+      oauthTokenEndpointAuthMethod: 'client_secret_basic',
+      oauthScopes: 'mcp_api refresh_token',
+      oauthAuthorizationEndpoint: 'https://login.salesforce.example.com/services/oauth2/authorize',
+      oauthTokenEndpoint: 'https://login.salesforce.example.com/services/oauth2/token',
+    }, { orgId: 'default', createdBy: null });
+  });
+
+  it('starts custom OAuth from stored endpoints and includes the MCP resource', async () => {
+    const res = await app.fetch(new Request(
+      'http://localhost/salesforce-mcp/oauth?redirect_uri=https%3A%2F%2Fapp.example.com%2Fintegrations%2Fcallback',
+    ), env);
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { url: string; state: string; code_verifier: string };
+    const url = new URL(body.url);
+    expect(url.origin + url.pathname).toBe('https://login.salesforce.example.com/services/oauth2/authorize');
+    expect(url.searchParams.get('client_id')).toBe('sf-client-id');
+    expect(url.searchParams.get('resource')).toBe('https://mcp.salesforce.example.com/platform/mcp');
+    expect(url.searchParams.get('scope')).toBe('mcp_api refresh_token');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(body.code_verifier).toBeTruthy();
+  });
+
+  it('lists custom OAuth connectors as available services and uses cached display names for actions', async () => {
+    db.insert(mcpToolCache).values({
+      service: 'salesforce-mcp',
+      actionId: 'salesforce.query',
+      name: 'Query',
+      description: 'Query records',
+      riskLevel: 'low',
+    }).run();
+
+    const availableRes = await app.fetch(new Request('http://localhost/available'), env);
+    const actionsRes = await app.fetch(new Request('http://localhost/actions'), env);
+
+    expect(availableRes.status).toBe(200);
+    await expect(availableRes.json()).resolves.toMatchObject({
+      services: expect.arrayContaining([
+        expect.objectContaining({
+          service: 'salesforce-mcp',
+          displayName: 'Salesforce MCP',
+          authType: 'oauth2',
+          supportedEntities: [],
+          hasActions: true,
+          hasTriggers: false,
+          isCustomConnector: true,
+        }),
+      ]),
+    });
+
+    expect(actionsRes.status).toBe(200);
+    await expect(actionsRes.json()).resolves.toMatchObject({
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          service: 'salesforce-mcp',
+          serviceDisplayName: 'Salesforce MCP',
+          actionId: 'salesforce.query',
+        }),
+      ]),
+    });
+  });
+
+  it('filters deleted custom connector integrations and stale cached actions', async () => {
+    db.insert(integrations).values({
+      id: 'integration-1',
+      userId: USER_ID,
+      service: 'deleted-custom',
+      config: { entities: [] },
+      status: 'active',
+    }).run();
+    db.insert(mcpToolCache).values({
+      service: 'deleted-custom',
+      actionId: 'stale.tool',
+      name: 'Stale',
+      description: '',
+      riskLevel: 'medium',
+    }).run();
+
+    const integrationsRes = await app.fetch(new Request('http://localhost/'), env);
+    const actionsRes = await app.fetch(new Request('http://localhost/actions'), env);
+
+    expect(integrationsRes.status).toBe(200);
+    await expect(integrationsRes.json()).resolves.toMatchObject({ integrations: [] });
+    expect(actionsRes.status).toBe(200);
+    expect((await actionsRes.json() as { actions: Array<{ service: string }> }).actions.some((a) => a.service === 'deleted-custom')).toBe(false);
+  });
+
+  it('exchanges custom OAuth callbacks with stored client credentials and resource', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const form = init?.body as URLSearchParams;
+      expect(form.get('grant_type')).toBe('authorization_code');
+      expect(form.get('client_id')).toBe('sf-client-id');
+      expect(form.get('code')).toBe('auth-code');
+      expect(form.get('code_verifier')).toBe('verifier');
+      expect(form.get('resource')).toBe('https://mcp.salesforce.example.com/platform/mcp');
+      expect(new Headers(init?.headers).get('Authorization')).toBe(`Basic ${btoa('sf-client-id:sf-client-secret')}`);
+      return Response.json({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        expires_in: 3600,
+        token_type: 'bearer',
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await app.fetch(new Request('http://localhost/salesforce-mcp/oauth/callback', {
+      method: 'POST',
+      body: JSON.stringify({
+        code: 'auth-code',
+        redirect_uri: 'https://app.example.com/integrations/callback',
+        code_verifier: 'verifier',
+      }),
+      headers: { 'content-type': 'application/json' },
+    }), env);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      credentials: {
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        expires_in: '3600',
+        token_type: 'bearer',
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('configures custom OAuth integrations through the route after callback exchange', async () => {
+    const res = await app.fetch(new Request('http://localhost/', {
+      method: 'POST',
+      body: JSON.stringify({
+        service: 'salesforce-mcp',
+        credentials: {
+          access_token: 'access-token',
+          refresh_token: 'refresh-token',
+          expires_in: '3600',
+          token_type: 'bearer',
+        },
+        config: { entities: [] },
+      }),
+      headers: { 'content-type': 'application/json' },
+    }), env);
+
+    expect(res.status).toBe(201);
+    await expect(res.json()).resolves.toMatchObject({
+      integration: {
+        service: 'salesforce-mcp',
+        status: 'active',
+      },
+    });
+    expect(db.select().from(integrations).all()).toEqual([
+      expect.objectContaining({
+        service: 'salesforce-mcp',
+        status: 'active',
+      }),
+    ]);
+  });
+});

--- a/packages/worker/src/routes/integrations.ts
+++ b/packages/worker/src/routes/integrations.ts
@@ -9,6 +9,7 @@ import {
   generatePkceChallenge,
   buildAuthorizationUrl,
   exchangeCodePkce,
+  exchangeCodeWithClientCredentials,
 } from '@valet/sdk';
 import { type Env, type Variables, getEnvString } from '../env.js';
 import * as db from '../lib/db.js';
@@ -19,6 +20,8 @@ import { revokeCredential } from '../services/credentials.js';
 import { getDb } from '../lib/drizzle.js';
 import { listMcpToolCache } from '../lib/db/mcp-tool-cache.js';
 import { getDisabledPluginServices } from '../lib/db/plugins.js';
+import { getCustomMcpOAuthConfig, loadCustomMcpConnectorContext } from '../services/custom-mcp-connectors.js';
+import { createSafeFetchOutbound } from '../services/safe-fetch-outbound.js';
 
 export const integrationsRouter = new Hono<{ Bindings: Env; Variables: Variables }>();
 
@@ -88,10 +91,7 @@ async function ensureMcpOAuthClient(
 
 // Validation schemas
 const configureIntegrationSchema = z.object({
-  service: z.string().min(1).refine(
-    (s) => integrationRegistry.getPackage(s) !== undefined,
-    (s) => ({ message: `Unknown integration service: ${s}` }),
-  ),
+  service: z.string().min(1),
   credentials: z.record(z.string()),
   config: z.object({
     entities: z.array(z.string()).default([]),
@@ -106,6 +106,7 @@ const configureIntegrationSchema = z.object({
 integrationsRouter.get('/', async (c) => {
   const user = c.get('user');
   const disabledPlugins = await getDisabledPluginServices(c.env.DB);
+  const customContext = await loadCustomMcpConnectorContext(c.env, c.get('db'), 'default');
 
   // Get user's own integrations
   const userIntegrations = await db.getUserIntegrations(c.get('db'), user.id);
@@ -135,7 +136,11 @@ integrationsRouter.get('/', async (c) => {
       },
       createdAt: i.createdAt,
     })),
-  ].filter((i) => !disabledPlugins.has(i.service));
+  ].filter((i) => {
+    if (disabledPlugins.has(i.service)) return false;
+    if (integrationRegistry.isBuiltinService(i.service)) return true;
+    return customContext.connectors.has(i.service);
+  });
 
   return c.json({ integrations: sanitized });
 });
@@ -148,8 +153,17 @@ integrationsRouter.get('/', async (c) => {
 integrationsRouter.get('/available', async (c) => {
   const packages = integrationRegistry.listPackages();
   const disabledPlugins = await getDisabledPluginServices(c.env.DB);
+  const customContext = await loadCustomMcpConnectorContext(c.env, c.get('db'), 'default');
 
-  const available = packages
+  const available: Array<{
+    service: string;
+    displayName: string;
+    authType: string;
+    supportedEntities: string[];
+    hasActions: boolean;
+    hasTriggers: boolean;
+    isCustomConnector?: boolean;
+  }> = packages
     .filter((pkg) => {
       // Skip plugins disabled by admin
       if (disabledPlugins.has(pkg.service)) return false;
@@ -174,6 +188,19 @@ integrationsRouter.get('/available', async (c) => {
       hasTriggers: !!pkg.triggers,
     }));
 
+  for (const connector of customContext.connectors.values()) {
+    if (connector.authType !== 'oauth') continue;
+    available.push({
+      service: connector.serviceSlug,
+      displayName: connector.displayName,
+      authType: 'oauth2',
+      supportedEntities: [],
+      hasActions: true,
+      hasTriggers: false,
+      isCustomConnector: true,
+    });
+  }
+
   return c.json({ services: available, disabledServices: [...disabledPlugins] });
 });
 
@@ -184,11 +211,15 @@ integrationsRouter.get('/available', async (c) => {
 integrationsRouter.get('/actions', async (c) => {
   const serviceFilter = c.req.query('service');
   const packages = integrationRegistry.listPackages();
+  const customContext = await loadCustomMcpConnectorContext(c.env, c.get('db'), 'default');
 
   // Build a lookup of provider display names by service for cache entries
   const displayNameMap = new Map<string, string>();
   for (const pkg of packages) {
     displayNameMap.set(pkg.service, pkg.provider.displayName);
+  }
+  for (const connector of customContext.connectors.values()) {
+    displayNameMap.set(connector.serviceSlug, connector.displayName);
   }
 
   const catalog: Array<{
@@ -225,9 +256,12 @@ integrationsRouter.get('/actions', async (c) => {
   // Merge cached MCP tool metadata (discovered at runtime by SessionAgentDO).
   // This surfaces MCP-backed tools that can't be listed without credentials.
   try {
-    const appDb = getDb(c.env.DB);
+    const appDb = c.get('db');
     const cached = await listMcpToolCache(appDb, serviceFilter ?? undefined);
     for (const entry of cached) {
+      if (!integrationRegistry.isBuiltinService(entry.service) && !customContext.connectors.has(entry.service)) {
+        continue;
+      }
       const key = `${entry.service}:${entry.actionId}`;
       if (seen.has(key)) continue; // static source already provided this tool
       seen.add(key);
@@ -425,7 +459,24 @@ integrationsRouter.get('/:service/oauth', async (c) => {
 
   const provider = integrationRegistry.getProvider(service);
   if (!provider) {
-    throw new ValidationError(`Unknown service: ${service}`);
+    const customOAuth = await getCustomMcpOAuthConfig(c.env, c.get('db'), service, 'default');
+    if (!customOAuth) {
+      throw new ValidationError(`Unknown service: ${service}`);
+    }
+
+    const { codeVerifier, codeChallenge } = await generatePkceChallenge();
+    const state = crypto.randomUUID();
+    const url = buildAuthorizationUrl({
+      authorizationEndpoint: customOAuth.authorizationEndpoint,
+      clientId: customOAuth.clientId,
+      redirectUri: redirect_uri,
+      codeChallenge,
+      state,
+      scopes: customOAuth.scopes,
+      resource: customOAuth.serverUrl,
+    });
+
+    return c.json({ url, state, code_verifier: codeVerifier });
   }
 
   if (provider.mcpServerUrl) {
@@ -474,7 +525,34 @@ integrationsRouter.post('/:service/oauth/callback', async (c) => {
 
   const provider = integrationRegistry.getProvider(service);
   if (!provider) {
-    throw new ValidationError(`Unknown service: ${service}`);
+    const customOAuth = await getCustomMcpOAuthConfig(c.env, c.get('db'), service, 'default');
+    if (!customOAuth) {
+      throw new ValidationError(`Unknown service: ${service}`);
+    }
+    if (!code_verifier) {
+      throw new ValidationError('code_verifier is required for MCP OAuth callback');
+    }
+
+    const tokens = await exchangeCodeWithClientCredentials({
+      tokenEndpoint: customOAuth.tokenEndpoint,
+      clientId: customOAuth.clientId,
+      clientSecret: customOAuth.clientSecret,
+      tokenEndpointAuthMethod: customOAuth.tokenEndpointAuthMethod,
+      code,
+      redirectUri: redirect_uri,
+      codeVerifier: code_verifier,
+      resource: customOAuth.serverUrl,
+      fetch: createSafeFetchOutbound({ mode: 'oauth-token' }),
+    });
+
+    const credentials: Record<string, string> = {
+      access_token: tokens.access_token,
+      token_type: tokens.token_type || 'bearer',
+    };
+    if (tokens.refresh_token) credentials.refresh_token = tokens.refresh_token;
+    if (tokens.expires_in) credentials.expires_in = String(tokens.expires_in);
+
+    return c.json({ credentials });
   }
 
   if (provider.mcpServerUrl) {

--- a/packages/worker/src/routes/integrations.ts
+++ b/packages/worker/src/routes/integrations.ts
@@ -132,7 +132,7 @@ integrationsRouter.get('/', async (c) => {
       status: i.status,
       scope: i.scope,
       config: {
-        entities: (i.config as any).entities,
+        entities: Array.isArray(i.config.entities) ? i.config.entities as string[] : [],
       },
       createdAt: i.createdAt,
     })),
@@ -189,11 +189,11 @@ integrationsRouter.get('/available', async (c) => {
     }));
 
   for (const connector of customContext.connectors.values()) {
-    if (connector.authType !== 'oauth') continue;
+    if (connector.authType === 'none') continue;
     available.push({
       service: connector.serviceSlug,
       displayName: connector.displayName,
-      authType: 'oauth2',
+      authType: connector.authType === 'oauth' ? 'oauth2' : connector.authType,
       supportedEntities: [],
       hasActions: true,
       hasTriggers: false,

--- a/packages/worker/src/services/credentials.test.ts
+++ b/packages/worker/src/services/credentials.test.ts
@@ -8,6 +8,11 @@ vi.mock('../lib/db/credentials.js', () => ({
   deleteCredential: vi.fn(),
   listCredentialsByOwner: vi.fn(),
   hasCredential: vi.fn(),
+  getExpiringCredentials: vi.fn(),
+}));
+
+vi.mock('./custom-mcp-connectors.js', () => ({
+  getCustomMcpOAuthConfig: vi.fn(),
 }));
 
 // Mock the crypto layer
@@ -18,7 +23,7 @@ vi.mock('../lib/crypto.js', () => ({
 
 // Mock the drizzle layer so we can verify getDb() return value is threaded through
 const { fakeDrizzleDb } = vi.hoisted(() => {
-  const fakeDrizzleDb = { __drizzle: true } as any;
+  const fakeDrizzleDb = { __drizzle: true } as const;
   return { fakeDrizzleDb };
 });
 vi.mock('../lib/drizzle.js', () => ({
@@ -26,6 +31,7 @@ vi.mock('../lib/drizzle.js', () => ({
 }));
 
 import * as credentialDb from '../lib/db/credentials.js';
+import { getCustomMcpOAuthConfig } from './custom-mcp-connectors.js';
 import { encryptStringPBKDF2, decryptStringPBKDF2 } from '../lib/crypto.js';
 import {
   getCredential,
@@ -46,6 +52,7 @@ const mockDb = credentialDb as unknown as {
 };
 const mockEncrypt = encryptStringPBKDF2 as ReturnType<typeof vi.fn>;
 const mockDecrypt = decryptStringPBKDF2 as ReturnType<typeof vi.fn>;
+const mockGetCustomMcpOAuthConfig = getCustomMcpOAuthConfig as ReturnType<typeof vi.fn>;
 
 const fakeEnv = {
   DB: {} as unknown,
@@ -54,6 +61,7 @@ const fakeEnv = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockGetCustomMcpOAuthConfig.mockResolvedValue(null);
 });
 
 describe('getCredential', () => {
@@ -169,6 +177,99 @@ describe('getCredential', () => {
     if (result.ok) {
       expect(result.credential.accessToken).toBe('sk-abc123');
     }
+  });
+
+  it('refreshes expired custom MCP OAuth credentials with stored client credentials and resource', async () => {
+    mockDb.getCredentialRow.mockResolvedValue({
+      id: 'cred-1',
+      ownerType: 'user',
+      ownerId: 'user-1',
+      provider: 'salesforce-mcp',
+      credentialType: 'oauth2',
+      encryptedData: 'encrypted-blob',
+      metadata: null,
+      scopes: 'mcp_api refresh_token',
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+      createdAt: '2025-01-01T00:00:00Z',
+      updatedAt: '2025-01-01T00:00:00Z',
+    });
+    mockDecrypt.mockResolvedValue(JSON.stringify({
+      access_token: 'old-access',
+      refresh_token: 'old-refresh',
+    }));
+    mockGetCustomMcpOAuthConfig.mockResolvedValue({
+      serviceSlug: 'salesforce-mcp',
+      serverUrl: 'https://mcp.salesforce.example.com/platform/mcp',
+      tokenEndpoint: 'https://login.salesforce.example.com/token',
+      authorizationEndpoint: 'https://login.salesforce.example.com/auth',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      tokenEndpointAuthMethod: 'client_secret_post',
+      scopes: ['mcp_api', 'refresh_token'],
+    });
+    mockEncrypt.mockResolvedValue('encrypted-refreshed');
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const form = init?.body as URLSearchParams;
+      expect(form.get('grant_type')).toBe('refresh_token');
+      expect(form.get('client_id')).toBe('client-id');
+      expect(form.get('client_secret')).toBe('client-secret');
+      expect(form.get('refresh_token')).toBe('old-refresh');
+      expect(form.get('resource')).toBe('https://mcp.salesforce.example.com/platform/mcp');
+      return Response.json({ access_token: 'new-access', expires_in: 3600 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await getCredential(fakeEnv, 'user', 'user-1', 'salesforce-mcp');
+
+    expect(result).toMatchObject({
+      ok: true,
+      credential: {
+        accessToken: 'new-access',
+        refreshToken: 'old-refresh',
+        refreshed: true,
+      },
+    });
+    expect(mockDb.upsertCredential).toHaveBeenCalledWith(
+      fakeDrizzleDb,
+      expect.objectContaining({
+        ownerType: 'user',
+        ownerId: 'user-1',
+        provider: 'salesforce-mcp',
+        credentialType: 'oauth2',
+        encryptedData: 'encrypted-refreshed',
+        expiresAt: expect.any(String),
+      }),
+    );
+  });
+
+  it('returns expired when an expired credential has no refresh token', async () => {
+    mockDb.getCredentialRow.mockResolvedValue({
+      id: 'cred-1',
+      ownerType: 'user',
+      ownerId: 'user-1',
+      provider: 'salesforce-mcp',
+      credentialType: 'oauth2',
+      encryptedData: 'encrypted-blob',
+      metadata: null,
+      scopes: 'mcp_api',
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+      createdAt: '2025-01-01T00:00:00Z',
+      updatedAt: '2025-01-01T00:00:00Z',
+    });
+    mockDecrypt.mockResolvedValue(JSON.stringify({
+      access_token: 'expired-access',
+    }));
+
+    const result = await getCredential(fakeEnv, 'user', 'user-1', 'salesforce-mcp');
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        service: 'salesforce-mcp',
+        reason: 'expired',
+      },
+    });
+    expect(mockGetCustomMcpOAuthConfig).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/worker/src/services/credentials.ts
+++ b/packages/worker/src/services/credentials.ts
@@ -1,10 +1,12 @@
-import { type OAuthConfig, refreshTokenPkce } from '@valet/sdk';
+import { type OAuthConfig, refreshTokenPkce, refreshTokenWithClientCredentials } from '@valet/sdk';
 import { type Env, getEnvString } from '../env.js';
 import { encryptStringPBKDF2, decryptStringPBKDF2 } from '../lib/crypto.js';
 import * as credentialDb from '../lib/db/credentials.js';
 import * as mcpOAuthDb from '../lib/db/mcp-oauth.js';
 import { getDb } from '../lib/drizzle.js';
 import { integrationRegistry } from '../integrations/registry.js';
+import { getCustomMcpOAuthConfig } from './custom-mcp-connectors.js';
+import { createSafeFetchOutbound } from './safe-fetch-outbound.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -287,6 +289,58 @@ async function attemptRefresh(
     }
   }
 
+  const db = getDb(env.DB);
+  const customOAuth = await getCustomMcpOAuthConfig(env, db, provider, 'default');
+  if (customOAuth) {
+    try {
+      const tokens = await refreshTokenWithClientCredentials({
+        tokenEndpoint: customOAuth.tokenEndpoint,
+        clientId: customOAuth.clientId,
+        clientSecret: customOAuth.clientSecret,
+        tokenEndpointAuthMethod: customOAuth.tokenEndpointAuthMethod,
+        refreshToken: data.refresh_token,
+        resource: customOAuth.serverUrl,
+        fetch: createSafeFetchOutbound({ mode: 'oauth-token' }),
+      });
+      const newData: CredentialData = {
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token || data.refresh_token,
+      };
+      const expiresAt = tokens.expires_in
+        ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+        : undefined;
+      const encrypted = await encryptCredentialData(newData, env.ENCRYPTION_KEY);
+      await credentialDb.upsertCredential(db, {
+        id: crypto.randomUUID(),
+        ownerType,
+        ownerId,
+        provider,
+        credentialType: 'oauth2',
+        encryptedData: encrypted,
+        expiresAt,
+      });
+      return {
+        ok: true,
+        credential: {
+          accessToken: tokens.access_token,
+          refreshToken: tokens.refresh_token || data.refresh_token,
+          expiresAt: expiresAt ? new Date(expiresAt) : undefined,
+          credentialType: 'oauth2',
+          refreshed: true,
+        },
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        error: {
+          service: provider,
+          reason: 'refresh_failed',
+          message: `Custom MCP OAuth refresh failed: ${err instanceof Error ? err.message : String(err)}`,
+        },
+      };
+    }
+  }
+
   if (!integrationProvider?.refreshOAuthTokens) {
     return {
       ok: false,
@@ -390,23 +444,35 @@ export async function getCredential(
     };
   }
 
-  // Force refresh if requested (e.g. after a 401 from the API indicates the token is invalid)
-  if (options?.forceRefresh && data.refresh_token) {
-    const refreshed = await attemptRefresh(env, ownerType, ownerId, provider, data);
-    if (refreshed.ok) return refreshed;
-    return {
-      ok: false,
-      error: { service: provider, reason: 'refresh_failed', message: 'Force refresh failed' },
-    };
-  }
+  const expiresSoon = row.expiresAt && new Date(row.expiresAt).getTime() - Date.now() < 60_000;
 
-  // Check expiration (with 60-second buffer)
-  if (row.expiresAt && new Date(row.expiresAt).getTime() - Date.now() < 60_000) {
+  // Force refresh if requested (e.g. after a 401 from the API indicates the token is invalid)
+  if (options?.forceRefresh) {
     if (data.refresh_token) {
       const refreshed = await attemptRefresh(env, ownerType, ownerId, provider, data);
       if (refreshed.ok) return refreshed;
     }
-    // Return potentially expired credential — caller can decide
+    return {
+      ok: false,
+      error: {
+        service: provider,
+        reason: expiresSoon ? 'expired' : 'refresh_failed',
+        message: data.refresh_token ? 'Force refresh failed' : `Credential for ${provider} cannot be refreshed because it has no refresh token`,
+      },
+    };
+  }
+
+  // Check expiration (with 60-second buffer)
+  if (expiresSoon) {
+    if (data.refresh_token) {
+      const refreshed = await attemptRefresh(env, ownerType, ownerId, provider, data);
+      if (refreshed.ok) return refreshed;
+      return refreshed;
+    }
+    return {
+      ok: false,
+      error: { service: provider, reason: 'expired', message: `Credential for ${provider} has expired and cannot be refreshed` },
+    };
   }
 
   const accessToken = extractAccessToken(data);

--- a/packages/worker/src/services/custom-mcp-connectors.test.ts
+++ b/packages/worker/src/services/custom-mcp-connectors.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it, vi } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { createTestDb } from '../test-utils/db.js';
+import { users } from '../lib/schema/users.js';
+import { credentials, integrations, mcpToolCache, customMcpConnectors } from '../lib/schema/index.js';
+import { actionPolicies, userActionPolicyOverrides } from '../lib/schema/actions.js';
+import { disabledActions } from '../lib/schema/disabled-actions.js';
+import { encryptString } from '../lib/crypto.js';
+import type { AppDb } from '../lib/drizzle.js';
+import {
+  createCustomMcpConnector,
+  deleteCustomMcpConnectorCascade,
+  getCustomMcpOAuthConfig,
+  loadCustomMcpConnectorContext,
+  listConnectorSummaries,
+  updateCustomMcpConnector,
+} from './custom-mcp-connectors.js';
+import type { Env } from '../env.js';
+
+const ENCRYPTION_KEY = 'test-encryption-key';
+
+function makeEnv(): Env {
+  return {
+    ENCRYPTION_KEY,
+  } as Env;
+}
+
+function makeD1Batch(sqlite: ReturnType<typeof createTestDb>['sqlite']): D1Database {
+  return {
+    prepare: vi.fn((sql: string) => ({
+      bind: vi.fn((...params: unknown[]) => ({
+        run: vi.fn(() => {
+          sqlite.prepare(sql).run(...params);
+          return Promise.resolve({ success: true });
+        }),
+      })),
+    })),
+    batch: vi.fn(async (statements: Array<{ run: () => Promise<unknown> }>) => {
+      for (const statement of statements) {
+        await statement.run();
+      }
+      return [];
+    }),
+  } as unknown as D1Database;
+}
+
+describe('custom MCP connector service', () => {
+  it('decrypts active connector context into static auth and additional headers', async () => {
+    const { db } = createTestDb();
+    const appDb: AppDb = db;
+    await db.insert(customMcpConnectors).values({
+      id: 'connector-1',
+      orgId: 'default',
+      serviceSlug: 'salesforce',
+      displayName: 'Salesforce',
+      serverUrl: 'https://mcp.salesforce.com/platform/mcp',
+      authType: 'bearer',
+      encryptedApiKey: await encryptString('bearer-token', ENCRYPTION_KEY),
+      apiKeyHeaderName: 'Authorization',
+      apiKeyPrefix: 'Bearer',
+      encryptedAdditionalHeaders: await encryptString(JSON.stringify({ 'X-Tenant': 'acme' }), ENCRYPTION_KEY),
+      status: 'active',
+    }).run();
+
+    const context = await loadCustomMcpConnectorContext(makeEnv(), appDb, 'default');
+
+    expect(context.connectors.get('salesforce')).toMatchObject({
+      serviceSlug: 'salesforce',
+      displayName: 'Salesforce',
+      serverUrl: 'https://mcp.salesforce.com/platform/mcp',
+      authType: 'bearer',
+      additionalHeaders: { 'X-Tenant': 'acme' },
+      staticAuthHeader: { name: 'Authorization', value: 'Bearer bearer-token' },
+    });
+  });
+
+  it('rejects protected additional headers while loading runtime context', async () => {
+    const { db } = createTestDb();
+    const appDb: AppDb = db;
+    await db.insert(customMcpConnectors).values({
+      id: 'connector-1',
+      orgId: 'default',
+      serviceSlug: 'bad-headers',
+      displayName: 'Bad Headers',
+      serverUrl: 'https://mcp.example.com',
+      authType: 'none',
+      encryptedAdditionalHeaders: await encryptString(JSON.stringify({ Authorization: 'Bearer nope' }), ENCRYPTION_KEY),
+      status: 'active',
+    }).run();
+
+    await expect(loadCustomMcpConnectorContext(makeEnv(), appDb, 'default')).rejects.toThrow(/protected header/i);
+  });
+
+  it('creates and updates connectors with validation, encryption, and cache invalidation', async () => {
+    const { db } = createTestDb();
+    const appDb: AppDb = db;
+    db.insert(users).values({ id: 'admin-1', email: 'admin@example.com' }).run();
+
+    const created = await createCustomMcpConnector(makeEnv(), appDb, {
+      displayName: 'Salesforce MCP',
+      serverUrl: 'https://mcp.salesforce.com/platform/mcp',
+      authType: 'api_key',
+      apiKey: 'secret-key',
+      apiKeyHeaderName: 'X-API-Key',
+      apiKeyPrefix: 'Token',
+      additionalHeaders: { 'X-Tenant': 'acme' },
+      status: 'active',
+    }, { orgId: 'default', createdBy: 'admin-1' });
+
+    expect(created).toMatchObject({
+      serviceSlug: 'salesforce-mcp',
+      hasApiKey: true,
+      hasAdditionalHeaders: true,
+    });
+
+    const row = db.select().from(customMcpConnectors).where(eq(customMcpConnectors.id, created.id)).get();
+    expect(row?.encryptedApiKey).toBeTruthy();
+    expect(row?.encryptedApiKey).not.toBe('secret-key');
+
+    await db.insert(mcpToolCache).values({
+      service: created.serviceSlug,
+      actionId: 'salesforce.query',
+      name: 'Query',
+      description: '',
+      riskLevel: 'low',
+    }).run();
+
+    const updated = await updateCustomMcpConnector(makeEnv(), appDb, created.id, {
+      authType: 'none',
+      serverUrl: 'https://mcp.salesforce.com/platform/new-mcp',
+      clearAdditionalHeaders: true,
+    });
+
+    expect(updated?.authType).toBe('none');
+    expect(updated?.hasApiKey).toBe(false);
+    expect(updated?.hasAdditionalHeaders).toBe(false);
+    expect(db.select().from(mcpToolCache).where(eq(mcpToolCache.service, created.serviceSlug)).all()).toEqual([]);
+  });
+
+  it('rejects service slugs that collide with built-in integrations', async () => {
+    const { db } = createTestDb();
+    const appDb: AppDb = db;
+
+    await expect(createCustomMcpConnector(makeEnv(), appDb, {
+      displayName: 'GitHub',
+      serverUrl: 'https://github-mcp.example.com/mcp',
+      authType: 'none',
+    }, { orgId: 'default', createdBy: null })).rejects.toThrow(/built-in/i);
+  });
+
+  it('rejects invalid API-key static auth header configuration before storage', async () => {
+    const { db } = createTestDb();
+    const appDb: AppDb = db;
+
+    await expect(createCustomMcpConnector(makeEnv(), appDb, {
+      displayName: 'Cookie Header MCP',
+      serverUrl: 'https://cookie-header.example.com/mcp',
+      authType: 'api_key',
+      apiKey: 'secret-key',
+      apiKeyHeaderName: 'Cookie',
+    }, { orgId: 'default', createdBy: null })).rejects.toThrow(/protected header/i);
+
+    await expect(createCustomMcpConnector(makeEnv(), appDb, {
+      displayName: 'Bad Secret MCP',
+      serverUrl: 'https://bad-secret.example.com/mcp',
+      authType: 'api_key',
+      apiKey: 'secret\r\nInjected: yes',
+      apiKeyHeaderName: 'X-API-Key',
+    }, { orgId: 'default', createdBy: null })).rejects.toThrow(/invalid value/i);
+  });
+
+  it('loads OAuth config with decrypted client secret', async () => {
+    const { db } = createTestDb();
+    const appDb: AppDb = db;
+    await createCustomMcpConnector(makeEnv(), appDb, {
+      displayName: 'Salesforce MCP',
+      serverUrl: 'https://mcp.salesforce.com/platform/mcp',
+      authType: 'oauth',
+      oauthClientId: 'client-id',
+      oauthClientSecret: 'client-secret',
+      oauthTokenEndpointAuthMethod: 'client_secret_basic',
+      oauthScopes: 'mcp_api refresh_token',
+      oauthAuthorizationEndpoint: 'https://login.salesforce.com/services/oauth2/authorize',
+      oauthTokenEndpoint: 'https://login.salesforce.com/services/oauth2/token',
+    }, { orgId: 'default', createdBy: null });
+
+    const config = await getCustomMcpOAuthConfig(makeEnv(), appDb, 'salesforce-mcp', 'default');
+
+    expect(config).toMatchObject({
+      serviceSlug: 'salesforce-mcp',
+      serverUrl: 'https://mcp.salesforce.com/platform/mcp',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      tokenEndpointAuthMethod: 'client_secret_basic',
+      scopes: ['mcp_api', 'refresh_token'],
+      authorizationEndpoint: 'https://login.salesforce.com/services/oauth2/authorize',
+      tokenEndpoint: 'https://login.salesforce.com/services/oauth2/token',
+    });
+  });
+
+  it('returns connector summaries with cached tool counts', async () => {
+    const { db } = createTestDb();
+    const appDb: AppDb = db;
+    const connector = await createCustomMcpConnector(makeEnv(), appDb, {
+      displayName: 'Summary MCP',
+      serverUrl: 'https://summary.example.com/mcp',
+      authType: 'none',
+    }, { orgId: 'default', createdBy: null });
+    await db.insert(mcpToolCache).values([
+      { service: connector.serviceSlug, actionId: 'a', name: 'A', description: '', riskLevel: 'low' },
+      { service: connector.serviceSlug, actionId: 'b', name: 'B', description: '', riskLevel: 'medium' },
+    ]).run();
+
+    const summaries = await listConnectorSummaries(appDb, 'default');
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].toolCount).toBe(2);
+  });
+
+  it('deletes connector-owned runtime state in one D1 batch while preserving action history', async () => {
+    const { db, sqlite } = createTestDb();
+    const appDb: AppDb = db;
+    db.insert(users).values({ id: 'user-1', email: 'user@example.com' }).run();
+    const connector = await createCustomMcpConnector(makeEnv(), appDb, {
+      displayName: 'Delete MCP',
+      serverUrl: 'https://delete.example.com/mcp',
+      authType: 'oauth',
+      oauthClientId: 'client-id',
+      oauthAuthorizationEndpoint: 'https://login.example.com/auth',
+      oauthTokenEndpoint: 'https://login.example.com/token',
+    }, { orgId: 'default', createdBy: null });
+
+    db.insert(integrations).values({
+      id: 'integration-1',
+      userId: 'user-1',
+      service: connector.serviceSlug,
+      config: { entities: [] },
+      status: 'active',
+    }).run();
+    db.insert(credentials).values({
+      id: 'credential-1',
+      ownerType: 'user',
+      ownerId: 'user-1',
+      provider: connector.serviceSlug,
+      credentialType: 'oauth2',
+      encryptedData: 'encrypted',
+    }).run();
+    db.insert(mcpToolCache).values({
+      service: connector.serviceSlug,
+      actionId: 'tool',
+      name: 'Tool',
+      description: '',
+      riskLevel: 'low',
+    }).run();
+    db.insert(disabledActions).values({
+      id: 'disabled-1',
+      service: connector.serviceSlug,
+      actionId: null,
+      disabledBy: 'user-1',
+    }).run();
+    db.insert(actionPolicies).values({
+      id: 'policy-1',
+      service: connector.serviceSlug,
+      actionId: null,
+      riskLevel: null,
+      mode: 'deny',
+      createdBy: 'user-1',
+    }).run();
+    db.insert(userActionPolicyOverrides).values({
+      id: 'override-1',
+      userId: 'user-1',
+      service: connector.serviceSlug,
+      actionId: null,
+      riskLevel: null,
+      mode: 'allow',
+    }).run();
+
+    await deleteCustomMcpConnectorCascade(makeD1Batch(sqlite), appDb, connector.id);
+
+    expect(db.select().from(customMcpConnectors).all()).toHaveLength(0);
+    expect(db.select().from(integrations).all()).toHaveLength(0);
+    expect(db.select().from(credentials).all()).toHaveLength(0);
+    expect(db.select().from(mcpToolCache).all()).toHaveLength(0);
+    expect(db.select().from(disabledActions).all()).toHaveLength(0);
+    expect(db.select().from(actionPolicies).all()).toHaveLength(0);
+    expect(db.select().from(userActionPolicyOverrides).all()).toHaveLength(0);
+  });
+});

--- a/packages/worker/src/services/custom-mcp-connectors.ts
+++ b/packages/worker/src/services/custom-mcp-connectors.ts
@@ -1,0 +1,541 @@
+import {
+  ValidationError,
+  type CustomMcpConnector,
+  type CreateCustomMcpConnectorRequest,
+  type UpdateCustomMcpConnectorRequest,
+  type CustomMcpConnectorAuthType,
+  type CustomMcpConnectorTokenEndpointAuthMethod,
+} from '@valet/shared';
+import { and, eq, sql } from 'drizzle-orm';
+import type { Env } from '../env.js';
+import type { AppDb } from '../lib/drizzle.js';
+import { encryptString, decryptString } from '../lib/crypto.js';
+import { getOrgSettings } from '../lib/db/org.js';
+import {
+  createConnector,
+  getConnector,
+  getConnectorBySlug,
+  listConnectors,
+  updateConnector,
+} from '../lib/db/custom-mcp-connectors.js';
+import { listMcpToolCache } from '../lib/db/mcp-tool-cache.js';
+import { customMcpConnectors, mcpToolCache } from '../lib/schema/index.js';
+import { integrationRegistry } from '../integrations/registry.js';
+import { validateOutboundUrl } from './outbound-url-policy.js';
+import { createSafeFetchOutbound } from './safe-fetch-outbound.js';
+
+export interface ResolvedCustomMcpConnector {
+  id: string;
+  orgId: string;
+  serviceSlug: string;
+  displayName: string;
+  serverUrl: string;
+  authType: CustomMcpConnectorAuthType;
+  oauthClientId: string | null;
+  oauthTokenEndpointAuthMethod: CustomMcpConnectorTokenEndpointAuthMethod;
+  oauthScopes: string | null;
+  oauthAuthorizationEndpoint: string | null;
+  oauthTokenEndpoint: string | null;
+  additionalHeaders?: Record<string, string>;
+  staticAuthHeader?: { name: string; value: string };
+}
+
+export interface CustomMcpConnectorContext {
+  orgId: string;
+  connectors: Map<string, ResolvedCustomMcpConnector>;
+  fetch: typeof fetch;
+}
+
+export interface CustomMcpOAuthConfig {
+  serviceSlug: string;
+  serverUrl: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  clientId: string;
+  clientSecret?: string;
+  tokenEndpointAuthMethod: CustomMcpConnectorTokenEndpointAuthMethod;
+  scopes: string[];
+}
+
+interface ConnectorServiceOptions {
+  orgId?: string;
+  createdBy?: string | null;
+}
+
+type ConnectorRow = typeof customMcpConnectors.$inferSelect;
+
+const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const HEADER_NAME_RE = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const PROTECTED_ADDITIONAL_HEADERS = new Set([
+  'authorization',
+  'content-type',
+  'accept',
+  'mcp-session-id',
+  'mcp-protocol-version',
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'host',
+  'content-length',
+  'cookie',
+  'date',
+  'dnt',
+  'expect',
+  'origin',
+  'referer',
+  'accept-charset',
+  'accept-encoding',
+  'access-control-request-headers',
+  'access-control-request-method',
+  'permissions-policy',
+]);
+
+export async function resolveOrgIdOrDefault(db: AppDb): Promise<string> {
+  try {
+    return (await getOrgSettings(db)).id || 'default';
+  } catch {
+    return 'default';
+  }
+}
+
+export async function listConnectorSummaries(db: AppDb, orgId = 'default'): Promise<CustomMcpConnector[]> {
+  const connectors = await listConnectors(db, orgId);
+  return Promise.all(connectors.map(async (connector) => ({
+    ...connector,
+    toolCount: (await listMcpToolCache(db, connector.serviceSlug)).length,
+  })));
+}
+
+export async function loadCustomMcpConnectorContext(
+  env: Pick<Env, 'ENCRYPTION_KEY'>,
+  db: AppDb,
+  orgId = 'default',
+): Promise<CustomMcpConnectorContext> {
+  const rows = await db
+    .select()
+    .from(customMcpConnectors)
+    .where(and(eq(customMcpConnectors.orgId, orgId), eq(customMcpConnectors.status, 'active')))
+    .all();
+
+  const connectors = new Map<string, ResolvedCustomMcpConnector>();
+  for (const row of rows) {
+    await validateOutboundUrl(row.serverUrl);
+    if (row.oauthAuthorizationEndpoint) await validateOutboundUrl(row.oauthAuthorizationEndpoint);
+    if (row.oauthTokenEndpoint) await validateOutboundUrl(row.oauthTokenEndpoint);
+    connectors.set(row.serviceSlug, await resolveConnectorRow(env, row));
+  }
+
+  return {
+    orgId,
+    connectors,
+    fetch: createSafeFetchOutbound({ mode: 'mcp' }),
+  };
+}
+
+export async function getCustomMcpConnectorBySlug(
+  _env: Pick<Env, 'ENCRYPTION_KEY'>,
+  db: AppDb,
+  slug: string,
+  orgId = 'default',
+): Promise<CustomMcpConnector | null> {
+  const connector = await getConnectorBySlug(db, slug);
+  if (!connector || connector.orgId !== orgId || connector.status !== 'active') return null;
+  return connector;
+}
+
+export async function getCustomMcpOAuthConfig(
+  env: Pick<Env, 'ENCRYPTION_KEY'>,
+  db: AppDb,
+  slug: string,
+  orgId = 'default',
+): Promise<CustomMcpOAuthConfig | null> {
+  const row = await getConnectorRowBySlug(db, slug);
+  if (!row || row.orgId !== orgId || row.status !== 'active') return null;
+  if (row.authType !== 'oauth') {
+    throw new ValidationError(`Custom connector "${slug}" is not configured for OAuth.`);
+  }
+  if (!row.oauthClientId || !row.oauthAuthorizationEndpoint || !row.oauthTokenEndpoint) {
+    throw new ValidationError(`Custom connector "${slug}" is missing OAuth configuration.`);
+  }
+
+  await validateOutboundUrl(row.serverUrl);
+  await validateOutboundUrl(row.oauthAuthorizationEndpoint);
+  await validateOutboundUrl(row.oauthTokenEndpoint);
+
+  return {
+    serviceSlug: row.serviceSlug,
+    serverUrl: row.serverUrl,
+    authorizationEndpoint: row.oauthAuthorizationEndpoint,
+    tokenEndpoint: row.oauthTokenEndpoint,
+    clientId: row.oauthClientId,
+    clientSecret: row.encryptedOauthClientSecret
+      ? await decryptString(row.encryptedOauthClientSecret, env.ENCRYPTION_KEY)
+      : undefined,
+    tokenEndpointAuthMethod: row.oauthTokenEndpointAuthMethod,
+    scopes: splitScopes(row.oauthScopes),
+  };
+}
+
+export async function createCustomMcpConnector(
+  env: Pick<Env, 'ENCRYPTION_KEY'>,
+  db: AppDb,
+  input: CreateCustomMcpConnectorRequest,
+  options: ConnectorServiceOptions = {},
+): Promise<CustomMcpConnector> {
+  const serviceSlug = slugify(input.displayName);
+  validateSlug(serviceSlug);
+  if (integrationRegistry.isBuiltinService(serviceSlug)) {
+    throw new ValidationError(`Custom connector slug "${serviceSlug}" collides with a built-in integration.`);
+  }
+  if (await getConnectorBySlug(db, serviceSlug)) {
+    throw new ValidationError(`Custom connector slug "${serviceSlug}" already exists.`);
+  }
+
+  await validateConfiguredUrls(input);
+  const normalized = await buildCreateData(env, serviceSlug, input, options);
+  return createConnector(db, normalized);
+}
+
+export async function updateCustomMcpConnector(
+  env: Pick<Env, 'ENCRYPTION_KEY'>,
+  db: AppDb,
+  id: string,
+  input: UpdateCustomMcpConnectorRequest,
+): Promise<CustomMcpConnector | null> {
+  const existing = await getConnectorRow(db, id);
+  if (!existing) return null;
+
+  const nextAuthType = input.authType;
+  const nextServerUrl = input.serverUrl ?? existing.serverUrl;
+  await validateConfiguredUrls({
+    serverUrl: nextServerUrl,
+    authType: nextAuthType,
+    oauthAuthorizationEndpoint: input.oauthAuthorizationEndpoint ?? existing.oauthAuthorizationEndpoint,
+    oauthTokenEndpoint: input.oauthTokenEndpoint ?? existing.oauthTokenEndpoint,
+  });
+
+  const update = await buildUpdateData(env, existing, input);
+  const shouldInvalidateCache = existing.serverUrl !== nextServerUrl
+    || existing.authType !== nextAuthType
+    || input.status !== undefined
+    || input.additionalHeaders !== undefined
+    || input.clearAdditionalHeaders === true
+    || input.apiKey !== undefined
+    || input.oauthClientSecret !== undefined
+    || input.clearClientSecret === true;
+
+  const connector = await updateConnector(db, id, update);
+  if (shouldInvalidateCache) {
+    await deleteMcpToolCacheForService(db, existing.serviceSlug);
+  }
+  return connector;
+}
+
+export async function deleteCustomMcpConnectorCascade(
+  d1: D1Database,
+  db: AppDb,
+  id: string,
+): Promise<void> {
+  const connector = await getConnector(db, id);
+  if (!connector) return;
+
+  const service = connector.serviceSlug;
+  await d1.batch([
+    d1.prepare('DELETE FROM mcp_tool_cache WHERE service = ?').bind(service),
+    d1.prepare('DELETE FROM integrations WHERE service = ?').bind(service),
+    d1.prepare('DELETE FROM credentials WHERE provider = ?').bind(service),
+    d1.prepare('DELETE FROM disabled_actions WHERE service = ?').bind(service),
+    d1.prepare('DELETE FROM action_policies WHERE service = ?').bind(service),
+    d1.prepare('DELETE FROM user_action_policy_overrides WHERE service = ?').bind(service),
+    d1.prepare('DELETE FROM custom_mcp_connectors WHERE id = ?').bind(id),
+  ]);
+}
+
+async function resolveConnectorRow(
+  env: Pick<Env, 'ENCRYPTION_KEY'>,
+  row: ConnectorRow,
+): Promise<ResolvedCustomMcpConnector> {
+  const additionalHeaders = row.encryptedAdditionalHeaders
+    ? validateAdditionalHeaders(JSON.parse(await decryptString(row.encryptedAdditionalHeaders, env.ENCRYPTION_KEY)) as Record<string, string>)
+    : undefined;
+
+  const staticAuthHeader = await resolveStaticAuthHeader(env, row, additionalHeaders);
+
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    serviceSlug: row.serviceSlug,
+    displayName: row.displayName,
+    serverUrl: row.serverUrl,
+    authType: row.authType,
+    oauthClientId: row.oauthClientId,
+    oauthTokenEndpointAuthMethod: row.oauthTokenEndpointAuthMethod,
+    oauthScopes: row.oauthScopes,
+    oauthAuthorizationEndpoint: row.oauthAuthorizationEndpoint,
+    oauthTokenEndpoint: row.oauthTokenEndpoint,
+    additionalHeaders,
+    staticAuthHeader,
+  };
+}
+
+async function resolveStaticAuthHeader(
+  env: Pick<Env, 'ENCRYPTION_KEY'>,
+  row: ConnectorRow,
+  additionalHeaders?: Record<string, string>,
+): Promise<{ name: string; value: string } | undefined> {
+  if (row.authType !== 'api_key' && row.authType !== 'bearer') return undefined;
+  if (!row.encryptedApiKey) {
+    throw new ValidationError(`Custom connector "${row.serviceSlug}" is missing its API key.`);
+  }
+
+  const secret = await decryptString(row.encryptedApiKey, env.ENCRYPTION_KEY);
+  const name = row.authType === 'bearer' ? 'Authorization' : row.apiKeyHeaderName || 'X-API-Key';
+  const prefix = row.authType === 'bearer' ? 'Bearer' : row.apiKeyPrefix || '';
+  validateStaticAuthHeaderName(name);
+  validateHeaderValue(name, prefix ? `${prefix} ${secret}` : secret);
+
+  if (additionalHeaders && Object.keys(additionalHeaders).some((header) => header.toLowerCase() === name.toLowerCase())) {
+    throw new ValidationError(`Custom connector "${row.serviceSlug}" has duplicate static header "${name}".`);
+  }
+
+  return {
+    name,
+    value: prefix ? `${prefix} ${secret}` : secret,
+  };
+}
+
+function validateAdditionalHeaders(headers: Record<string, string>): Record<string, string> {
+  const normalized = new Set<string>();
+  const result: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const lowerName = validateHeaderName(name);
+    if (normalized.has(lowerName)) {
+      throw new ValidationError(`Duplicate additional header "${name}".`);
+    }
+    if (PROTECTED_ADDITIONAL_HEADERS.has(lowerName) || lowerName.startsWith('proxy-') || lowerName.startsWith('sec-')) {
+      throw new ValidationError(`Protected header "${name}" cannot be configured as an additional header.`);
+    }
+    validateHeaderValue(name, value);
+    normalized.add(lowerName);
+    result[name] = value;
+  }
+  return result;
+}
+
+function validateHeaderName(name: string): string {
+  if (!HEADER_NAME_RE.test(name)) {
+    throw new ValidationError(`Invalid header name "${name}".`);
+  }
+  return name.toLowerCase();
+}
+
+function validateStaticAuthHeaderName(name: string): string {
+  const lowerName = validateHeaderName(name);
+  if (
+    lowerName !== 'authorization'
+    && (PROTECTED_ADDITIONAL_HEADERS.has(lowerName) || lowerName.startsWith('proxy-') || lowerName.startsWith('sec-'))
+  ) {
+    throw new ValidationError(`Protected header "${name}" cannot be configured as a static auth header.`);
+  }
+  return lowerName;
+}
+
+function validateHeaderValue(name: string, value: string): void {
+  if (typeof value !== 'string' || /[\r\n\0]/.test(value)) {
+    throw new ValidationError(`Invalid value for header "${name}".`);
+  }
+}
+
+async function validateConfiguredUrls(input: {
+  serverUrl: string;
+  authType: CustomMcpConnectorAuthType;
+  oauthAuthorizationEndpoint?: string | null;
+  oauthTokenEndpoint?: string | null;
+}): Promise<void> {
+  await validateOutboundUrl(input.serverUrl);
+  if (input.oauthAuthorizationEndpoint) await validateOutboundUrl(input.oauthAuthorizationEndpoint);
+  if (input.oauthTokenEndpoint) await validateOutboundUrl(input.oauthTokenEndpoint);
+}
+
+async function buildCreateData(
+  env: Pick<Env, 'ENCRYPTION_KEY'>,
+  serviceSlug: string,
+  input: CreateCustomMcpConnectorRequest,
+  options: ConnectorServiceOptions,
+) {
+  const auth = await normalizeAuthFields(env, input.authType, input, null);
+  const encryptedAdditionalHeaders = await encryptAdditionalHeaders(env, input.additionalHeaders);
+  return {
+    orgId: options.orgId ?? 'default',
+    serviceSlug,
+    displayName: input.displayName.trim(),
+    serverUrl: input.serverUrl,
+    authType: input.authType,
+    ...auth,
+    encryptedAdditionalHeaders,
+    status: input.status ?? 'active',
+    createdBy: options.createdBy ?? null,
+  };
+}
+
+async function buildUpdateData(
+  env: Pick<Env, 'ENCRYPTION_KEY'>,
+  existing: ConnectorRow,
+  input: UpdateCustomMcpConnectorRequest,
+) {
+  const auth = await normalizeAuthFields(env, input.authType, input, existing);
+  const update: Record<string, unknown> = {
+    displayName: input.displayName?.trim() ?? existing.displayName,
+    serverUrl: input.serverUrl ?? existing.serverUrl,
+    authType: input.authType,
+    ...auth,
+  };
+
+  if (input.status !== undefined) update.status = input.status;
+  if (input.serverUrl && input.serverUrl !== existing.serverUrl) update.lastError = null;
+  if (input.clearAdditionalHeaders || (input.additionalHeaders && Object.keys(input.additionalHeaders).length === 0)) {
+    update.encryptedAdditionalHeaders = null;
+  } else if (input.additionalHeaders) {
+    update.encryptedAdditionalHeaders = await encryptAdditionalHeaders(env, input.additionalHeaders);
+  }
+
+  return update;
+}
+
+async function normalizeAuthFields(
+  env: Pick<Env, 'ENCRYPTION_KEY'>,
+  authType: CustomMcpConnectorAuthType,
+  input: CreateCustomMcpConnectorRequest | UpdateCustomMcpConnectorRequest,
+  existing: ConnectorRow | null,
+) {
+  if (authType === 'none') {
+    return {
+      oauthClientId: null,
+      encryptedOauthClientSecret: null,
+      oauthTokenEndpointAuthMethod: 'none' as const,
+      oauthScopes: null,
+      oauthAuthorizationEndpoint: null,
+      oauthTokenEndpoint: null,
+      encryptedApiKey: null,
+      apiKeyHeaderName: null,
+      apiKeyPrefix: null,
+    };
+  }
+
+  if (authType === 'oauth') {
+    const clientId = input.oauthClientId ?? existing?.oauthClientId ?? null;
+    const authorizationEndpoint = input.oauthAuthorizationEndpoint ?? existing?.oauthAuthorizationEndpoint ?? null;
+    const tokenEndpoint = input.oauthTokenEndpoint ?? existing?.oauthTokenEndpoint ?? null;
+    if (!clientId || !authorizationEndpoint || !tokenEndpoint) {
+      throw new ValidationError('OAuth connectors require a client ID, authorization endpoint, and token endpoint.');
+    }
+
+    const replacingSecret = input.oauthClientSecret && input.oauthClientSecret.trim().length > 0;
+    const clearSecret = 'clearClientSecret' in input && input.clearClientSecret === true;
+    let encryptedOauthClientSecret: string | null = existing?.encryptedOauthClientSecret ?? null;
+    if (replacingSecret) {
+      encryptedOauthClientSecret = await encryptString(input.oauthClientSecret!.trim(), env.ENCRYPTION_KEY);
+    } else if (clearSecret) {
+      encryptedOauthClientSecret = null;
+    } else if (existing?.authType !== 'oauth') {
+      encryptedOauthClientSecret = null;
+    }
+
+    return {
+      oauthClientId: clientId,
+      encryptedOauthClientSecret,
+      oauthTokenEndpointAuthMethod: normalizeTokenEndpointAuthMethod(
+        input.oauthTokenEndpointAuthMethod ?? existing?.oauthTokenEndpointAuthMethod ?? 'none',
+        !!encryptedOauthClientSecret,
+      ),
+      oauthScopes: input.oauthScopes ?? existing?.oauthScopes ?? null,
+      oauthAuthorizationEndpoint: authorizationEndpoint,
+      oauthTokenEndpoint: tokenEndpoint,
+      encryptedApiKey: null,
+      apiKeyHeaderName: null,
+      apiKeyPrefix: null,
+    };
+  }
+
+  const secret = 'apiKey' in input ? input.apiKey?.trim() : undefined;
+  let encryptedApiKey = existing?.authType === authType ? existing.encryptedApiKey : null;
+  if (secret) {
+    encryptedApiKey = await encryptString(secret, env.ENCRYPTION_KEY);
+  }
+  if (!encryptedApiKey) {
+    throw new ValidationError('API key and bearer connectors require a secret.');
+  }
+
+  const apiKeyHeaderName = authType === 'bearer' ? 'Authorization' : input.apiKeyHeaderName || existing?.apiKeyHeaderName || 'X-API-Key';
+  const apiKeyPrefix = authType === 'bearer' ? 'Bearer' : input.apiKeyPrefix ?? existing?.apiKeyPrefix ?? null;
+  validateStaticAuthHeaderName(apiKeyHeaderName);
+  validateHeaderValue(apiKeyHeaderName, apiKeyPrefix ?? '');
+  if (secret) {
+    validateHeaderValue(apiKeyHeaderName, apiKeyPrefix ? `${apiKeyPrefix} ${secret}` : secret);
+  }
+
+  return {
+    oauthClientId: null,
+    encryptedOauthClientSecret: null,
+    oauthTokenEndpointAuthMethod: 'none' as const,
+    oauthScopes: null,
+    oauthAuthorizationEndpoint: null,
+    oauthTokenEndpoint: null,
+    encryptedApiKey,
+    apiKeyHeaderName,
+    apiKeyPrefix,
+  };
+}
+
+function normalizeTokenEndpointAuthMethod(
+  method: CustomMcpConnectorTokenEndpointAuthMethod | 'auto',
+  hasClientSecret: boolean,
+): CustomMcpConnectorTokenEndpointAuthMethod {
+  if (method === 'auto') return hasClientSecret ? 'client_secret_basic' : 'none';
+  return method;
+}
+
+async function encryptAdditionalHeaders(
+  env: Pick<Env, 'ENCRYPTION_KEY'>,
+  headers: Record<string, string> | undefined,
+): Promise<string | null> {
+  if (!headers || Object.keys(headers).length === 0) return null;
+  return encryptString(JSON.stringify(validateAdditionalHeaders(headers)), env.ENCRYPTION_KEY);
+}
+
+function splitScopes(scopes: string | null): string[] {
+  return scopes?.split(/\s+/).filter(Boolean) ?? [];
+}
+
+function slugify(displayName: string): string {
+  return displayName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 63)
+    .replace(/-+$/g, '');
+}
+
+function validateSlug(slug: string): void {
+  if (!SLUG_RE.test(slug)) {
+    throw new ValidationError('Connector name must produce a valid service slug.');
+  }
+}
+
+async function getConnectorRow(db: AppDb, id: string): Promise<ConnectorRow | null> {
+  return await db.select().from(customMcpConnectors).where(eq(customMcpConnectors.id, id)).get() ?? null;
+}
+
+async function getConnectorRowBySlug(db: AppDb, slug: string): Promise<ConnectorRow | null> {
+  return await db.select().from(customMcpConnectors).where(eq(customMcpConnectors.serviceSlug, slug)).get() ?? null;
+}
+
+async function deleteMcpToolCacheForService(db: AppDb, service: string): Promise<void> {
+  await db.delete(mcpToolCache).where(eq(mcpToolCache.service, service));
+}

--- a/packages/worker/src/services/custom-mcp-connectors.ts
+++ b/packages/worker/src/services/custom-mcp-connectors.ts
@@ -210,7 +210,7 @@ export async function updateCustomMcpConnector(
   const existing = await getConnectorRow(db, id);
   if (!existing) return null;
 
-  const nextAuthType = input.authType;
+  const nextAuthType = input.authType ?? existing.authType;
   const nextServerUrl = input.serverUrl ?? existing.serverUrl;
   await validateConfiguredUrls({
     serverUrl: nextServerUrl,
@@ -388,11 +388,12 @@ async function buildUpdateData(
   existing: ConnectorRow,
   input: UpdateCustomMcpConnectorRequest,
 ) {
-  const auth = await normalizeAuthFields(env, input.authType, input, existing);
+  const effectiveAuthType = input.authType ?? existing.authType;
+  const auth = await normalizeAuthFields(env, effectiveAuthType, input, existing);
   const update: Record<string, unknown> = {
     displayName: input.displayName?.trim() ?? existing.displayName,
     serverUrl: input.serverUrl ?? existing.serverUrl,
-    authType: input.authType,
+    authType: effectiveAuthType,
     ...auth,
   };
 

--- a/packages/worker/src/services/integrations.test.ts
+++ b/packages/worker/src/services/integrations.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { eq } from 'drizzle-orm';
+import type { Env } from '../env.js';
+import { createTestDb } from '../test-utils/db.js';
+import type { AppDb } from '../lib/drizzle.js';
+import { credentials, integrations } from '../lib/schema/index.js';
+import { createCustomMcpConnector } from './custom-mcp-connectors.js';
+
+const holder = vi.hoisted(() => ({
+  db: null as AppDb | null,
+}));
+
+vi.mock('../lib/drizzle.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/drizzle.js')>();
+  return {
+    ...actual,
+    getDb: vi.fn(() => holder.db),
+  };
+});
+
+import { configureIntegration } from './integrations.js';
+
+const ENCRYPTION_KEY = 'test-encryption-key';
+
+function makeEnv(): Env {
+  return {
+    DB: {} as D1Database,
+    ENCRYPTION_KEY,
+  } as Env;
+}
+
+describe('configureIntegration custom MCP OAuth', () => {
+  let db: AppDb;
+  let env: Env;
+
+  beforeEach(async () => {
+    const testDb = createTestDb();
+    db = testDb.db;
+    holder.db = db;
+    env = makeEnv();
+
+    await createCustomMcpConnector(env, db, {
+      displayName: 'Salesforce MCP',
+      serverUrl: 'https://mcp.salesforce.example.com/platform/mcp',
+      authType: 'oauth',
+      oauthClientId: 'sf-client-id',
+      oauthAuthorizationEndpoint: 'https://login.salesforce.example.com/auth',
+      oauthTokenEndpoint: 'https://login.salesforce.example.com/token',
+    }, { orgId: 'default', createdBy: null });
+  });
+
+  it('stores credentials and upserts existing custom OAuth integrations on reconnect', async () => {
+    const first = await configureIntegration(env, 'user-1', 'user@example.com', {
+      service: 'salesforce-mcp',
+      credentials: {
+        access_token: 'access-1',
+        refresh_token: 'refresh-1',
+        expires_in: '3600',
+      },
+      config: { entities: ['mcp_api'] },
+    });
+
+    expect(first).toMatchObject({
+      service: 'salesforce-mcp',
+      status: 'active',
+    });
+
+    const second = await configureIntegration(env, 'user-1', 'user@example.com', {
+      service: 'salesforce-mcp',
+      credentials: {
+        access_token: 'access-2',
+        refresh_token: 'refresh-2',
+        expires_in: '7200',
+      },
+      config: { entities: ['mcp_api', 'refresh_token'] },
+    });
+
+    expect(second.id).toBe(first.id);
+    const integrationRows = db.select().from(integrations).where(eq(integrations.service, 'salesforce-mcp')).all();
+    expect(integrationRows).toHaveLength(1);
+    expect(integrationRows[0].status).toBe('active');
+    expect(integrationRows[0].config).toEqual({ entities: ['mcp_api', 'refresh_token'] });
+
+    const credentialRows = db.select().from(credentials).where(eq(credentials.provider, 'salesforce-mcp')).all();
+    expect(credentialRows).toHaveLength(1);
+    expect(credentialRows[0].credentialType).toBe('oauth2');
+    expect(credentialRows[0].expiresAt).toBeTruthy();
+  });
+});

--- a/packages/worker/src/services/integrations.ts
+++ b/packages/worker/src/services/integrations.ts
@@ -4,6 +4,7 @@ import * as db from '../lib/db.js';
 import { getDb } from '../lib/drizzle.js';
 import { integrationRegistry } from '../integrations/registry.js';
 import { storeCredential } from '../services/credentials.js';
+import { loadCustomMcpConnectorContext } from './custom-mcp-connectors.js';
 
 // ─── Configure Integration ──────────────────────────────────────────────────
 
@@ -33,15 +34,13 @@ export async function configureIntegration(
   const appDb = getDb(env.DB);
   // Check if integration already exists
   const existing = await db.getUserIntegrations(appDb, userId);
-  if (existing.some((i) => i.service === params.service)) {
-    throw new IntegrationError(
-      `Integration for ${params.service} already exists`,
-      ErrorCodes.INTEGRATION_ALREADY_EXISTS
-    );
-  }
+  const existingIntegration = existing.find((i) => i.service === params.service);
 
   // Get the integration provider
-  const provider = integrationRegistry.getProvider(params.service);
+  const customContext = integrationRegistry.isBuiltinService(params.service)
+    ? undefined
+    : await loadCustomMcpConnectorContext(env, appDb, 'default');
+  const provider = integrationRegistry.getProvider(params.service, customContext);
   if (!provider) {
     throw new ValidationError(`Unsupported integration: ${params.service}`);
   }
@@ -102,7 +101,27 @@ export async function configureIntegration(
     expiresAt,
   });
 
-  // Create integration record (without credentials)
+  if (existingIntegration) {
+    const updated = await db.updateIntegration(appDb, existingIntegration.id, {
+      config: params.config,
+      status: 'active',
+      errorMessage: null,
+    });
+    if (!updated) {
+      throw new IntegrationError(
+        `Integration for ${params.service} disappeared during update`,
+        ErrorCodes.INTEGRATION_NOT_FOUND,
+      );
+    }
+    return {
+      id: updated.id,
+      service: updated.service,
+      status: 'active',
+      config: updated.config as unknown as Record<string, unknown>,
+      createdAt: updated.createdAt,
+    };
+  }
+
   const integrationId = crypto.randomUUID();
   const created = await db.createIntegration(appDb, {
     id: integrationId,
@@ -111,7 +130,6 @@ export async function configureIntegration(
     config: params.config,
   });
 
-  // Update status to active
   await db.updateIntegrationStatus(appDb, integrationId, 'active');
 
   return {

--- a/packages/worker/src/services/outbound-url-policy.test.ts
+++ b/packages/worker/src/services/outbound-url-policy.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { validateOutboundUrl } from './outbound-url-policy.js';
+
+describe('outbound URL policy', () => {
+  it('accepts public HTTPS URLs and validates resolved addresses when provided', async () => {
+    await expect(validateOutboundUrl('https://mcp.salesforce.com/platform/mcp')).resolves.toEqual(
+      new URL('https://mcp.salesforce.com/platform/mcp'),
+    );
+
+    await expect(validateOutboundUrl('https://mcp.example.com', {
+      resolveHost: async () => ['203.0.113.10'],
+    })).rejects.toThrow(/not allowed/i);
+
+    await expect(validateOutboundUrl('https://mcp.example.com', {
+      resolveHost: async () => ['8.8.8.8', '2001:4860:4860::8888'],
+    })).resolves.toEqual(new URL('https://mcp.example.com/'));
+  });
+
+  it('rejects non-public URL forms before they can be stored or fetched', async () => {
+    const rejected = [
+      'http://mcp.example.com',
+      'https://user:pass@mcp.example.com',
+      'https://mcp.example.com:8443',
+      'https://mcp.example.com/path#fragment',
+      'https://localhost/mcp',
+      'https://api.local/mcp',
+      'https://api.internal/mcp',
+      'https://internal/mcp',
+      'https://127.0.0.1/mcp',
+      'https://10.0.0.5/mcp',
+      'https://[::1]/mcp',
+      'https://[fd00::1]/mcp',
+      'https://[::ffff:10.0.0.5]/mcp',
+      'https://169.254.169.254/latest/meta-data',
+    ];
+
+    for (const url of rejected) {
+      await expect(validateOutboundUrl(url)).rejects.toThrow(/not allowed|https|credentials|fragment|port/i);
+    }
+  });
+
+  it('rejects injected resolved addresses that are private, reserved, or metadata ranges', async () => {
+    const blockedAnswers = [
+      '127.0.0.1',
+      '10.1.2.3',
+      '172.16.0.1',
+      '192.168.0.1',
+      '100.64.0.1',
+      '169.254.169.254',
+      '192.0.2.10',
+      '198.51.100.10',
+      '203.0.113.10',
+      '::1',
+      'fc00::1',
+      'fe80::1',
+      '::ffff:192.168.0.1',
+    ];
+
+    for (const address of blockedAnswers) {
+      await expect(validateOutboundUrl('https://mcp.example.com', {
+        resolveHost: async () => [address],
+      })).rejects.toThrow(/resolved/i);
+    }
+  });
+});

--- a/packages/worker/src/services/outbound-url-policy.ts
+++ b/packages/worker/src/services/outbound-url-policy.ts
@@ -1,0 +1,207 @@
+import { ValidationError } from '@valet/shared';
+
+export interface OutboundUrlPolicyOptions {
+  resolveHost?: (hostname: string) => Promise<string[]>;
+}
+
+const BLOCKED_HOST_SUFFIXES = ['.localhost', '.local', '.internal'];
+
+export async function validateOutboundUrl(
+  input: string | URL,
+  options: OutboundUrlPolicyOptions = {},
+): Promise<URL> {
+  const url = input instanceof URL ? new URL(input.href) : parseUrl(input);
+
+  if (url.protocol !== 'https:') {
+    throw new ValidationError('Outbound connector URLs must use https.');
+  }
+  if (url.username || url.password) {
+    throw new ValidationError('Outbound connector URLs must not include credentials.');
+  }
+  if (url.hash) {
+    throw new ValidationError('Outbound connector URLs must not include fragments.');
+  }
+  if (url.port && url.port !== '443') {
+    throw new ValidationError('Outbound connector URLs must use the default HTTPS port.');
+  }
+
+  const hostname = normalizeHostname(url.hostname);
+  validateHostname(hostname);
+
+  if (options.resolveHost) {
+    const addresses = await options.resolveHost(hostname);
+    if (addresses.length === 0) {
+      throw new ValidationError(`Outbound connector host "${hostname}" did not resolve to any addresses.`);
+    }
+    for (const address of addresses) {
+      validateResolvedAddress(address, hostname);
+    }
+  }
+
+  return url;
+}
+
+function parseUrl(input: string): URL {
+  try {
+    return new URL(input);
+  } catch {
+    throw new ValidationError('Outbound connector URL is invalid.');
+  }
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '').replace(/\.$/, '');
+}
+
+function validateHostname(hostname: string): void {
+  if (!hostname) {
+    throw new ValidationError('Outbound connector URL host is required.');
+  }
+  if (hostname === 'localhost' || BLOCKED_HOST_SUFFIXES.some((suffix) => hostname.endsWith(suffix))) {
+    throw new ValidationError(`Outbound connector host "${hostname}" is not allowed.`);
+  }
+  if (!hostname.includes('.')) {
+    throw new ValidationError(`Outbound connector host "${hostname}" is not allowed.`);
+  }
+  if (parseIPv4(hostname) || parseIPv6(hostname)) {
+    throw new ValidationError('Outbound connector IP literals are not allowed; use a public DNS hostname.');
+  }
+}
+
+function validateResolvedAddress(address: string, hostname: string): void {
+  const normalized = normalizeHostname(address);
+  const ipv4 = parseIPv4(normalized);
+  if (ipv4) {
+    if (!isPublicIPv4(ipv4)) {
+      throw new ValidationError(`Outbound connector host "${hostname}" resolved to a non-public address and is not allowed.`);
+    }
+    return;
+  }
+
+  const ipv6 = parseIPv6(normalized);
+  if (ipv6) {
+    const mapped = getIPv4MappedAddress(ipv6);
+    if (mapped) {
+      if (!isPublicIPv4(mapped)) {
+        throw new ValidationError(`Outbound connector host "${hostname}" resolved to a non-public address and is not allowed.`);
+      }
+      return;
+    }
+
+    if (!isPublicIPv6(ipv6)) {
+      throw new ValidationError(`Outbound connector host "${hostname}" resolved to a non-public address and is not allowed.`);
+    }
+    return;
+  }
+
+  throw new ValidationError(`Outbound connector host "${hostname}" resolved to an invalid address.`);
+}
+
+function parseIPv4(value: string): number[] | null {
+  const parts = value.split('.');
+  if (parts.length !== 4) return null;
+  const octets = parts.map((part) => {
+    if (!/^\d{1,3}$/.test(part)) return Number.NaN;
+    const n = Number(part);
+    return n >= 0 && n <= 255 ? n : Number.NaN;
+  });
+  return octets.some(Number.isNaN) ? null : octets;
+}
+
+function ipv4ToInt(octets: number[]): number {
+  return ((octets[0] << 24) >>> 0) + (octets[1] << 16) + (octets[2] << 8) + octets[3];
+}
+
+function inIPv4Range(octets: number[], cidrBase: string, bits: number): boolean {
+  const base = parseIPv4(cidrBase);
+  if (!base) return false;
+  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+  return (ipv4ToInt(octets) & mask) === (ipv4ToInt(base) & mask);
+}
+
+function isPublicIPv4(octets: number[]): boolean {
+  const blocked: Array<[string, number]> = [
+    ['0.0.0.0', 8],
+    ['10.0.0.0', 8],
+    ['100.64.0.0', 10],
+    ['127.0.0.0', 8],
+    ['169.254.0.0', 16],
+    ['172.16.0.0', 12],
+    ['192.0.0.0', 24],
+    ['192.0.2.0', 24],
+    ['192.168.0.0', 16],
+    ['198.18.0.0', 15],
+    ['198.51.100.0', 24],
+    ['203.0.113.0', 24],
+    ['224.0.0.0', 4],
+    ['240.0.0.0', 4],
+  ];
+  return !blocked.some(([base, bits]) => inIPv4Range(octets, base, bits));
+}
+
+function parseIPv6(value: string): number[] | null {
+  let input = value.toLowerCase();
+  const zoneIndex = input.indexOf('%');
+  if (zoneIndex !== -1) input = input.slice(0, zoneIndex);
+  if (!input.includes(':')) return null;
+
+  let ipv4Tail: number[] | null = null;
+  const lastColon = input.lastIndexOf(':');
+  const tail = input.slice(lastColon + 1);
+  if (tail.includes('.')) {
+    ipv4Tail = parseIPv4(tail);
+    if (!ipv4Tail) return null;
+    input = `${input.slice(0, lastColon)}:${((ipv4Tail[0] << 8) | ipv4Tail[1]).toString(16)}:${((ipv4Tail[2] << 8) | ipv4Tail[3]).toString(16)}`;
+  }
+
+  const halves = input.split('::');
+  if (halves.length > 2) return null;
+
+  const left = halves[0] ? halves[0].split(':') : [];
+  const right = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  const parseGroup = (group: string): number | null => {
+    if (!/^[0-9a-f]{1,4}$/.test(group)) return null;
+    return parseInt(group, 16);
+  };
+
+  const leftGroups = left.map(parseGroup);
+  const rightGroups = right.map(parseGroup);
+  if (leftGroups.some((g) => g === null) || rightGroups.some((g) => g === null)) return null;
+
+  const present = leftGroups.length + rightGroups.length;
+  if (halves.length === 1) {
+    if (present !== 8) return null;
+    return leftGroups as number[];
+  }
+
+  const zeroCount = 8 - present;
+  if (zeroCount < 1) return null;
+  return [
+    ...(leftGroups as number[]),
+    ...Array.from({ length: zeroCount }, () => 0),
+    ...(rightGroups as number[]),
+  ];
+}
+
+function getIPv4MappedAddress(groups: number[]): number[] | null {
+  const isMapped = groups[0] === 0
+    && groups[1] === 0
+    && groups[2] === 0
+    && groups[3] === 0
+    && groups[4] === 0
+    && groups[5] === 0xffff;
+  if (!isMapped) return null;
+  return [groups[6] >> 8, groups[6] & 0xff, groups[7] >> 8, groups[7] & 0xff];
+}
+
+function isPublicIPv6(groups: number[]): boolean {
+  const allZero = groups.every((group) => group === 0);
+  const loopback = groups.slice(0, 7).every((group) => group === 0) && groups[7] === 1;
+  const first = groups[0];
+  if (allZero || loopback) return false;
+  if ((first & 0xfe00) === 0xfc00) return false; // ULA fc00::/7
+  if ((first & 0xffc0) === 0xfe80) return false; // link-local fe80::/10
+  if ((first & 0xff00) === 0xff00) return false; // multicast ff00::/8
+  if (groups[0] === 0x2001 && groups[1] === 0x0db8) return false; // documentation
+  return true;
+}

--- a/packages/worker/src/services/safe-fetch-outbound.test.ts
+++ b/packages/worker/src/services/safe-fetch-outbound.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createSafeFetchOutbound,
+  safeFetchOutbound,
+} from './safe-fetch-outbound.js';
+
+describe('safeFetchOutbound', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('forces manual redirects and rejects redirects for MCP and OAuth token requests', async () => {
+    const fetchMock = vi.fn(async () => new Response(null, {
+      status: 302,
+      headers: { Location: 'https://mcp.example.com/next' },
+    }));
+    const fetchFn = createSafeFetchOutbound({ fetch: fetchMock });
+
+    await expect(fetchFn('https://mcp.example.com/rpc', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    })).rejects.toThrow(/redirect/i);
+
+    expect(fetchMock).toHaveBeenCalledWith('https://mcp.example.com/rpc', expect.objectContaining({
+      redirect: 'manual',
+    }));
+  });
+
+  it('follows discovery redirects only through policy-approved targets', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, {
+        status: 302,
+        headers: { Location: 'https://auth.example.com/.well-known/oauth-authorization-server' },
+      }))
+      .mockResolvedValueOnce(Response.json({ issuer: 'https://auth.example.com' }));
+
+    const res = await safeFetchOutbound('https://mcp.example.com/.well-known/oauth-authorization-server', {}, {
+      mode: 'discovery',
+      fetch: fetchMock,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toBe('https://auth.example.com/.well-known/oauth-authorization-server');
+  });
+
+  it('does not forward sensitive headers to a different origin during discovery redirects', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, {
+        status: 302,
+        headers: { Location: 'https://auth.example.com/metadata' },
+      }))
+      .mockResolvedValueOnce(Response.json({ issuer: 'https://auth.example.com' }));
+
+    await safeFetchOutbound('https://mcp.example.com/metadata', {
+      headers: {
+        Authorization: 'Bearer secret',
+        Cookie: 'sid=secret',
+        'X-Tenant': 'acme',
+      },
+    }, {
+      mode: 'discovery',
+      fetch: fetchMock,
+    });
+
+    const redirectedInit = fetchMock.mock.calls[1][1] as RequestInit;
+    const redirectedHeaders = new Headers(redirectedInit.headers);
+    expect(redirectedHeaders.has('Authorization')).toBe(false);
+    expect(redirectedHeaders.has('Cookie')).toBe(false);
+    expect(redirectedHeaders.has('X-Tenant')).toBe(false);
+  });
+
+  it('returns large MCP responses without applying a response-size cap', async () => {
+    const body = 'x'.repeat(128 * 1024);
+    const fetchMock = vi.fn(async () => new Response(body));
+
+    const res = await safeFetchOutbound('https://mcp.example.com/rpc', {}, {
+      fetch: fetchMock,
+    });
+
+    await expect(res.text()).resolves.toHaveLength(body.length);
+  });
+
+  it('keeps the timeout active until the returned response body finishes', async () => {
+    let bodyController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal as AbortSignal;
+      return new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          bodyController = controller;
+          signal.addEventListener('abort', () => controller.error(new Error('aborted')));
+        },
+      }));
+    });
+
+    const responsePromise = safeFetchOutbound('https://mcp.example.com/rpc', {}, {
+      fetch: fetchMock,
+      timeoutMs: 10,
+    });
+    try {
+      const res = await Promise.race([
+        responsePromise,
+        delay(50).then(() => {
+          throw new Error('safeFetchOutbound did not return before the response body completed');
+        }),
+      ]);
+      const readResult = res.text().then(
+        () => 'resolved',
+        () => 'rejected',
+      );
+
+      await delay(25);
+      await expect(Promise.race([readResult, Promise.resolve('pending')])).resolves.toBe('rejected');
+    } finally {
+      try {
+        bodyController?.close();
+      } catch {
+        // Stream may already be errored by the timeout.
+      }
+    }
+  });
+});
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/worker/src/services/safe-fetch-outbound.ts
+++ b/packages/worker/src/services/safe-fetch-outbound.ts
@@ -101,7 +101,7 @@ function composeAbortSignal(existing: AbortSignal | null | undefined, controller
 }
 
 function isRedirect(status: number): boolean {
-  return status >= 300 && status < 400;
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
 }
 
 function responseWithTimedBody(response: Response, timeout: ReturnType<typeof setTimeout>): Response {

--- a/packages/worker/src/services/safe-fetch-outbound.ts
+++ b/packages/worker/src/services/safe-fetch-outbound.ts
@@ -1,0 +1,162 @@
+import { ValidationError } from '@valet/shared';
+import { validateOutboundUrl, type OutboundUrlPolicyOptions } from './outbound-url-policy.js';
+
+export type SafeFetchMode = 'mcp' | 'oauth-token' | 'discovery';
+
+export interface SafeFetchOutboundOptions extends OutboundUrlPolicyOptions {
+  mode?: SafeFetchMode;
+  fetch?: typeof fetch;
+  maxRedirects?: number;
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_REDIRECTS = 3;
+
+export function createSafeFetchOutbound(defaultOptions: SafeFetchOutboundOptions = {}): typeof fetch {
+  return (input, init) => safeFetchOutbound(input, init, defaultOptions);
+}
+
+export async function safeFetchOutbound(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+  options: SafeFetchOutboundOptions = {},
+): Promise<Response> {
+  const fetchImpl = options.fetch ?? fetch;
+  const mode = options.mode ?? 'mcp';
+  const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  let currentUrl = await validateOutboundUrl(getInputUrl(input), options);
+  let currentInput: RequestInfo | URL = currentUrl.href;
+  let currentInit = mergeRequestInit(input, init);
+
+  for (let redirects = 0; ; redirects++) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const signal = composeAbortSignal(currentInit.signal, controller);
+    let response: Response;
+    try {
+      response = await fetchImpl(currentInput, {
+        ...currentInit,
+        redirect: 'manual',
+        signal,
+      });
+    } catch (err) {
+      clearTimeout(timeout);
+      throw err;
+    }
+
+    if (!isRedirect(response.status)) {
+      return responseWithTimedBody(response, timeout);
+    }
+
+    clearTimeout(timeout);
+
+    const location = response.headers.get('location');
+    if (!location) {
+      throw new ValidationError('Outbound connector request returned a redirect without a Location header.');
+    }
+    if (mode !== 'discovery') {
+      throw new ValidationError('Outbound connector requests do not follow redirects.');
+    }
+    if (redirects >= maxRedirects) {
+      throw new ValidationError('Outbound connector discovery exceeded the redirect limit.');
+    }
+
+    const nextUrl = await validateOutboundUrl(new URL(location, currentUrl), options);
+    const sameOrigin = nextUrl.origin === currentUrl.origin;
+    currentInit = {
+      ...currentInit,
+      headers: sameOrigin ? currentInit.headers : stripCrossOriginHeaders(currentInit.headers),
+    };
+    currentUrl = nextUrl;
+    currentInput = nextUrl.href;
+  }
+}
+
+function getInputUrl(input: RequestInfo | URL): string | URL {
+  if (input instanceof Request) return input.url;
+  return input;
+}
+
+function mergeRequestInit(input: RequestInfo | URL, init: RequestInit): RequestInit {
+  if (!(input instanceof Request)) return { ...init };
+  return {
+    method: init.method ?? input.method,
+    headers: init.headers ?? input.headers,
+    body: init.body ?? input.body,
+    ...init,
+  };
+}
+
+function composeAbortSignal(existing: AbortSignal | null | undefined, controller: AbortController): AbortSignal {
+  if (!existing) return controller.signal;
+  if (existing.aborted) {
+    controller.abort();
+    return controller.signal;
+  }
+  existing.addEventListener('abort', () => controller.abort(), { once: true });
+  return controller.signal;
+}
+
+function isRedirect(status: number): boolean {
+  return status >= 300 && status < 400;
+}
+
+function responseWithTimedBody(response: Response, timeout: ReturnType<typeof setTimeout>): Response {
+  if (!response.body) {
+    clearTimeout(timeout);
+    return response;
+  }
+
+  return new Response(wrapTimedBody(response.body, timeout), {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
+function wrapTimedBody(body: ReadableStream<Uint8Array>, timeout: ReturnType<typeof setTimeout>): ReadableStream<Uint8Array> {
+  const reader = body.getReader();
+  let cleanedUp = false;
+  const cleanup = () => {
+    if (!cleanedUp) {
+      cleanedUp = true;
+      clearTimeout(timeout);
+    }
+  };
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          cleanup();
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (err) {
+        cleanup();
+        controller.error(err);
+      }
+    },
+    async cancel(reason) {
+      cleanup();
+      await reader.cancel(reason).catch(() => undefined);
+    },
+  });
+}
+
+function stripCrossOriginHeaders(headers: HeadersInit | undefined): Headers {
+  const stripped = new Headers();
+  const original = new Headers(headers);
+  for (const [name, value] of original) {
+    const lower = name.toLowerCase();
+    if (lower === 'accept' || lower === 'content-type') {
+      stripped.set(name, value);
+    }
+  }
+  return stripped;
+}

--- a/packages/worker/src/services/session-tools.test.ts
+++ b/packages/worker/src/services/session-tools.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { resolveActionPolicy } from './session-tools.js';
+import { listTools, resolveActionPolicy } from './session-tools.js';
 import { createTestDb } from '../test-utils/db.js';
 import { upsertActionPolicy } from '../lib/db/actions.js';
 import { upsertMcpToolCache } from '../lib/db/mcp-tool-cache.js';
-import { integrations, sessions, users } from '../lib/schema/index.js';
+import { integrations, sessions, users, customMcpConnectors, disabledActions } from '../lib/schema/index.js';
+import { encryptString } from '../lib/crypto.js';
+import type { AppDb } from '../lib/drizzle.js';
 import { integrationRegistry } from '../integrations/registry.js';
 import type { Env } from '../env.js';
+import type { ActionSource, IntegrationProvider } from '@valet/sdk';
 
 const USER_ID = 'mcp-policy-user';
 const SESSION_ID = 'mcp-policy-session';
@@ -28,13 +31,59 @@ function emptyCredentialCache() {
   };
 }
 
+function envWithEncryption(): Env {
+  return { ENCRYPTION_KEY: 'test-encryption-key' } as Env;
+}
+
+function stubMcpFetch() {
+  const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body));
+    if (body.method === 'initialize') {
+      return new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        id: body.id,
+        result: {
+          protocolVersion: '2025-11-25',
+          capabilities: {},
+          serverInfo: { name: 'custom-mcp', version: '1.0.0' },
+        },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json', 'mcp-session-id': 'session-1' },
+      });
+    }
+    if (body.method === 'notifications/initialized') {
+      return new Response(null, { status: 202 });
+    }
+    return new Response(JSON.stringify({
+      jsonrpc: '2.0',
+      id: body.id,
+      result: {
+        tools: [{
+          name: 'query',
+          description: 'Query records',
+          inputSchema: { type: 'object' },
+          annotations: { readOnlyHint: true },
+        }],
+      },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
 describe('resolveActionPolicy', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('uses cached MCP risk metadata when runtime listActions misses the tool', async () => {
     const { db } = createTestDb();
+    const appDb: AppDb = db;
     db.insert(users).values({ id: USER_ID, email: 'mcp-policy@example.com' }).run();
     db.insert(sessions).values({
       id: SESSION_ID,
@@ -49,27 +98,36 @@ describe('resolveActionPolicy', () => {
       config: { entities: [] },
       status: 'active',
     }).run();
-    await upsertActionPolicy(db as any, {
+    await upsertActionPolicy(appDb, {
       id: 'deny-critical',
       riskLevel: 'critical',
       mode: 'deny',
       createdBy: USER_ID,
     });
-    await upsertMcpToolCache(db as any, [{
+    await upsertMcpToolCache(appDb, [{
       service: 'mcp_service',
       actionId: 'dangerous_tool',
       name: 'Dangerous Tool',
       description: 'Known critical MCP tool',
       riskLevel: 'critical',
     }]);
-    vi.spyOn(integrationRegistry, 'getActions').mockReturnValue({
+    const emptyActionSource: ActionSource = {
       listActions: vi.fn(async () => []),
       execute: vi.fn(),
-    } as any);
-    vi.spyOn(integrationRegistry, 'getProvider').mockReturnValue({ authType: 'none' } as any);
+    };
+    const noAuthProvider: IntegrationProvider = {
+      service: 'mcp_service',
+      displayName: 'MCP Service',
+      authType: 'none',
+      supportedEntities: [],
+      validateCredentials: () => true,
+      testConnection: async () => true,
+    };
+    vi.spyOn(integrationRegistry, 'getActions').mockReturnValue(emptyActionSource);
+    vi.spyOn(integrationRegistry, 'getProvider').mockReturnValue(noAuthProvider);
 
     const result = await resolveActionPolicy(
-      db as any,
+      appDb,
       mockD1(),
       {} as Env,
       USER_ID,
@@ -86,6 +144,115 @@ describe('resolveActionPolicy', () => {
     expect(result).toMatchObject({
       outcome: 'denied',
       riskLevel: 'critical',
+    });
+  });
+
+  it('lists custom API-key connector tools without resolving user credentials', async () => {
+    const { db } = createTestDb();
+    const appDb: AppDb = db;
+    db.insert(users).values({ id: USER_ID, email: 'mcp-policy@example.com' }).run();
+    db.insert(customMcpConnectors).values({
+      id: 'connector-1',
+      orgId: 'default',
+      serviceSlug: 'salesforce',
+      displayName: 'Salesforce',
+      serverUrl: 'https://mcp.example.com',
+      authType: 'api_key',
+      encryptedApiKey: await encryptString('org-api-key', 'test-encryption-key'),
+      apiKeyHeaderName: 'X-API-Key',
+      apiKeyPrefix: null,
+      status: 'active',
+    }).run();
+    const fetchMock = stubMcpFetch();
+    const credentialCache = emptyCredentialCache();
+    const resolveSpy = vi.spyOn(integrationRegistry, 'resolveCredentials');
+
+    const result = await listTools(appDb, mockD1(), envWithEncryption(), USER_ID, {
+      credentialCache,
+      orgId: 'default',
+    });
+
+    expect(result.tools).toMatchObject([{ id: 'salesforce:salesforce.query', riskLevel: 'low' }]);
+    expect(resolveSpy).not.toHaveBeenCalledWith('salesforce', expect.anything(), expect.anything(), expect.anything());
+    const toolsListHeaders = new Headers((fetchMock.mock.calls.at(-1)?.[1] as RequestInit).headers);
+    expect(toolsListHeaders.get('X-API-Key')).toBe('org-api-key');
+  });
+
+  it('filters disabled actions for custom connector slugs', async () => {
+    const { db } = createTestDb();
+    const appDb: AppDb = db;
+    db.insert(users).values({ id: USER_ID, email: 'mcp-policy@example.com' }).run();
+    db.insert(customMcpConnectors).values({
+      id: 'connector-1',
+      orgId: 'default',
+      serviceSlug: 'salesforce',
+      displayName: 'Salesforce',
+      serverUrl: 'https://mcp.example.com',
+      authType: 'api_key',
+      encryptedApiKey: await encryptString('org-api-key', 'test-encryption-key'),
+      apiKeyHeaderName: 'X-API-Key',
+      status: 'active',
+    }).run();
+    db.insert(disabledActions).values({
+      id: 'disabled-salesforce-query',
+      service: 'salesforce',
+      actionId: 'salesforce.query',
+      disabledBy: USER_ID,
+    }).run();
+    stubMcpFetch();
+
+    const result = await listTools(appDb, mockD1(), envWithEncryption(), USER_ID, {
+      credentialCache: emptyCredentialCache(),
+      orgId: 'default',
+    });
+
+    expect(result.discoveredRiskLevels.get('salesforce:salesforce.query')).toBe('low');
+    expect(result.tools.some((tool) => tool.id === 'salesforce:salesforce.query')).toBe(false);
+  });
+
+  it('allows active custom API-key connector policy resolution without an integration row', async () => {
+    const { db } = createTestDb();
+    const appDb: AppDb = db;
+    db.insert(users).values({ id: USER_ID, email: 'mcp-policy@example.com' }).run();
+    db.insert(sessions).values({
+      id: SESSION_ID,
+      userId: USER_ID,
+      workspace: '/tmp/mcp-policy',
+      status: 'running',
+    }).run();
+    db.insert(customMcpConnectors).values({
+      id: 'connector-1',
+      orgId: 'default',
+      serviceSlug: 'salesforce',
+      displayName: 'Salesforce',
+      serverUrl: 'https://mcp.example.com',
+      authType: 'api_key',
+      encryptedApiKey: await encryptString('org-api-key', 'test-encryption-key'),
+      apiKeyHeaderName: 'X-API-Key',
+      status: 'active',
+    }).run();
+
+    const result = await resolveActionPolicy(
+      appDb,
+      mockD1(),
+      envWithEncryption(),
+      USER_ID,
+      'salesforce:salesforce.query',
+      {},
+      {
+        sessionId: SESSION_ID,
+        discoveredToolRiskLevels: new Map([['salesforce:salesforce.query', 'low']]),
+        credentialCache: emptyCredentialCache(),
+        disabledPluginServicesCache: null,
+        orgId: 'default',
+      },
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'allowed',
+      service: 'salesforce',
+      actionId: 'salesforce.query',
+      riskLevel: 'low',
     });
   });
 });

--- a/packages/worker/src/services/session-tools.ts
+++ b/packages/worker/src/services/session-tools.ts
@@ -8,6 +8,7 @@ import { getDisabledActionsIndex, isActionDisabled } from '../lib/db/disabled-ac
 import { listMcpToolCache, upsertMcpToolCache } from '../lib/db/mcp-tool-cache.js';
 import { getAutoEnabledServices, getDisabledPluginServices } from '../lib/db/plugins.js';
 import { getUserIdentityLinks, getOrchestratorIdentity } from '../lib/db.js';
+import { loadCustomMcpConnectorContext } from './custom-mcp-connectors.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -55,6 +56,7 @@ export interface ListToolsOpts {
   service?: string;
   query?: string;
   credentialCache: CredentialCache;
+  orgId?: string;
 }
 
 export type InvokeOutcome = 'denied' | 'pending_approval' | 'allowed';
@@ -140,15 +142,16 @@ export async function listTools(
   userId: string,
   opts?: ListToolsOpts,
 ): Promise<ListToolsResult> {
-  const { service: filterService, query, credentialCache } = opts ?? {} as ListToolsOpts;
+  const { service: filterService, query, credentialCache, orgId = 'default' } = opts ?? {} as ListToolsOpts;
 
-  const [userIntegrations, orgIntegrations, autoServices, { disabledActions: disabledActionSet, disabledServices: disabledServiceSet }, disabledPluginServices] =
+  const [userIntegrations, orgIntegrations, autoServices, { disabledActions: disabledActionSet, disabledServices: disabledServiceSet }, disabledPluginServices, customContext] =
     await Promise.all([
       getUserIntegrations(appDb, userId),
       getOrgIntegrations(appDb),
-      getAutoEnabledServices(envDB),
+      getAutoEnabledServices(envDB, orgId),
       getDisabledActionsIndex(appDb),
-      getDisabledPluginServices(envDB),
+      getDisabledPluginServices(envDB, orgId),
+      loadCustomMcpConnectorContext(env, appDb, orgId),
     ]);
 
   // Group all active integrations by service, deduplicate by ID
@@ -171,6 +174,15 @@ export async function listTools(
     }
   }
 
+  for (const connector of customContext.connectors.values()) {
+    if (connector.authType === 'oauth') {
+      continue;
+    }
+    if (!serviceSourceMap.has(connector.serviceSlug)) {
+      serviceSourceMap.set(connector.serviceSlug, [{ id: `custom:${connector.serviceSlug}`, scope: 'org' as const, userId }]);
+    }
+  }
+
   console.log(`[session-tools] list-tools: userId=${userId}, service=${filterService ?? 'all'}, services with sources: [${[...serviceSourceMap.keys()].join(', ')}]`);
 
   const tools: ToolDescriptor[] = [];
@@ -183,16 +195,16 @@ export async function listTools(
     if (disabledServiceSet.has(service)) continue;
     if (disabledPluginServices.has(service)) continue;
 
-    const actionSource = integrationRegistry.getActions(service);
+    const actionSource = integrationRegistry.getActions(service, customContext);
     if (!actionSource) continue;
 
-    const provider = integrationRegistry.getProvider(service);
+    const provider = integrationRegistry.getProvider(service, customContext);
 
     // MCP-backed sources need credentials for listing (they return different tools per user).
     // Static sources (no mcpServerUrl) skip credential resolution during listing.
     let credCtx: { credentials: { access_token: string } } | undefined;
     const isMcpSource = !!provider?.mcpServerUrl;
-    if (isMcpSource && provider?.authType !== 'none') {
+    if (isMcpSource && requiresUserCredential(provider)) {
       const firstSource = sources[0];
 
       // Check credential cache first
@@ -236,7 +248,7 @@ export async function listTools(
     let actions = await actionSource.listActions(credCtx);
 
     // MCP sources may return [] when tokens are silently expired — force-refresh and retry
-    if (actions.length === 0 && isMcpSource && credCtx && provider?.authType !== 'none') {
+    if (actions.length === 0 && isMcpSource && credCtx && requiresUserCredential(provider)) {
       credentialCache?.invalidate('user', userId, service);
       const refreshed = await integrationRegistry.resolveCredentials(service, env, userId, {
         forceRefresh: true,
@@ -312,6 +324,7 @@ export async function resolveActionPolicy(
     discoveredToolRiskLevels: Map<string, string>;
     credentialCache: CredentialCache;
     disabledPluginServicesCache: { services: Set<string>; expiresAt: number } | null;
+    orgId?: string;
   },
 ): Promise<PolicyResult & {
   service: string;
@@ -326,6 +339,9 @@ export async function resolveActionPolicy(
   }
   const service = toolId.slice(0, colonIndex);
   const actionId = toolId.slice(colonIndex + 1);
+  const orgId = opts.orgId ?? 'default';
+  const customContext = await loadCustomMcpConnectorContext(env, appDb, orgId);
+  const customConnector = customContext.connectors.get(service);
 
   // Safety net: reject disabled actions even if the tool ID was guessed
   if (await isActionDisabled(appDb, service, actionId)) {
@@ -336,7 +352,7 @@ export async function resolveActionPolicy(
   let disabledPluginServicesCache = opts.disabledPluginServicesCache;
   if (!disabledPluginServicesCache || Date.now() > disabledPluginServicesCache.expiresAt) {
     disabledPluginServicesCache = {
-      services: await getDisabledPluginServices(envDB),
+      services: await getDisabledPluginServices(envDB, orgId),
       expiresAt: Date.now() + 60 * 1000, // 1 minute TTL
     };
   }
@@ -350,16 +366,17 @@ export async function resolveActionPolicy(
   const hasActiveIntegration = [...userIntegrations, ...orgIntegrations].some(
     (i) => i.service === service && i.status === 'active',
   );
+  const customConnectorDoesNotNeedIntegration = !!customConnector && customConnector.authType !== 'oauth';
 
-  if (!hasActiveIntegration) {
-    const autoServices = await getAutoEnabledServices(envDB);
+  if (!hasActiveIntegration && !customConnectorDoesNotNeedIntegration) {
+    const autoServices = await getAutoEnabledServices(envDB, orgId);
     if (!autoServices.includes(service)) {
       throw new Error(`Integration "${service}" is not active. Configure it in Settings > Integrations.`);
     }
   }
 
   // Look up ActionSource
-  const actionSource = integrationRegistry.getActions(service);
+  const actionSource = integrationRegistry.getActions(service, customContext);
   if (!actionSource) {
     throw new Error(`No integration package found for service "${service}".`);
   }
@@ -373,9 +390,9 @@ export async function resolveActionPolicy(
     riskLevel = cachedRisk;
   } else {
     // Resolve list context for policy fallback — skip credential lookup for no-auth services
-    const fallbackProvider = integrationRegistry.getProvider(service);
+    const fallbackProvider = integrationRegistry.getProvider(service, customContext);
     let listCtx: { credentials: { access_token: string } } | undefined;
-    if (fallbackProvider?.authType !== 'none') {
+    if (requiresUserCredential(fallbackProvider)) {
       const listCredResult = await integrationRegistry.resolveCredentials(service, env, userId, {
         forceRefresh: false,
       });
@@ -418,6 +435,7 @@ export async function resolveActionPolicy(
 
 export interface ExecuteActionOpts {
   credentialCache: CredentialCache;
+  orgId?: string;
   /** Spawn request env vars, used to detect orchestrator sessions */
   spawnEnvVars?: Record<string, string>;
   /** Org-level guard configuration, threaded from the DO to action plugins. */
@@ -445,11 +463,13 @@ export async function executeAction(
     return { success: false, error: `No integration package found for service "${service}".`, analyticsEvents: [], durationMs: 0 };
   }
 
-  const provider = integrationRegistry.getProvider(service);
+  const orgId = opts.orgId ?? 'default';
+  const customContext = await loadCustomMcpConnectorContext(env, appDb, orgId);
+  const provider = integrationRegistry.getProvider(service, customContext);
   let credentials: Record<string, string>;
   let attribution: { name: string; email: string } | undefined;
 
-  if (provider?.authType === 'none') {
+  if (!requiresUserCredential(provider)) {
     credentials = {};
   } else {
     const credResult = await integrationRegistry.resolveCredentials(service, env, userId, {
@@ -491,7 +511,7 @@ export async function executeAction(
   const toolExecStart = Date.now();
   let actionResult;
   try {
-    actionResult = await actionSource.execute(actionId, params, { credentials, userId, attribution, callerIdentity, analytics: actionAnalytics, guardConfig: opts.guardConfig });
+    actionResult = await actionSource.execute(actionId, params, { credentials, userId, orgId, attribution, callerIdentity, analytics: actionAnalytics, guardConfig: opts.guardConfig });
 
     // Auth failure retry — force-refresh on 401 and retry once (simple token-expired retry)
     // Note: 403 is excluded — GitHub 403s are permission problems (missing App permissions),
@@ -499,7 +519,7 @@ export async function executeAction(
     const isAuthError = !actionResult.success && actionResult.error &&
       /\b(401|unauthorized|invalid.credentials|token.*expired|token.*revoked)\b/i.test(actionResult.error);
 
-    if (provider?.authType !== 'none' && provider?.authType !== 'bot_token' && isAuthError) {
+    if (requiresUserCredential(provider) && provider?.authType !== 'bot_token' && isAuthError) {
       console.log(`[session-tools] Tool "${toolId}" auth error, force-refreshing credential`);
       const refreshed = await integrationRegistry.resolveCredentials(service, env, userId, {
         params,
@@ -513,6 +533,7 @@ export async function executeAction(
         }
         actionResult = await actionSource.execute(actionId, params, {
           credentials: refreshedCredentials, userId, attribution, callerIdentity, analytics: actionAnalytics, guardConfig: opts.guardConfig,
+          orgId,
         });
       }
     }
@@ -555,4 +576,11 @@ function buildCredentials(credResult: CredentialResult & { ok: true }): Record<s
     credentials._credential_type = credResult.credential.credentialType;
   }
   return credentials;
+}
+
+function requiresUserCredential(provider?: { authType?: string; isCustomConnector?: boolean }): boolean {
+  if (!provider) return false;
+  if (provider.authType === 'none') return false;
+  if (provider.isCustomConnector && provider.authType === 'api_key') return false;
+  return true;
 }


### PR DESCRIPTION
## Summary
- Add admin-managed custom MCP connector definitions with metadata, OAuth, credential storage, and registry integration.
- Surface custom connectors in settings and the connect flow, including dynamic OAuth config for providers like Salesforce.
- Add outbound URL policy and safe fetch handling for connector discovery/OAuth, with focused regression tests.

## Verification
- pnpm typecheck
- cd packages/sdk && pnpm exec vitest run src/mcp/client.test.ts src/mcp/oauth.test.ts
- cd packages/worker && pnpm exec vitest run src/routes/admin-mcp-connectors.test.ts src/routes/integrations.test.ts src/services/custom-mcp-connectors.test.ts src/services/session-tools.test.ts src/services/credentials.test.ts src/services/integrations.test.ts src/integrations/registry.test.ts src/services/outbound-url-policy.test.ts src/services/safe-fetch-outbound.test.ts src/lib/db/custom-mcp-connectors.test.ts
- cd packages/client && pnpm build
- git diff --check