### PR TITLE
Fix agent date/time awareness for ad-hoc sessions

### DIFF
--- a/packages/plugin-slack/src/actions/actions.test.ts
+++ b/packages/plugin-slack/src/actions/actions.test.ts
@@ -11,7 +11,7 @@ vi.mock('./api.js', () => ({
   slackFetch: mocks.slackFetch,
 }));
 
-import { slackActions } from './actions.js';
+import { slackActions, resolveToSlackTimestamp } from './actions.js';
 
 function slackResponse(data: Record<string, unknown>): Response {
   return new Response(JSON.stringify({ ok: true, ...data }), { status: 200 });
@@ -23,6 +23,39 @@ function actionContext(): ActionContext {
     userId: 'user-1',
   };
 }
+
+describe('resolveToSlackTimestamp', () => {
+  it('passes through Unix timestamps unchanged', () => {
+    expect(resolveToSlackTimestamp('1774000000')).toBe('1774000000');
+    expect(resolveToSlackTimestamp('1774000000.000000')).toBe('1774000000.000000');
+  });
+
+  it('converts ISO-8601 datetime to Unix seconds', () => {
+    const result = resolveToSlackTimestamp('2026-05-19T00:00:00Z');
+    const expected = (new Date('2026-05-19T00:00:00Z').getTime() / 1000).toFixed(6);
+    expect(result).toBe(expected);
+  });
+
+  it('converts date-only string to Unix seconds', () => {
+    const result = resolveToSlackTimestamp('2026-05-19');
+    const expected = (new Date('2026-05-19').getTime() / 1000).toFixed(6);
+    expect(result).toBe(expected);
+  });
+
+  it('converts ISO-8601 with timezone offset', () => {
+    const result = resolveToSlackTimestamp('2026-05-19T08:00:00-07:00');
+    const expected = (new Date('2026-05-19T08:00:00-07:00').getTime() / 1000).toFixed(6);
+    expect(result).toBe(expected);
+  });
+
+  it('trims whitespace', () => {
+    expect(resolveToSlackTimestamp('  1774000000  ')).toBe('1774000000');
+  });
+
+  it('throws on unparseable input', () => {
+    expect(() => resolveToSlackTimestamp('not-a-date')).toThrow('Cannot parse timestamp');
+  });
+});
 
 describe('slackActions list_users', () => {
   beforeEach(() => vi.clearAllMocks());

--- a/packages/plugin-slack/src/actions/actions.ts
+++ b/packages/plugin-slack/src/actions/actions.ts
@@ -19,6 +19,25 @@ async function guardPrivateChannel(token: string, channelId: string, ctx: Action
   return null;
 }
 
+// ─── Timestamp Helpers ───────────────────────────────────────────────────────
+
+/**
+ * Convert an ISO-8601 datetime string or Unix timestamp to Slack's epoch format.
+ * Pass-through values that already look like Unix timestamps (digits with optional decimal).
+ * Throws on unparseable input so the caller can return an actionable error.
+ */
+export function resolveToSlackTimestamp(input: string): string {
+  const trimmed = input.trim();
+  // Already a Unix timestamp (e.g. "1774000000" or "1774000000.000000")
+  if (/^\d+(\.\d+)?$/.test(trimmed)) return trimmed;
+  // Try parsing as a date string (ISO-8601, date-only, etc.)
+  const date = new Date(trimmed);
+  if (isNaN(date.getTime())) {
+    throw new Error(`Cannot parse timestamp "${trimmed}" — use ISO-8601 (e.g. "2026-05-19T00:00:00Z") or Unix seconds`);
+  }
+  return (date.getTime() / 1000).toFixed(6);
+}
+
 // ─── Action Definitions ──────────────────────────────────────────────────────
 
 const dmOwner: ActionDefinition = {
@@ -74,8 +93,8 @@ const readHistory: ActionDefinition = {
     channel: z.string().describe('Channel ID (C...)'),
     limit: z.number().int().min(1).max(200).optional().describe('Max messages per page (default 100, max 200)'),
     cursor: z.string().optional().describe('Pagination cursor from a previous response\'s next_cursor'),
-    oldest: z.string().optional().describe('Only messages after this Unix ts (e.g. "1774000000.000000"). Inclusive.'),
-    latest: z.string().optional().describe('Only messages before this Unix ts. Inclusive. Defaults to now.'),
+    oldest: z.string().optional().describe('Only messages after this time. Accepts ISO-8601 datetime (e.g. "2026-05-19T00:00:00-07:00") or Unix timestamp (e.g. "1774000000.000000"). Include a timezone offset for date-boundary accuracy — bare dates like "2026-05-19" resolve to midnight UTC. Inclusive.'),
+    latest: z.string().optional().describe('Only messages before this time. Accepts ISO-8601 datetime (with timezone offset) or Unix timestamp. Inclusive. Defaults to now.'),
     filter: z.string().optional().describe('Case-insensitive keyword filter applied client-side. Only messages whose text contains this substring are returned. Pagination still advances through all messages — use has_more/next_cursor to continue.'),
     threads_only: z.boolean().optional().describe('When true, only return messages that have thread replies (reply_count > 0). Useful for finding discussions in noisy alert channels.'),
     include_subtypes: z.boolean().optional().describe(
@@ -494,8 +513,12 @@ async function executeAction(
           limit: p.limit || 100,
         };
         if (p.cursor) query.cursor = p.cursor;
-        if (p.oldest) query.oldest = p.oldest;
-        if (p.latest) query.latest = p.latest;
+        try {
+          if (p.oldest) query.oldest = resolveToSlackTimestamp(p.oldest);
+          if (p.latest) query.latest = resolveToSlackTimestamp(p.latest);
+        } catch (err) {
+          return { success: false, error: String(err instanceof Error ? err.message : err) };
+        }
         if (p.oldest || p.latest) query.inclusive = true;
         const res = await slackGet('conversations.history', token, query);
         if (!res.ok) return slackError(res);

--- a/packages/runner/src/prompt.test.ts
+++ b/packages/runner/src/prompt.test.ts
@@ -116,9 +116,9 @@ describe("PromptHandler thread resume", () => {
       "GET http://opencode.test/session/persisted-thread",
       "POST http://opencode.test/session/persisted-thread/message",
     ]);
-    expect(fetchCalls[1]?.body).toMatchObject({
-      parts: [{ type: "text", text: "actual user prompt" }],
-    });
+    // Adopted persisted sessions get refreshed date context (TKAI-79)
+    const adoptedBody = fetchCalls[1]?.body as { parts: { text: string }[] };
+    expect(adoptedBody.parts[0].text).toMatch(/^\[Today is .+\]\n\nactual user prompt$/);
     expect(agentClient.sendThreadCreated).not.toHaveBeenCalled();
     expect(agentClient.sendError).not.toHaveBeenCalled();
   });
@@ -186,9 +186,9 @@ describe("PromptHandler thread resume", () => {
         },
       ],
     });
-    expect(fetchCalls[3]?.body).toMatchObject({
-      parts: [{ type: "text", text: "resume this task" }],
-    });
+    // First user prompt on a new session gets date context prepended (TKAI-79)
+    const resumeBody = fetchCalls[3]?.body as { parts: { text: string }[] };
+    expect(resumeBody.parts[0].text).toMatch(/^\[Today is .+\]\n\nresume this task$/);
     expect(agentClient.sendThreadCreated).toHaveBeenCalledTimes(1);
     expect(agentClient.sendThreadCreated).toHaveBeenCalledWith("thread-2", "new-thread-session");
     expect(agentClient.sendError).not.toHaveBeenCalled();
@@ -266,9 +266,9 @@ describe("PromptHandler thread resume", () => {
         },
       ],
     });
-    expect(fetchCalls[promptIndex]?.body).toMatchObject({
-      parts: [{ type: "text", text: "continue the work" }],
-    });
+    // First prompt on recreated session gets date context (TKAI-79)
+    const transientBody = fetchCalls[promptIndex]?.body as { parts: { text: string }[] };
+    expect(transientBody.parts[0].text).toMatch(/^\[Today is .+\]\n\ncontinue the work$/);
     expect(agentClient.sendThreadCreated).toHaveBeenCalledWith("thread-3", "recreated-after-transient");
     expect(agentClient.sendError).not.toHaveBeenCalled();
   });
@@ -327,9 +327,9 @@ describe("PromptHandler thread resume", () => {
         },
       ],
     });
-    expect(fetchCalls[2]?.body).toMatchObject({
-      parts: [{ type: "text", text: "start from here" }],
-    });
+    // First user prompt on a new session gets date context prepended (TKAI-79)
+    const legacyBody = fetchCalls[2]?.body as { parts: { text: string }[] };
+    expect(legacyBody.parts[0].text).toMatch(/^\[Today is .+\]\n\nstart from here$/);
     expect(agentClient.sendThreadCreated).toHaveBeenCalledWith("thread-4", "new-session-without-persisted-id");
     expect(agentClient.sendError).not.toHaveBeenCalled();
   });

--- a/packages/runner/src/prompt.ts
+++ b/packages/runner/src/prompt.ts
@@ -28,6 +28,30 @@ import {
   type WorkflowStepExecutionResult,
 } from "./workflow-engine.js";
 
+// ─── Date Context ────────────────────────────────────────────────────────────
+
+/**
+ * Build the date context prefix for agent prompts (TKAI-79). Returns both the
+ * date key (YYYY-MM-DD, for change detection) and the formatted prefix string.
+ * Uses a single clock read to avoid mismatches at midnight boundaries.
+ */
+function buildDateContext(): { date: string; prefix: string } {
+  const now = new Date();
+  const tz = process.env.TZ || 'UTC';
+  try {
+    const isoDate = new Intl.DateTimeFormat('en-CA', {
+      year: 'numeric', month: '2-digit', day: '2-digit', timeZone: tz,
+    }).format(now);
+    const dayOfWeek = new Intl.DateTimeFormat('en-US', {
+      weekday: 'long', timeZone: tz,
+    }).format(now);
+    return { date: isoDate, prefix: `[Today is ${dayOfWeek}, ${isoDate} (${tz})]` };
+  } catch {
+    const isoDate = now.toISOString().slice(0, 10);
+    return { date: isoDate, prefix: `[Today is ${isoDate} (UTC)]` };
+  }
+}
+
 // OpenCode ToolState status values
 type ToolStatus = "pending" | "running" | "completed" | "error";
 
@@ -429,6 +453,11 @@ export class ChannelSession {
   // True when session id was injected from DO persistence rather than created
   // in this runner process. We re-sync it before first prompt dispatch.
   adoptedPersistedSession = false;
+  // The date string last injected into this session's conversation (TKAI-79).
+  // Compared against the current date on each prompt — when it differs (new
+  // session, midnight rollover, hibernation restore) the date context is
+  // re-injected. null means no date has been injected yet.
+  lastInjectedDate: string | null = null;
 
   // Track current prompt so we can route events back to the DO
   activeMessageId: string | null = null;
@@ -822,6 +851,7 @@ export class PromptHandler {
       this.ocSessionToChannel.delete(channel.opencodeSessionId);
     }
     channel.opencodeSessionId = persisted;
+    channel.lastInjectedDate = null; // force date re-injection on restored session
     this.ocSessionToChannel.set(persisted, channel);
     channel.adoptedPersistedSession = true;
   }
@@ -917,6 +947,7 @@ export class PromptHandler {
       this.ocSessionToChannel.delete(oldId);
     }
     channel.opencodeSessionId = await this.createSession();
+    channel.lastInjectedDate = null; // force date re-injection on fresh conversation
     this.ocSessionToChannel.set(channel.opencodeSessionId, channel);
     this.agentClient.sendChannelSessionCreated(channel.channelKey, channel.opencodeSessionId);
     // Notify DO when a new OpenCode session is created for a thread channel
@@ -1505,8 +1536,15 @@ export class PromptHandler {
       // user preferences. This keeps failover anchored to the actual selected model.
       const failoverChain = this.buildModelFailoverChain(model, modelPreferences);
 
-      // Transcribe audio attachments before sending to OpenCode
+      // Inject date context when the date has changed or hasn't been injected
+      // yet (TKAI-79). Covers new sessions, midnight rollover, and hibernation
+      // restore — no separate mechanism needed for each case.
       let effectiveContent = content;
+      const { date, prefix } = buildDateContext();
+      if (channel.lastInjectedDate !== date) {
+        channel.lastInjectedDate = date;
+        effectiveContent = `${prefix}\n\n${effectiveContent}`;
+      }
       let effectiveAttachments = attachments ?? [];
       const hasAudio = effectiveAttachments.some(a => a.mime.startsWith('audio/'));
       if (hasAudio) {
@@ -2277,6 +2315,7 @@ export class PromptHandler {
 
     // Create fresh session
     channel.opencodeSessionId = await this.createSession();
+    channel.lastInjectedDate = null; // force date re-injection on fresh conversation
     this.ocSessionToChannel.set(channel.opencodeSessionId, channel);
     channel.resetPromptState();
 
@@ -2822,6 +2861,7 @@ export class PromptHandler {
       }
       // Null out session IDs — they won't survive the restart
       channel.opencodeSessionId = null;
+      channel.lastInjectedDate = null;
       channel.adoptedPersistedSession = false;
     }
 


### PR DESCRIPTION
## Summary

Fixes [TKAI-79](https://linear.app/turnkey/issue/TKAI-79): agents in ad-hoc sessions had no date awareness, causing incorrect timestamp arithmetic and date confusion when users referenced relative dates.

- **Slack `read_history` accepts ISO-8601 dates** in `oldest`/`latest` params, converting to epoch server-side via `resolveToSlackTimestamp()`. Eliminates LLM date-to-epoch arithmetic — the primary failure mode from Julie's report.
- **Runner injects `[Today is {day}, {date} ({tz})]`** into the first prompt of each OpenCode session. Uses `lastInjectedDate` on `ChannelSession` to detect date changes — handles new sessions, midnight rollover, hibernation restore, and session recreation with a single mechanism. Single clock read in `buildDateContext()` avoids midnight-boundary mismatches.

No image bump needed — Slack plugin compiles into the worker, and the Runner change only affects prompt construction.

## Test plan

- [x] `resolveToSlackTimestamp` unit tests: pass-through, ISO-8601 with/without offset, date-only, whitespace, error
- [x] Runner prompt tests: date prefix on new sessions, adopted sessions, recreated sessions, legacy thread resume
- [x] Typecheck clean on both packages