### PR TITLE
feat(analytics): API request observability — latency, leakage forensics & reliability triage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,6 +368,17 @@ async () => cloudflare.request({
 - **Can't**: access Modal container logs historically (live-stream only via `modal container logs <id>`), query logs older than CF's retention period
 - **Tip**: `modal container list --json` shows all currently running sandbox containers with full IDs; cross-reference timestamps with CF logs to correlate DO events with sandbox lifecycle
 
+### API request forensics (`request_metrics`)
+
+Every sampled `/api/*` request is recorded to the `request_metrics` D1 table (method, route pattern, status, duration, inbound `request_bytes`, `user_id`, `request_id`). Authorization failures (401/403) and 5xx are always recorded regardless of sample rate. The admin dashboard's Performance tab surfaces it (latency percentiles, slow routes, access denials, heaviest/slowest requests), or query D1 directly.
+
+The workflow for investigating a leak or failure is **aggregate → pivot**:
+
+1. Find the suspicious row(s): repeated 403s by an actor (probing / broken object-level auth), an abnormally heavy request that 5xx'd (large-file parse failure), or a slow request (timeout).
+2. Take its `request_id` and search the Worker logs for that id (`needle: { value: '<request_id>' }`) to recover the full request — headers, body, downstream calls — i.e. the *cause*.
+
+The route is stored as the low-cardinality pattern (`/api/sessions/:id`), never the raw id, so the table stays PII-light; the specific resource is recoverable via the `request_id` pivot only when an investigation needs it.
+
 ## Code Conventions
 
 ### Worker (Hono)

--- a/packages/client/src/api/analytics.ts
+++ b/packages/client/src/api/analytics.ts
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
-import type { AnalyticsPerformanceResponse, AnalyticsEventsResponse } from '@valet/shared';
+import type { AnalyticsPerformanceResponse, AnalyticsEventsResponse, RequestMetricsResponse } from '@valet/shared';
 import { api } from './client';
 
 export const analyticsKeys = {
   all: ['analytics'] as const,
   performance: (period: number) => [...analyticsKeys.all, 'performance', period] as const,
+  requests: (period: number) => [...analyticsKeys.all, 'requests', period] as const,
   events: (period: number, type?: string) => [...analyticsKeys.all, 'events', period, type] as const,
 };
 
@@ -12,6 +13,14 @@ export function useAnalyticsPerformance(periodHours: number = 720) {
   return useQuery({
     queryKey: analyticsKeys.performance(periodHours),
     queryFn: () => api.get<AnalyticsPerformanceResponse>(`/analytics/performance?period=${periodHours}`),
+    refetchInterval: 60_000,
+  });
+}
+
+export function useAnalyticsRequests(periodHours: number = 720) {
+  return useQuery({
+    queryKey: analyticsKeys.requests(periodHours),
+    queryFn: () => api.get<RequestMetricsResponse>(`/analytics/requests?period=${periodHours}`),
     refetchInterval: 60_000,
   });
 }

--- a/packages/client/src/api/analytics.ts
+++ b/packages/client/src/api/analytics.ts
@@ -1,11 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
-import type { AnalyticsPerformanceResponse, AnalyticsEventsResponse, RequestMetricsResponse } from '@valet/shared';
+import type { AnalyticsPerformanceResponse, AnalyticsEventsResponse, RequestMetricsResponse, RequestForensicsResponse } from '@valet/shared';
 import { api } from './client';
 
 export const analyticsKeys = {
   all: ['analytics'] as const,
   performance: (period: number) => [...analyticsKeys.all, 'performance', period] as const,
   requests: (period: number) => [...analyticsKeys.all, 'requests', period] as const,
+  requestForensics: (period: number) => [...analyticsKeys.all, 'request-forensics', period] as const,
   events: (period: number, type?: string) => [...analyticsKeys.all, 'events', period, type] as const,
 };
 
@@ -21,6 +22,14 @@ export function useAnalyticsRequests(periodHours: number = 720) {
   return useQuery({
     queryKey: analyticsKeys.requests(periodHours),
     queryFn: () => api.get<RequestMetricsResponse>(`/analytics/requests?period=${periodHours}`),
+    refetchInterval: 60_000,
+  });
+}
+
+export function useAnalyticsRequestForensics(periodHours: number = 720) {
+  return useQuery({
+    queryKey: analyticsKeys.requestForensics(periodHours),
+    queryFn: () => api.get<RequestForensicsResponse>(`/analytics/requests/forensics?period=${periodHours}`),
     refetchInterval: 60_000,
   });
 }

--- a/packages/client/src/components/analytics/api-latency-panel.tsx
+++ b/packages/client/src/components/analytics/api-latency-panel.tsx
@@ -1,0 +1,103 @@
+import type { RequestMetricsResponse } from '@valet/shared';
+import { HeroMetricCard } from '@/components/dashboard/hero-metric-card';
+
+type Hero = RequestMetricsResponse['hero'];
+type Route = RequestMetricsResponse['routes'][number];
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return 'N/A';
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${Math.round(ms)}ms`;
+}
+
+function ClockIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <polyline points="12 6 12 12 16 14" />
+    </svg>
+  );
+}
+
+function HashIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="4" y1="9" x2="20" y2="9" />
+      <line x1="4" y1="15" x2="20" y2="15" />
+      <line x1="10" y1="3" x2="8" y2="21" />
+      <line x1="16" y1="3" x2="14" y2="21" />
+    </svg>
+  );
+}
+
+function AlertIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  );
+}
+
+function HeroRow({ hero }: { hero: Hero }) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+      <HeroMetricCard icon={<ClockIcon />} label="API P50" value={formatDuration(hero.p50)} tooltip="Median API request latency" index={0} />
+      <HeroMetricCard icon={<ClockIcon />} label="API P95" value={formatDuration(hero.p95)} tooltip="95th percentile API request latency" index={1} />
+      <HeroMetricCard icon={<ClockIcon />} label="API P99" value={formatDuration(hero.p99)} tooltip="99th percentile API request latency" index={2} />
+      <HeroMetricCard icon={<HashIcon />} label="Requests" value={hero.count.toLocaleString()} tooltip="Requests recorded in the selected window" index={3} />
+      <HeroMetricCard icon={<AlertIcon />} label="Error Rate" value={`${(hero.errorRate * 100).toFixed(1)}%`} tooltip="Share of requests returning a 5xx status" index={4} />
+    </div>
+  );
+}
+
+function SlowRoutesTable({ routes }: { routes: Route[] }) {
+  return (
+    <div className="animate-stagger-in rounded-lg border border-neutral-200/80 bg-white p-6 shadow-[0_1px_2px_0_rgb(0_0_0/0.04)] dark:border-neutral-800 dark:bg-surface-1 dark:shadow-none" style={{ animationDelay: '350ms' }}>
+      <h3 className="label-mono text-neutral-400 mb-4">Slowest API Routes</h3>
+      {routes.length === 0 ? (
+        <p className="text-sm text-neutral-300">No request data yet</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-neutral-100 dark:border-neutral-800">
+                <th className="pb-2 pr-4 text-left font-mono text-2xs font-medium text-neutral-400">Method</th>
+                <th className="pb-2 px-4 text-left font-mono text-2xs font-medium text-neutral-400">Route</th>
+                <th className="pb-2 px-4 text-right font-mono text-2xs font-medium text-neutral-400">Count</th>
+                <th className="pb-2 px-4 text-right font-mono text-2xs font-medium text-neutral-400">P50</th>
+                <th className="pb-2 px-4 text-right font-mono text-2xs font-medium text-neutral-400">P95</th>
+                <th className="pb-2 pl-4 text-right font-mono text-2xs font-medium text-neutral-400">Err</th>
+              </tr>
+            </thead>
+            <tbody>
+              {routes.map((row, idx) => (
+                <tr key={`${row.method}-${row.route}-${idx}`} className="border-b border-neutral-50 last:border-0 dark:border-neutral-800/50">
+                  <td className="py-2.5 pr-4 font-mono text-xs font-medium text-neutral-600 dark:text-neutral-300">{row.method}</td>
+                  <td className="py-2.5 px-4 font-mono text-xs text-neutral-900 dark:text-neutral-100">{row.route}</td>
+                  <td className="py-2.5 px-4 text-right font-mono text-xs tabular-nums text-neutral-600 dark:text-neutral-300">{row.count.toLocaleString()}</td>
+                  <td className="py-2.5 px-4 text-right font-mono text-xs tabular-nums text-neutral-600 dark:text-neutral-300">{formatDuration(row.p50)}</td>
+                  <td className="py-2.5 px-4 text-right font-mono text-xs tabular-nums text-neutral-600 dark:text-neutral-300">{formatDuration(row.p95)}</td>
+                  <td className="py-2.5 pl-4 text-right font-mono text-xs tabular-nums text-neutral-600 dark:text-neutral-300">{`${(row.errorRate * 100).toFixed(0)}%`}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ApiLatencyPanel({ data }: { data: RequestMetricsResponse }) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="label-mono text-neutral-400 mb-3">API Request Latency</h3>
+        <HeroRow hero={data.hero} />
+      </div>
+      <SlowRoutesTable routes={data.routes} />
+    </div>
+  );
+}

--- a/packages/client/src/components/analytics/performance-tab.tsx
+++ b/packages/client/src/components/analytics/performance-tab.tsx
@@ -1,13 +1,15 @@
-import { useAnalyticsPerformance, useAnalyticsRequests } from '@/api/analytics';
+import { useAnalyticsPerformance, useAnalyticsRequests, useAnalyticsRequestForensics } from '@/api/analytics';
 import { PerfHeroMetrics } from './perf-hero-metrics';
 import { LatencyTrendChart } from './latency-trend-chart';
 import { StageBreakdownTable } from './stage-breakdown-table';
 import { SlowPathsTable } from './slow-paths-table';
 import { ApiLatencyPanel } from './api-latency-panel';
+import { RequestForensicsPanel } from './request-forensics-panel';
 
 export function PerformanceTab({ period }: { period: number }) {
   const { data, isLoading } = useAnalyticsPerformance(period);
   const { data: requests } = useAnalyticsRequests(period);
+  const { data: forensics } = useAnalyticsRequestForensics(period);
 
   if (isLoading) {
     return (
@@ -35,6 +37,7 @@ export function PerformanceTab({ period }: { period: number }) {
         <SlowPathsTable data={data.slowPaths} />
       </div>
       {requests && <ApiLatencyPanel data={requests} />}
+      {forensics && <RequestForensicsPanel data={forensics} />}
     </div>
   );
 }

--- a/packages/client/src/components/analytics/performance-tab.tsx
+++ b/packages/client/src/components/analytics/performance-tab.tsx
@@ -1,11 +1,13 @@
-import { useAnalyticsPerformance } from '@/api/analytics';
+import { useAnalyticsPerformance, useAnalyticsRequests } from '@/api/analytics';
 import { PerfHeroMetrics } from './perf-hero-metrics';
 import { LatencyTrendChart } from './latency-trend-chart';
 import { StageBreakdownTable } from './stage-breakdown-table';
 import { SlowPathsTable } from './slow-paths-table';
+import { ApiLatencyPanel } from './api-latency-panel';
 
 export function PerformanceTab({ period }: { period: number }) {
   const { data, isLoading } = useAnalyticsPerformance(period);
+  const { data: requests } = useAnalyticsRequests(period);
 
   if (isLoading) {
     return (
@@ -32,6 +34,7 @@ export function PerformanceTab({ period }: { period: number }) {
         <StageBreakdownTable data={data.stages} />
         <SlowPathsTable data={data.slowPaths} />
       </div>
+      {requests && <ApiLatencyPanel data={requests} />}
     </div>
   );
 }

--- a/packages/client/src/components/analytics/request-forensics-panel.tsx
+++ b/packages/client/src/components/analytics/request-forensics-panel.tsx
@@ -1,0 +1,121 @@
+import type { RequestForensicsResponse, RequestSample } from '@valet/shared';
+
+type AccessDenial = RequestForensicsResponse['accessDenials'][number];
+
+function formatDuration(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${Math.round(ms)}ms`;
+}
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null) return '—';
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${bytes} B`;
+}
+
+function shortId(id: string | null): string {
+  return id ? id.slice(0, 8) : '—';
+}
+
+const cardClass =
+  'animate-stagger-in rounded-lg border border-neutral-200/80 bg-white p-6 shadow-[0_1px_2px_0_rgb(0_0_0/0.04)] dark:border-neutral-800 dark:bg-surface-1 dark:shadow-none';
+const thClass = 'pb-2 text-left font-mono text-2xs font-medium text-neutral-400';
+const tdClass = 'py-2.5 font-mono text-xs text-neutral-600 dark:text-neutral-300';
+
+function AccessDenialsTable({ rows }: { rows: AccessDenial[] }) {
+  return (
+    <div className={cardClass}>
+      <h3 className="label-mono text-neutral-400 mb-1">Access Denials</h3>
+      <p className="mb-4 text-2xs text-neutral-400">Repeated 401/403 by actor + route — probing or broken object-level authorization.</p>
+      {rows.length === 0 ? (
+        <p className="text-sm text-neutral-300">No denied requests</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-neutral-100 dark:border-neutral-800">
+                <th className={`${thClass} pr-4`}>Actor</th>
+                <th className={`${thClass} px-4`}>Route</th>
+                <th className={`${thClass} px-4 text-right`}>Status</th>
+                <th className={`${thClass} pl-4 text-right`}>Count</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r, idx) => (
+                <tr key={`${r.userId}-${r.route}-${r.status}-${idx}`} className="border-b border-neutral-50 last:border-0 dark:border-neutral-800/50">
+                  <td className={`${tdClass} pr-4`}>{r.userId ? shortId(r.userId) : 'anon'}</td>
+                  <td className={`${tdClass} px-4 text-neutral-900 dark:text-neutral-100`}>{r.route}</td>
+                  <td className={`${tdClass} px-4 text-right tabular-nums`}>{r.status}</td>
+                  <td className={`${tdClass} pl-4 text-right tabular-nums`}>{r.count.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SamplesTable({ title, blurb, rows, metric }: { title: string; blurb: string; rows: RequestSample[]; metric: 'bytes' | 'duration' }) {
+  return (
+    <div className={cardClass}>
+      <h3 className="label-mono text-neutral-400 mb-1">{title}</h3>
+      <p className="mb-4 text-2xs text-neutral-400">{blurb}</p>
+      {rows.length === 0 ? (
+        <p className="text-sm text-neutral-300">No data</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-neutral-100 dark:border-neutral-800">
+                <th className={`${thClass} pr-4`}>Route</th>
+                <th className={`${thClass} px-4 text-right`}>{metric === 'bytes' ? 'Size' : 'Duration'}</th>
+                <th className={`${thClass} px-4 text-right`}>Status</th>
+                <th className={`${thClass} pl-4 text-right`}>Request ID</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r, idx) => (
+                <tr key={`${r.requestId}-${idx}`} className="border-b border-neutral-50 last:border-0 dark:border-neutral-800/50">
+                  <td className={`${tdClass} pr-4 text-neutral-900 dark:text-neutral-100`}>
+                    <span className="text-neutral-400">{r.method}</span> {r.route}
+                  </td>
+                  <td className={`${tdClass} px-4 text-right tabular-nums`}>
+                    {metric === 'bytes' ? formatBytes(r.requestBytes) : formatDuration(r.durationMs)}
+                  </td>
+                  <td className={`${tdClass} px-4 text-right tabular-nums ${r.status >= 500 ? 'text-red-600 dark:text-red-400' : ''}`}>{r.status}</td>
+                  <td className={`${tdClass} pl-4 text-right`} title={r.requestId ?? undefined}>{shortId(r.requestId)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function RequestForensicsPanel({ data }: { data: RequestForensicsResponse }) {
+  return (
+    <div className="space-y-6">
+      <h3 className="label-mono text-neutral-400">Security &amp; Reliability</h3>
+      <AccessDenialsTable rows={data.accessDenials} />
+      <div className="grid gap-6 lg:grid-cols-2">
+        <SamplesTable
+          title="Heaviest Requests"
+          blurb="Largest inbound payloads — large-file ingress; a 5xx status flags parse/processing failures."
+          rows={data.heavyRequests}
+          metric="bytes"
+        />
+        <SamplesTable
+          title="Slowest Requests"
+          blurb="Longest-running calls — timeout-prone paths. Pivot the request ID into logs to see the cause."
+          rows={data.slowestRequests}
+          metric="duration"
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1187,6 +1187,29 @@ export interface AnalyticsEventsResponse {
   period: number;
 }
 
+// ─── API Request Latency Types ───────────────────────────────────────────────
+// Server-side latency of the REST API surface (the synchronous path real users
+// wait on), distinct from the agent-turn telemetry in AnalyticsPerformanceResponse.
+
+export interface RequestMetricsResponse {
+  hero: {
+    p50: number | null;
+    p95: number | null;
+    p99: number | null;
+    count: number;
+    errorRate: number;
+  };
+  routes: Array<{
+    method: string;
+    route: string;
+    count: number;
+    p50: number | null;
+    p95: number | null;
+    errorRate: number;
+  }>;
+  period: number;
+}
+
 // Plugin types
 export interface OrgPlugin {
   id: string;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1210,6 +1210,30 @@ export interface RequestMetricsResponse {
   period: number;
 }
 
+// Security + reliability investigation lenses over the same request telemetry.
+// Each sample carries requestId to pivot into the full request log.
+export interface RequestForensicsResponse {
+  accessDenials: Array<{
+    userId: string | null;
+    route: string;
+    status: number;
+    count: number;
+  }>;
+  heavyRequests: RequestSample[];
+  slowestRequests: RequestSample[];
+  period: number;
+}
+
+export interface RequestSample {
+  method: string;
+  route: string;
+  status: number;
+  durationMs: number;
+  requestBytes: number | null;
+  requestId: string | null;
+  createdAt: string;
+}
+
 // Plugin types
 export interface OrgPlugin {
   id: string;

--- a/packages/worker/migrations/0017_request_metrics.sql
+++ b/packages/worker/migrations/0017_request_metrics.sql
@@ -6,6 +6,12 @@
 -- metrics are keyed by route, not session, so they live in their own table.
 --
 -- One row per sampled request, written fire-and-forget from the edge.
+--
+-- Doubles as a forensic index: an anomalous row (forbidden access, abnormal
+-- payload, a timeout) carries request_id, which pivots into the full request
+-- log in Cloudflare Observability to inspect the actual headers/body. The
+-- metric itself stays low-cardinality and PII-light — resource ids live behind
+-- the route pattern, recoverable via the request_id pivot only when needed.
 CREATE TABLE request_metrics (
   id TEXT PRIMARY KEY,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
@@ -13,9 +19,12 @@ CREATE TABLE request_metrics (
   route TEXT NOT NULL,          -- matched route pattern, e.g. /api/sessions/:id (low cardinality)
   status INTEGER NOT NULL,      -- HTTP status code
   duration_ms INTEGER NOT NULL, -- wall-clock time to produce the response
+  request_id TEXT,              -- X-Request-Id; pivot into full request logs for cause analysis
+  request_bytes INTEGER,        -- inbound Content-Length; flags large-file / large-payload ingress
   user_id TEXT REFERENCES users(id) ON DELETE SET NULL
 );
 
--- Time-window scans (overall percentiles) and per-route breakdowns.
+-- Time-window scans drive every read (percentiles, per-route breakdowns, and
+-- the forensic lenses, which filter/group in app code over the window).
 CREATE INDEX idx_request_metrics_created ON request_metrics(created_at);
 CREATE INDEX idx_request_metrics_route_created ON request_metrics(route, created_at);

--- a/packages/worker/migrations/0017_request_metrics.sql
+++ b/packages/worker/migrations/0017_request_metrics.sql
@@ -1,0 +1,21 @@
+-- Request-level performance telemetry for the Worker API surface.
+--
+-- Captures the synchronous HTTP latency real users wait on for every /api/*
+-- request (list sessions, dashboard load, etc.). This is a different grain from
+-- analytics_events (which is session-scoped, agent-turn telemetry) — request
+-- metrics are keyed by route, not session, so they live in their own table.
+--
+-- One row per sampled request, written fire-and-forget from the edge.
+CREATE TABLE request_metrics (
+  id TEXT PRIMARY KEY,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  method TEXT NOT NULL,
+  route TEXT NOT NULL,          -- matched route pattern, e.g. /api/sessions/:id (low cardinality)
+  status INTEGER NOT NULL,      -- HTTP status code
+  duration_ms INTEGER NOT NULL, -- wall-clock time to produce the response
+  user_id TEXT REFERENCES users(id) ON DELETE SET NULL
+);
+
+-- Time-window scans (overall percentiles) and per-route breakdowns.
+CREATE INDEX idx_request_metrics_created ON request_metrics(created_at);
+CREATE INDEX idx_request_metrics_route_created ON request_metrics(route, created_at);

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -48,6 +48,10 @@ export interface Env {
 
   // Email allowlist (comma-separated). If unset, all emails are allowed.
   ALLOWED_EMAILS?: string;
+
+  // Fraction of API requests to record as latency telemetry, in [0, 1].
+  // Unset = record all (server errors are always recorded regardless).
+  REQUEST_TELEMETRY_SAMPLE_RATE?: string;
 }
 
 /** Read a string-valued env var by dynamic key name. Returns undefined for missing or non-string values. */

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -8,6 +8,7 @@ import type { Env, Variables } from './env.js';
 import { errorHandler } from './middleware/error-handler.js';
 import { authMiddleware } from './middleware/auth.js';
 import { dbMiddleware } from './middleware/db.js';
+import { requestTelemetry } from './middleware/request-telemetry.js';
 
 import { sessionsRouter } from './routes/sessions.js';
 import { integrationsRouter } from './routes/integrations.js';
@@ -90,6 +91,9 @@ const app = new Hono<{ Bindings: Env; Variables: Variables }>();
 
 // Global middleware
 app.use('*', requestId());
+// Capture API request latency. Registered early so it wraps the full pipeline
+// (auth, db, handler); records fire-and-forget so it adds no response latency.
+app.use('*', requestTelemetry);
 app.use('*', dbMiddleware);
 app.use('*', logger());
 app.use('*', async (c, next) => {
@@ -278,6 +282,25 @@ const scheduled: ExportedHandlerScheduledHandler<Env> = async (event, env, ctx) 
       }
     } catch (error) {
       console.error('Analytics retention error:', error);
+    }
+
+    // Delete request metrics older than 90 days (batched to avoid D1 timeout)
+    try {
+      const cutoff = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+      let totalDeleted = 0;
+      let deleted: number;
+      do {
+        const result = await env.DB.prepare(
+          'DELETE FROM request_metrics WHERE id IN (SELECT id FROM request_metrics WHERE created_at < ? LIMIT 1000)'
+        ).bind(cutoff).run();
+        deleted = result.meta.changes ?? 0;
+        totalDeleted += deleted;
+      } while (deleted >= 1000);
+      if (totalDeleted > 0) {
+        console.log(`Request metrics retention: deleted ${totalDeleted} rows older than 90 days`);
+      }
+    } catch (error) {
+      console.error('Request metrics retention error:', error);
     }
 
     // Prune schedule tick dedup rows older than 7 days (only needed for ~4h catch-up window, batched to avoid D1 timeout)

--- a/packages/worker/src/lib/db.ts
+++ b/packages/worker/src/lib/db.ts
@@ -28,6 +28,7 @@ export * from './db/dashboard.js';
 export * from './db/actions.js';
 export * from './db/disabled-actions.js';
 export * from './db/analytics.js';
+export * from './db/request-metrics.js';
 export * from './db/plugins.js';
 export * from './db/skills.js';
 export * from './db/persona-tools.js';

--- a/packages/worker/src/lib/db.ts
+++ b/packages/worker/src/lib/db.ts
@@ -29,6 +29,7 @@ export * from './db/actions.js';
 export * from './db/disabled-actions.js';
 export * from './db/analytics.js';
 export * from './db/request-metrics.js';
+export * from './db/request-forensics.js';
 export * from './db/plugins.js';
 export * from './db/skills.js';
 export * from './db/persona-tools.js';

--- a/packages/worker/src/lib/db/request-forensics.test.ts
+++ b/packages/worker/src/lib/db/request-forensics.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type BetterSqlite3 from 'better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { createTestDb } from '../../test-utils/db.js';
+import { requestMetrics } from '../schema/index.js';
+import { getAccessDenials, getHeavyRequests, getSlowestRequests } from './request-forensics.js';
+
+const HOUR = 60 * 60 * 1000;
+
+interface SeedRow {
+  method?: string;
+  route: string;
+  status: number;
+  durationMs?: number;
+  requestBytes?: number | null;
+  requestId?: string | null;
+  userId?: string | null;
+  ageMs?: number;
+}
+
+function seed(db: BetterSQLite3Database, rows: SeedRow[]): void {
+  for (const r of rows) {
+    db.insert(requestMetrics).values({
+      id: crypto.randomUUID(),
+      createdAt: new Date(Date.now() - (r.ageMs ?? 60_000)).toISOString(),
+      method: r.method ?? 'GET',
+      route: r.route,
+      status: r.status,
+      durationMs: r.durationMs ?? 1,
+      requestId: r.requestId ?? null,
+      requestBytes: r.requestBytes ?? null,
+      userId: r.userId ?? null,
+    }).run();
+  }
+}
+
+describe('request-forensics queries', () => {
+  let db: BetterSQLite3Database;
+  let sqlite: BetterSqlite3.Database;
+  beforeEach(() => {
+    ({ db, sqlite } = createTestDb());
+  });
+
+  it('groups authorization failures by actor + route, most frequent first', async () => {
+    // user_id is an FK to users — seed the actors the denials reference.
+    for (const id of ['user-a', 'user-b']) {
+      sqlite.prepare('INSERT INTO users (id, email) VALUES (?, ?)').run(id, `${id}@example.com`);
+    }
+    seed(db, [
+      { route: '/api/sessions/:id', status: 403, userId: 'user-a' },
+      { route: '/api/sessions/:id', status: 403, userId: 'user-a' },
+      { route: '/api/sessions/:id', status: 403, userId: 'user-a' },
+      { route: '/api/files', status: 401, userId: 'user-a' },
+      { route: '/api/files', status: 401, userId: 'user-a' },
+      { route: '/api/sessions/:id', status: 403, userId: 'user-b' },
+      { route: '/api/sessions/:id', status: 200, userId: 'user-a' }, // success — excluded
+      { route: '/api/sessions/:id', status: 403, userId: 'user-a', ageMs: 2 * HOUR }, // out of window
+    ]);
+
+    const periodStart = new Date(Date.now() - HOUR).toISOString();
+    const denials = await getAccessDenials(db, periodStart);
+
+    expect(denials).toEqual([
+      { userId: 'user-a', route: '/api/sessions/:id', status: 403, count: 3 },
+      { userId: 'user-a', route: '/api/files', status: 401, count: 2 },
+      { userId: 'user-b', route: '/api/sessions/:id', status: 403, count: 1 },
+    ]);
+  });
+
+  it('returns the heaviest inbound payloads, excluding rows without a size', async () => {
+    seed(db, [
+      { route: '/api/files', status: 200, requestBytes: 5_000, requestId: 'req-mid' },
+      { route: '/api/files', status: 413, requestBytes: 1_000_000, requestId: 'req-big' },
+      { route: '/api/sessions', status: 200, requestBytes: null }, // no size — excluded
+      { route: '/api/files', status: 200, requestBytes: 250, requestId: 'req-small' },
+    ]);
+
+    const periodStart = new Date(Date.now() - HOUR).toISOString();
+    const heavy = await getHeavyRequests(db, periodStart);
+
+    expect(heavy.map((r) => r.requestBytes)).toEqual([1_000_000, 5_000, 250]);
+    // The biggest one failed (413) — exactly the large-file symptom we want to surface.
+    expect(heavy[0]).toMatchObject({ route: '/api/files', status: 413, requestId: 'req-big' });
+  });
+
+  it('returns the slowest requests with a pivotable request id', async () => {
+    seed(db, [
+      { route: '/api/a', status: 200, durationMs: 10, requestId: 'req-fast' },
+      { route: '/api/b', status: 504, durationMs: 30_000, requestId: 'req-timeout' },
+      { route: '/api/c', status: 200, durationMs: 200, requestId: 'req-mid' },
+    ]);
+
+    const periodStart = new Date(Date.now() - HOUR).toISOString();
+    const slowest = await getSlowestRequests(db, periodStart, 2);
+
+    expect(slowest.map((r) => r.durationMs)).toEqual([30_000, 200]);
+    expect(slowest[0]).toMatchObject({ route: '/api/b', status: 504, requestId: 'req-timeout' });
+  });
+});

--- a/packages/worker/src/lib/db/request-forensics.ts
+++ b/packages/worker/src/lib/db/request-forensics.ts
@@ -1,0 +1,128 @@
+import { sql, and, gte, desc, isNotNull, inArray } from 'drizzle-orm';
+import type { AppDb } from '../drizzle.js';
+import { requestMetrics } from '../schema/index.js';
+
+// ─── Request Forensics Queries ───────────────────────────────────────────────
+//
+// Investigation lenses over `request_metrics`. They answer "who touched what,
+// was it allowed, and how big / slow was it" — the starting point for both
+// information-leakage and reliability investigations. Each row carries the
+// request_id, so an analyst can pivot from a suspicious aggregate to the full
+// request log in Cloudflare Observability.
+
+export interface AccessDenialRow {
+  userId: string | null;
+  route: string;
+  status: number; // 401 (unauthenticated) or 403 (forbidden)
+  count: number;
+}
+
+/**
+ * Authorization failures grouped by actor + route, most frequent first.
+ *
+ * Repeated 403s on resource-scoped routes (e.g. /api/sessions/:id) are the
+ * canonical signal for probing or broken object-level authorization — i.e.
+ * attempts to reach information the caller should not see.
+ */
+export async function getAccessDenials(
+  db: AppDb,
+  periodStart: string,
+  limit = 20,
+): Promise<AccessDenialRow[]> {
+  const rows = await db
+    .select({
+      userId: requestMetrics.userId,
+      route: requestMetrics.route,
+      status: requestMetrics.status,
+      count: sql<number>`count(*)`,
+    })
+    .from(requestMetrics)
+    .where(and(gte(requestMetrics.createdAt, periodStart), inArray(requestMetrics.status, [401, 403])))
+    .groupBy(requestMetrics.userId, requestMetrics.route, requestMetrics.status)
+    .orderBy(desc(sql`count(*)`))
+    .limit(limit);
+
+  return rows.map((r) => ({
+    userId: r.userId ?? null,
+    route: r.route,
+    status: r.status,
+    count: Number(r.count),
+  }));
+}
+
+export interface RequestSampleRow {
+  method: string;
+  route: string;
+  status: number;
+  durationMs: number;
+  requestBytes: number | null;
+  requestId: string | null;
+  createdAt: string;
+}
+
+const sampleColumns = {
+  method: requestMetrics.method,
+  route: requestMetrics.route,
+  status: requestMetrics.status,
+  durationMs: requestMetrics.durationMs,
+  requestBytes: requestMetrics.requestBytes,
+  requestId: requestMetrics.requestId,
+  createdAt: requestMetrics.createdAt,
+} as const;
+
+function toSample(r: {
+  method: string;
+  route: string;
+  status: number;
+  durationMs: number;
+  requestBytes: number | null;
+  requestId: string | null;
+  createdAt: string | null;
+}): RequestSampleRow {
+  return {
+    method: r.method,
+    route: r.route,
+    status: r.status,
+    durationMs: r.durationMs,
+    requestBytes: r.requestBytes ?? null,
+    requestId: r.requestId ?? null,
+    createdAt: r.createdAt ?? '',
+  };
+}
+
+/**
+ * Largest inbound payloads, biggest first. Surfaces large-file / large-payload
+ * ingress and — via the status on each row — whether those heavy requests failed,
+ * the API-side symptom of "can't parse large files".
+ */
+export async function getHeavyRequests(
+  db: AppDb,
+  periodStart: string,
+  limit = 10,
+): Promise<RequestSampleRow[]> {
+  const rows = await db
+    .select(sampleColumns)
+    .from(requestMetrics)
+    .where(and(gte(requestMetrics.createdAt, periodStart), isNotNull(requestMetrics.requestBytes)))
+    .orderBy(desc(requestMetrics.requestBytes))
+    .limit(limit);
+  return rows.map(toSample);
+}
+
+/**
+ * Slowest requests, longest first. Surfaces timeout-prone synchronous calls; the
+ * request_id pivots into the trace to see where the time went.
+ */
+export async function getSlowestRequests(
+  db: AppDb,
+  periodStart: string,
+  limit = 10,
+): Promise<RequestSampleRow[]> {
+  const rows = await db
+    .select(sampleColumns)
+    .from(requestMetrics)
+    .where(gte(requestMetrics.createdAt, periodStart))
+    .orderBy(desc(requestMetrics.durationMs))
+    .limit(limit);
+  return rows.map(toSample);
+}

--- a/packages/worker/src/lib/db/request-metrics.test.ts
+++ b/packages/worker/src/lib/db/request-metrics.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { createTestDb } from '../../test-utils/db.js';
+import { requestMetrics } from '../schema/index.js';
+import { recordRequestMetric } from '../request-telemetry.js';
+import { getRequestLatency, getSlowRoutes } from './request-metrics.js';
+
+const HOUR = 60 * 60 * 1000;
+
+interface SeedRow {
+  method: string;
+  route: string;
+  status: number;
+  durationMs: number;
+  ageMs?: number; // how long ago the request happened (default: 1 min)
+}
+
+function seed(db: BetterSQLite3Database, rows: SeedRow[]): void {
+  for (const r of rows) {
+    db.insert(requestMetrics).values({
+      id: crypto.randomUUID(),
+      createdAt: new Date(Date.now() - (r.ageMs ?? 60_000)).toISOString(),
+      method: r.method,
+      route: r.route,
+      status: r.status,
+      durationMs: r.durationMs,
+    }).run();
+  }
+}
+
+describe('request-metrics queries', () => {
+  let db: BetterSQLite3Database;
+
+  beforeEach(() => {
+    ({ db } = createTestDb());
+  });
+
+  it('records a well-formed row via recordRequestMetric', async () => {
+    await recordRequestMetric(db, {
+      method: 'GET',
+      route: '/api/sessions/:id',
+      status: 200,
+      durationMs: 42,
+      userId: null,
+    });
+
+    const rows = db.select().from(requestMetrics).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      method: 'GET',
+      route: '/api/sessions/:id',
+      status: 200,
+      durationMs: 42,
+      userId: null,
+    });
+    expect(rows[0].id).toBeTruthy();
+    expect(rows[0].createdAt).toBeTruthy();
+  });
+
+  it('computes overall percentiles and 5xx error rate within the window', async () => {
+    // Route A: 10 fast GETs (10..100ms), all 200.
+    seed(db, Array.from({ length: 10 }, (_, i) => ({
+      method: 'GET', route: '/api/sessions', status: 200, durationMs: (i + 1) * 10,
+    })));
+    // Route B: 3 slow GETs (200/400/600ms); the slowest is a 500.
+    seed(db, [
+      { method: 'GET', route: '/api/sessions/:id', status: 200, durationMs: 200 },
+      { method: 'GET', route: '/api/sessions/:id', status: 200, durationMs: 400 },
+      { method: 'GET', route: '/api/sessions/:id', status: 500, durationMs: 600 },
+    ]);
+    // Outside the 1h window — must be excluded.
+    seed(db, [{ method: 'GET', route: '/api/old', status: 200, durationMs: 9999, ageMs: 2 * HOUR }]);
+
+    const periodStart = new Date(Date.now() - HOUR).toISOString();
+    const stats = await getRequestLatency(db, periodStart);
+
+    // In-window durations sorted: 10,20,30,40,50,60,70,80,90,100,200,400,600 (n=13)
+    expect(stats.count).toBe(13);
+    expect(stats.p50).toBe(70);  // offset floor(12*0.50)=6
+    expect(stats.p95).toBe(400); // offset floor(12*0.95)=11
+    expect(stats.p99).toBe(400); // offset floor(12*0.99)=11
+    expect(stats.errorCount).toBe(1);
+    expect(stats.errorRate).toBeCloseTo(1 / 13);
+  });
+
+  it('returns zeros when there is no data in the window', async () => {
+    const periodStart = new Date(Date.now() - HOUR).toISOString();
+    const stats = await getRequestLatency(db, periodStart);
+    expect(stats).toEqual({ p50: null, p95: null, p99: null, count: 0, errorCount: 0, errorRate: 0 });
+  });
+
+  it('breaks down latency per route, slowest (p95) first', async () => {
+    seed(db, Array.from({ length: 10 }, (_, i) => ({
+      method: 'GET', route: '/api/sessions', status: 200, durationMs: (i + 1) * 10,
+    })));
+    seed(db, [
+      { method: 'GET', route: '/api/sessions/:id', status: 200, durationMs: 200 },
+      { method: 'GET', route: '/api/sessions/:id', status: 200, durationMs: 400 },
+      { method: 'GET', route: '/api/sessions/:id', status: 500, durationMs: 600 },
+    ]);
+    seed(db, [{ method: 'GET', route: '/api/old', status: 200, durationMs: 9999, ageMs: 2 * HOUR }]);
+
+    const periodStart = new Date(Date.now() - HOUR).toISOString();
+    const routes = await getSlowRoutes(db, periodStart);
+
+    expect(routes.map((r) => r.route)).toEqual(['/api/sessions/:id', '/api/sessions']);
+
+    const [slow, fast] = routes;
+    expect(slow).toMatchObject({ method: 'GET', route: '/api/sessions/:id', count: 3, errorCount: 1, p50: 400, p95: 400 });
+    expect(slow.errorRate).toBeCloseTo(1 / 3);
+    expect(fast).toMatchObject({ method: 'GET', route: '/api/sessions', count: 10, errorCount: 0, errorRate: 0, p50: 50, p95: 90 });
+  });
+
+  it('honours the limit', async () => {
+    seed(db, [
+      { method: 'GET', route: '/api/a', status: 200, durationMs: 10 },
+      { method: 'GET', route: '/api/b', status: 200, durationMs: 20 },
+      { method: 'GET', route: '/api/c', status: 200, durationMs: 30 },
+    ]);
+    const periodStart = new Date(Date.now() - HOUR).toISOString();
+    const routes = await getSlowRoutes(db, periodStart, 2);
+    expect(routes).toHaveLength(2);
+    // Slowest two by p95: /api/c (30) then /api/b (20).
+    expect(routes.map((r) => r.route)).toEqual(['/api/c', '/api/b']);
+  });
+});

--- a/packages/worker/src/lib/db/request-metrics.ts
+++ b/packages/worker/src/lib/db/request-metrics.ts
@@ -1,0 +1,113 @@
+import { sql, gte, asc } from 'drizzle-orm';
+import type { AppDb } from '../drizzle.js';
+import { requestMetrics } from '../schema/index.js';
+
+// ─── Request Performance Queries ─────────────────────────────────────────────
+//
+// Reads over `request_metrics` for the API-latency dashboard. Percentiles use the
+// same ordered-offset approach as lib/db/analytics.ts (exact, index-friendly for
+// the row counts this table holds) so behaviour stays uniform across the two
+// telemetry surfaces.
+
+export interface RequestLatencyStats {
+  p50: number | null;
+  p95: number | null;
+  p99: number | null;
+  count: number;
+  errorCount: number;
+  errorRate: number;
+}
+
+/** Overall request latency (p50/p95/p99) and 5xx error rate across the window. */
+export async function getRequestLatency(
+  db: AppDb,
+  periodStart: string,
+): Promise<RequestLatencyStats> {
+  const [agg] = await db
+    .select({
+      count: sql<number>`count(*)`,
+      errors: sql<number>`coalesce(sum(case when ${requestMetrics.status} >= 500 then 1 else 0 end), 0)`,
+    })
+    .from(requestMetrics)
+    .where(gte(requestMetrics.createdAt, periodStart));
+
+  const count = Number(agg?.count ?? 0);
+  const errorCount = Number(agg?.errors ?? 0);
+  if (count === 0) {
+    return { p50: null, p95: null, p99: null, count: 0, errorCount: 0, errorRate: 0 };
+  }
+
+  // The k-th smallest duration_ms via ORDER BY ... LIMIT 1 OFFSET k.
+  const at = async (quantile: number): Promise<number | null> => {
+    const offset = Math.min(Math.floor((count - 1) * quantile), count - 1);
+    const [row] = await db
+      .select({ durationMs: requestMetrics.durationMs })
+      .from(requestMetrics)
+      .where(gte(requestMetrics.createdAt, periodStart))
+      .orderBy(asc(requestMetrics.durationMs))
+      .limit(1)
+      .offset(offset);
+    return row?.durationMs ?? null;
+  };
+
+  const [p50, p95, p99] = await Promise.all([at(0.5), at(0.95), at(0.99)]);
+
+  return { p50, p95, p99, count, errorCount, errorRate: errorCount / count };
+}
+
+export interface SlowRouteRow {
+  method: string;
+  route: string;
+  count: number;
+  errorCount: number;
+  errorRate: number;
+  p50: number | null;
+  p95: number | null;
+}
+
+/**
+ * Per-route latency breakdown, slowest first (by p95). Rows arrive ordered by
+ * (route, method, duration) so each group's durations are already ascending and
+ * percentile offsets are a direct index.
+ */
+export async function getSlowRoutes(
+  db: AppDb,
+  periodStart: string,
+  limit = 20,
+): Promise<SlowRouteRow[]> {
+  const rows = await db
+    .select({
+      method: requestMetrics.method,
+      route: requestMetrics.route,
+      status: requestMetrics.status,
+      durationMs: requestMetrics.durationMs,
+    })
+    .from(requestMetrics)
+    .where(gte(requestMetrics.createdAt, periodStart))
+    .orderBy(asc(requestMetrics.route), asc(requestMetrics.method), asc(requestMetrics.durationMs));
+
+  const groups = new Map<string, { method: string; route: string; durations: number[]; errors: number }>();
+  for (const r of rows) {
+    const key = `${r.method} ${r.route}`;
+    const group = groups.get(key) ?? { method: r.method, route: r.route, durations: [], errors: 0 };
+    group.durations.push(r.durationMs);
+    if (r.status >= 500) group.errors += 1;
+    groups.set(key, group);
+  }
+
+  return Array.from(groups.values())
+    .map((g) => {
+      const n = g.durations.length;
+      return {
+        method: g.method,
+        route: g.route,
+        count: n,
+        errorCount: g.errors,
+        errorRate: n > 0 ? g.errors / n : 0,
+        p50: g.durations[Math.floor((n - 1) * 0.5)] ?? null,
+        p95: g.durations[Math.floor((n - 1) * 0.95)] ?? null,
+      };
+    })
+    .sort((a, b) => (b.p95 ?? 0) - (a.p95 ?? 0))
+    .slice(0, limit);
+}

--- a/packages/worker/src/lib/request-telemetry.test.ts
+++ b/packages/worker/src/lib/request-telemetry.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_SAMPLE_RATE, resolveSampleRate, shouldSample } from './request-telemetry.js';
+
+describe('shouldSample', () => {
+  // Constant rng so the decision is deterministic.
+  const rng = (value: number) => () => value;
+
+  it('always records server errors regardless of rate', () => {
+    expect(shouldSample(500, 0, rng(0.99))).toBe(true);
+    expect(shouldSample(503, 0, rng(0.99))).toBe(true);
+  });
+
+  it('records everything at rate >= 1', () => {
+    expect(shouldSample(200, 1, rng(0.99))).toBe(true);
+    expect(shouldSample(404, 1, rng(0.99))).toBe(true);
+  });
+
+  it('records nothing (except 5xx) at rate <= 0', () => {
+    expect(shouldSample(200, 0, rng(0))).toBe(false);
+    expect(shouldSample(404, 0, rng(0))).toBe(false);
+  });
+
+  it('keeps the rng < rate fraction', () => {
+    expect(shouldSample(200, 0.5, rng(0.49))).toBe(true);
+    expect(shouldSample(200, 0.5, rng(0.5))).toBe(false);
+    expect(shouldSample(200, 0.5, rng(0.51))).toBe(false);
+  });
+});
+
+describe('resolveSampleRate', () => {
+  it('defaults when unset', () => {
+    expect(resolveSampleRate({})).toBe(DEFAULT_SAMPLE_RATE);
+  });
+
+  it('parses a valid fraction', () => {
+    expect(resolveSampleRate({ REQUEST_TELEMETRY_SAMPLE_RATE: '0.25' })).toBe(0.25);
+    expect(resolveSampleRate({ REQUEST_TELEMETRY_SAMPLE_RATE: '0' })).toBe(0);
+    expect(resolveSampleRate({ REQUEST_TELEMETRY_SAMPLE_RATE: '1' })).toBe(1);
+  });
+
+  it('falls back to the default for out-of-range or malformed values', () => {
+    expect(resolveSampleRate({ REQUEST_TELEMETRY_SAMPLE_RATE: '1.5' })).toBe(DEFAULT_SAMPLE_RATE);
+    expect(resolveSampleRate({ REQUEST_TELEMETRY_SAMPLE_RATE: '-0.2' })).toBe(DEFAULT_SAMPLE_RATE);
+    expect(resolveSampleRate({ REQUEST_TELEMETRY_SAMPLE_RATE: 'abc' })).toBe(DEFAULT_SAMPLE_RATE);
+  });
+});

--- a/packages/worker/src/lib/request-telemetry.test.ts
+++ b/packages/worker/src/lib/request-telemetry.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_SAMPLE_RATE, resolveSampleRate, shouldSample } from './request-telemetry.js';
+import { DEFAULT_SAMPLE_RATE, isAlwaysRecorded, resolveSampleRate, shouldSample } from './request-telemetry.js';
+
+describe('isAlwaysRecorded', () => {
+  it('flags server errors and authorization failures', () => {
+    expect(isAlwaysRecorded(500)).toBe(true);
+    expect(isAlwaysRecorded(503)).toBe(true);
+    expect(isAlwaysRecorded(401)).toBe(true);
+    expect(isAlwaysRecorded(403)).toBe(true);
+  });
+
+  it('does not flag ordinary success or client errors', () => {
+    expect(isAlwaysRecorded(200)).toBe(false);
+    expect(isAlwaysRecorded(404)).toBe(false);
+    expect(isAlwaysRecorded(429)).toBe(false);
+  });
+});
 
 describe('shouldSample', () => {
   // Constant rng so the decision is deterministic.
@@ -8,6 +23,11 @@ describe('shouldSample', () => {
   it('always records server errors regardless of rate', () => {
     expect(shouldSample(500, 0, rng(0.99))).toBe(true);
     expect(shouldSample(503, 0, rng(0.99))).toBe(true);
+  });
+
+  it('always records authorization failures regardless of rate', () => {
+    expect(shouldSample(401, 0, rng(0.99))).toBe(true);
+    expect(shouldSample(403, 0, rng(0.99))).toBe(true);
   });
 
   it('records everything at rate >= 1', () => {

--- a/packages/worker/src/lib/request-telemetry.ts
+++ b/packages/worker/src/lib/request-telemetry.ts
@@ -1,0 +1,62 @@
+import type { AppDb } from './drizzle.js';
+import { requestMetrics } from './schema/index.js';
+import type { Env } from '../env.js';
+
+/**
+ * Capture helpers for API request telemetry.
+ *
+ * Pure functions live here (sampling decision, rate resolution, the single-row
+ * insert) so they can be tested without a request context. The middleware in
+ * `middleware/request-telemetry.ts` wires them onto the request lifecycle.
+ */
+
+/** Record every request by default. Operators can dial this down for high-traffic deployments. */
+export const DEFAULT_SAMPLE_RATE = 1;
+
+export interface RequestMetricEntry {
+  method: string;
+  route: string;
+  status: number;
+  durationMs: number;
+  userId?: string | null;
+}
+
+/**
+ * Resolve the sample rate from the optional `REQUEST_TELEMETRY_SAMPLE_RATE` env
+ * var (a number in [0, 1]). Falls back to {@link DEFAULT_SAMPLE_RATE} when unset
+ * or malformed.
+ */
+export function resolveSampleRate(env: Pick<Env, 'REQUEST_TELEMETRY_SAMPLE_RATE'>): number {
+  const raw = env.REQUEST_TELEMETRY_SAMPLE_RATE;
+  if (raw == null) return DEFAULT_SAMPLE_RATE;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : DEFAULT_SAMPLE_RATE;
+}
+
+/**
+ * Decide whether to record a request. Server errors (5xx) are always kept — they
+ * are rare and high-signal — otherwise we keep a `rate` fraction of requests.
+ * `rng` is injectable for deterministic tests.
+ */
+export function shouldSample(status: number, rate: number, rng: () => number = Math.random): boolean {
+  if (status >= 500) return true;
+  if (rate >= 1) return true;
+  if (rate <= 0) return false;
+  return rng() < rate;
+}
+
+/**
+ * Insert one request-metric row. Fire-and-forget from the edge — callers run this
+ * inside `ctx.waitUntil` so it never adds latency to the response it measures.
+ */
+export async function recordRequestMetric(db: AppDb, entry: RequestMetricEntry): Promise<void> {
+  await db.insert(requestMetrics).values({
+    id: crypto.randomUUID(),
+    createdAt: new Date().toISOString(),
+    method: entry.method,
+    route: entry.route,
+    status: entry.status,
+    durationMs: entry.durationMs,
+    userId: entry.userId ?? null,
+  });
+}

--- a/packages/worker/src/lib/request-telemetry.ts
+++ b/packages/worker/src/lib/request-telemetry.ts
@@ -18,7 +18,22 @@ export interface RequestMetricEntry {
   route: string;
   status: number;
   durationMs: number;
+  requestId?: string | null;
+  requestBytes?: number | null;
   userId?: string | null;
+}
+
+/** Authorization failures — authenticated-but-forbidden and unauthenticated. */
+const AUTH_FAILURE_STATUSES = new Set([401, 403]);
+
+/**
+ * Whether a request must be recorded regardless of the sample rate. These are the
+ * forensic-critical events that sampling must never drop: server errors (5xx) and
+ * authorization failures (401/403 — the signal for probing / broken object-level
+ * authorization / leakage attempts).
+ */
+export function isAlwaysRecorded(status: number): boolean {
+  return status >= 500 || AUTH_FAILURE_STATUSES.has(status);
 }
 
 /**
@@ -34,12 +49,13 @@ export function resolveSampleRate(env: Pick<Env, 'REQUEST_TELEMETRY_SAMPLE_RATE'
 }
 
 /**
- * Decide whether to record a request. Server errors (5xx) are always kept — they
- * are rare and high-signal — otherwise we keep a `rate` fraction of requests.
+ * Decide whether to record a request. Forensic-critical events (5xx and auth
+ * failures — see {@link isAlwaysRecorded}) are always kept so security signal
+ * survives aggressive sampling; otherwise we keep a `rate` fraction of requests.
  * `rng` is injectable for deterministic tests.
  */
 export function shouldSample(status: number, rate: number, rng: () => number = Math.random): boolean {
-  if (status >= 500) return true;
+  if (isAlwaysRecorded(status)) return true;
   if (rate >= 1) return true;
   if (rate <= 0) return false;
   return rng() < rate;
@@ -57,6 +73,8 @@ export async function recordRequestMetric(db: AppDb, entry: RequestMetricEntry):
     route: entry.route,
     status: entry.status,
     durationMs: entry.durationMs,
+    requestId: entry.requestId ?? null,
+    requestBytes: entry.requestBytes ?? null,
     userId: entry.userId ?? null,
   });
 }

--- a/packages/worker/src/lib/schema/index.ts
+++ b/packages/worker/src/lib/schema/index.ts
@@ -17,6 +17,7 @@ export * from './actions.js';
 export * from './disabled-actions.js';
 export * from './mcp-oauth.js';
 export * from './analytics.js';
+export * from './request-metrics.js';
 export * from './plugins.js';
 export * from './skills.js';
 export * from './persona-tools.js';

--- a/packages/worker/src/lib/schema/request-metrics.ts
+++ b/packages/worker/src/lib/schema/request-metrics.ts
@@ -1,0 +1,23 @@
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+import { sql } from 'drizzle-orm';
+import { users } from './users.js';
+
+/**
+ * Request-level performance telemetry for the Worker API surface.
+ *
+ * One row per sampled `/api/*` request. Distinct grain from `analytics_events`
+ * (session-scoped agent telemetry) — request metrics are keyed by route, so the
+ * route pattern is stored low-cardinality (`/api/sessions/:id`, never raw IDs).
+ */
+export const requestMetrics = sqliteTable('request_metrics', {
+  id: text().primaryKey(),
+  createdAt: text().notNull().default(sql`(datetime('now'))`),
+  method: text().notNull(),
+  route: text().notNull(),
+  status: integer().notNull(),
+  durationMs: integer().notNull(),
+  userId: text().references(() => users.id, { onDelete: 'set null' }),
+}, (table) => [
+  index('idx_request_metrics_created').on(table.createdAt),
+  index('idx_request_metrics_route_created').on(table.route, table.createdAt),
+]);

--- a/packages/worker/src/lib/schema/request-metrics.ts
+++ b/packages/worker/src/lib/schema/request-metrics.ts
@@ -16,6 +16,8 @@ export const requestMetrics = sqliteTable('request_metrics', {
   route: text().notNull(),
   status: integer().notNull(),
   durationMs: integer().notNull(),
+  requestId: text(),
+  requestBytes: integer(),
   userId: text().references(() => users.id, { onDelete: 'set null' }),
 }, (table) => [
   index('idx_request_metrics_created').on(table.createdAt),

--- a/packages/worker/src/middleware/request-telemetry.test.ts
+++ b/packages/worker/src/middleware/request-telemetry.test.ts
@@ -17,6 +17,7 @@ function buildApp(db: BetterSQLite3Database) {
   app.onError(errorHandler);
   app.use('*', requestTelemetry);
   app.use('*', async (c, next) => {
+    c.set('requestId', 'req-test'); // set by hono's requestId() in production
     c.set('db', db);
     await next();
   });
@@ -25,6 +26,8 @@ function buildApp(db: BetterSQLite3Database) {
     await new Promise((resolve) => setTimeout(resolve, 12));
     return c.json({ id: c.req.param('id') });
   });
+  app.post('/api/upload', (c) => c.json({ ok: true }));
+  app.get('/api/forbidden', (c) => c.json({ error: 'forbidden' }, 403));
   app.get('/api/boom', () => {
     throw new Error('kaboom');
   });
@@ -63,11 +66,23 @@ describe('requestTelemetry middleware', () => {
     const rows = db.select().from(requestMetrics).all().sort((a, b) => a.route.localeCompare(b.route));
     expect(rows).toHaveLength(2);
 
-    expect(rows[0]).toMatchObject({ method: 'GET', route: '/api/fast', status: 200 });
+    expect(rows[0]).toMatchObject({ method: 'GET', route: '/api/fast', status: 200, requestId: 'req-test' });
     // IDs are collapsed to the parameter name — low cardinality for grouping.
-    expect(rows[1]).toMatchObject({ method: 'GET', route: '/api/slow/:id', status: 200 });
+    expect(rows[1]).toMatchObject({ method: 'GET', route: '/api/slow/:id', status: 200, requestId: 'req-test' });
     expect(rows[1].durationMs).toBeGreaterThanOrEqual(5);
     for (const row of rows) expect(row.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('captures inbound payload size from Content-Length', async () => {
+    const app = buildApp(db);
+    const { ctx, waits } = fakeCtx();
+
+    await app.request('/api/upload', { method: 'POST', headers: { 'content-length': '4096' } }, {}, ctx);
+    await Promise.all(waits);
+
+    const rows = db.select().from(requestMetrics).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ method: 'POST', route: '/api/upload', requestBytes: 4096 });
   });
 
   it('captures the error status for thrown requests', async () => {
@@ -96,7 +111,7 @@ describe('requestTelemetry middleware', () => {
     expect(db.select().from(requestMetrics).all()).toHaveLength(0);
   });
 
-  it('respects a zero sample rate but always records server errors', async () => {
+  it('respects a zero sample rate but always records errors and auth failures', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     const app = buildApp(db);
     const { ctx, waits } = fakeCtx();
@@ -104,11 +119,14 @@ describe('requestTelemetry middleware', () => {
 
     await app.request('/api/fast', undefined, env, ctx); // 200 — dropped by sampling
     await app.request('/api/boom', undefined, env, ctx); // 500 — always kept
+    await app.request('/api/forbidden', undefined, env, ctx); // 403 — always kept (security signal)
     await Promise.all(waits);
 
-    const rows = db.select().from(requestMetrics).all();
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({ route: '/api/boom', status: 500 });
+    const rows = db.select().from(requestMetrics).all().sort((a, b) => a.status - b.status);
+    expect(rows.map((r) => ({ route: r.route, status: r.status }))).toEqual([
+      { route: '/api/forbidden', status: 403 },
+      { route: '/api/boom', status: 500 },
+    ]);
     vi.restoreAllMocks();
   });
 });

--- a/packages/worker/src/middleware/request-telemetry.test.ts
+++ b/packages/worker/src/middleware/request-telemetry.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import type { Env, Variables } from '../env.js';
+import { errorHandler } from './error-handler.js';
+import { requestTelemetry } from './request-telemetry.js';
+import { createTestDb } from '../test-utils/db.js';
+import { requestMetrics } from '../lib/schema/index.js';
+
+/**
+ * Builds an app wired exactly like production: requestTelemetry wraps the
+ * pipeline, and a db-provider middleware (standing in for dbMiddleware) sets the
+ * per-request Drizzle instance that the telemetry recorder reads from c.get('db').
+ */
+function buildApp(db: BetterSQLite3Database) {
+  const app = new Hono<{ Bindings: Env; Variables: Variables }>();
+  app.onError(errorHandler);
+  app.use('*', requestTelemetry);
+  app.use('*', async (c, next) => {
+    c.set('db', db);
+    await next();
+  });
+  app.get('/api/fast', (c) => c.json({ ok: true }));
+  app.get('/api/slow/:id', async (c) => {
+    await new Promise((resolve) => setTimeout(resolve, 12));
+    return c.json({ id: c.req.param('id') });
+  });
+  app.get('/api/boom', () => {
+    throw new Error('kaboom');
+  });
+  app.get('/health', (c) => c.json({ ok: true }));
+  return app;
+}
+
+/** Fake ExecutionContext that captures waitUntil promises so the test can await the flush. */
+function fakeCtx() {
+  const waits: Promise<unknown>[] = [];
+  const ctx = {
+    waitUntil(p: Promise<unknown>) {
+      waits.push(p);
+    },
+    passThroughOnException() {},
+    props: {},
+  };
+  return { ctx, waits };
+}
+
+describe('requestTelemetry middleware', () => {
+  let db: BetterSQLite3Database;
+
+  beforeEach(() => {
+    ({ db } = createTestDb());
+  });
+
+  it('records latency for each /api request, labelled by route pattern', async () => {
+    const app = buildApp(db);
+    const { ctx, waits } = fakeCtx();
+
+    await app.request('/api/fast', undefined, {}, ctx);
+    await app.request('/api/slow/abc123', undefined, {}, ctx);
+    await Promise.all(waits);
+
+    const rows = db.select().from(requestMetrics).all().sort((a, b) => a.route.localeCompare(b.route));
+    expect(rows).toHaveLength(2);
+
+    expect(rows[0]).toMatchObject({ method: 'GET', route: '/api/fast', status: 200 });
+    // IDs are collapsed to the parameter name — low cardinality for grouping.
+    expect(rows[1]).toMatchObject({ method: 'GET', route: '/api/slow/:id', status: 200 });
+    expect(rows[1].durationMs).toBeGreaterThanOrEqual(5);
+    for (const row of rows) expect(row.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('captures the error status for thrown requests', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const app = buildApp(db);
+    const { ctx, waits } = fakeCtx();
+
+    const res = await app.request('/api/boom', undefined, {}, ctx);
+    await Promise.all(waits);
+
+    expect(res.status).toBe(500);
+    const rows = db.select().from(requestMetrics).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ method: 'GET', route: '/api/boom', status: 500 });
+    vi.restoreAllMocks();
+  });
+
+  it('skips non-API paths', async () => {
+    const app = buildApp(db);
+    const { ctx, waits } = fakeCtx();
+
+    const res = await app.request('/health', undefined, {}, ctx);
+    await Promise.all(waits);
+
+    expect(res.status).toBe(200);
+    expect(db.select().from(requestMetrics).all()).toHaveLength(0);
+  });
+
+  it('respects a zero sample rate but always records server errors', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const app = buildApp(db);
+    const { ctx, waits } = fakeCtx();
+    const env = { REQUEST_TELEMETRY_SAMPLE_RATE: '0' };
+
+    await app.request('/api/fast', undefined, env, ctx); // 200 — dropped by sampling
+    await app.request('/api/boom', undefined, env, ctx); // 500 — always kept
+    await Promise.all(waits);
+
+    const rows = db.select().from(requestMetrics).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ route: '/api/boom', status: 500 });
+    vi.restoreAllMocks();
+  });
+});

--- a/packages/worker/src/middleware/request-telemetry.ts
+++ b/packages/worker/src/middleware/request-telemetry.ts
@@ -3,6 +3,13 @@ import { ValetError } from '@valet/shared';
 import type { Env, Variables } from '../env.js';
 import { recordRequestMetric, resolveSampleRate, shouldSample } from '../lib/request-telemetry.js';
 
+/** Parse a Content-Length header into a non-negative byte count, or null if absent/invalid. */
+function parseContentLength(value: string | undefined): number | null {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isInteger(n) && n >= 0 ? n : null;
+}
+
 /**
  * Times each REST API request and records its latency to `request_metrics`.
  *
@@ -38,6 +45,8 @@ export const requestTelemetry: MiddlewareHandler<{ Bindings: Env; Variables: Var
           route: c.req.routePath, // low-cardinality pattern, e.g. /api/sessions/:id
           status,
           durationMs,
+          requestId: c.get('requestId') ?? null, // pivots to the full request log
+          requestBytes: parseContentLength(c.req.header('content-length')),
           userId: c.get('user')?.id ?? null,
         };
         // c.get('db') is the per-request Drizzle instance set by dbMiddleware,

--- a/packages/worker/src/middleware/request-telemetry.ts
+++ b/packages/worker/src/middleware/request-telemetry.ts
@@ -1,0 +1,56 @@
+import type { MiddlewareHandler } from 'hono';
+import { ValetError } from '@valet/shared';
+import type { Env, Variables } from '../env.js';
+import { recordRequestMetric, resolveSampleRate, shouldSample } from '../lib/request-telemetry.js';
+
+/**
+ * Times each REST API request and records its latency to `request_metrics`.
+ *
+ * Scope is deliberately the `/api/*` surface — the synchronous latency real users
+ * wait on. The `/agent/*` proxy (long-lived IDE/VNC/terminal streams) would skew
+ * the distribution, and CORS preflights carry no useful signal.
+ *
+ * Recording is fire-and-forget via `ctx.waitUntil`, so it adds zero latency to the
+ * response it measures, and the whole emit path is guarded — telemetry must never
+ * break or slow the request it observes.
+ */
+export const requestTelemetry: MiddlewareHandler<{ Bindings: Env; Variables: Variables }> = async (c, next) => {
+  if (c.req.method === 'OPTIONS' || !c.req.path.startsWith('/api/')) {
+    return next();
+  }
+
+  const start = Date.now();
+  let status = 500;
+  try {
+    await next();
+    status = c.res.status;
+  } catch (err) {
+    // Thrown errors are rendered downstream by the error handler; capture the
+    // status they will resolve to, then rethrow so that handler still runs.
+    status = err instanceof ValetError ? err.statusCode : 500;
+    throw err;
+  } finally {
+    try {
+      const durationMs = Date.now() - start;
+      if (shouldSample(status, resolveSampleRate(c.env))) {
+        const entry = {
+          method: c.req.method,
+          route: c.req.routePath, // low-cardinality pattern, e.g. /api/sessions/:id
+          status,
+          durationMs,
+          userId: c.get('user')?.id ?? null,
+        };
+        // c.get('db') is the per-request Drizzle instance set by dbMiddleware,
+        // which runs inside next() and is therefore available here in finally.
+        c.executionCtx.waitUntil(
+          recordRequestMetric(c.get('db'), entry).catch((err) => {
+            console.error('[request-telemetry] failed to record request metric:', err);
+          }),
+        );
+      }
+    } catch (err) {
+      // Never let telemetry surface an error into the request path.
+      console.error('[request-telemetry] middleware error:', err);
+    }
+  }
+};

--- a/packages/worker/src/routes/analytics.ts
+++ b/packages/worker/src/routes/analytics.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import type { Env, Variables } from '../env.js';
-import type { AnalyticsPerformanceResponse, AnalyticsEventsResponse } from '@valet/shared';
+import type { AnalyticsPerformanceResponse, AnalyticsEventsResponse, RequestMetricsResponse } from '@valet/shared';
 import {
   getPercentiles,
   getPerfTrend,
@@ -10,6 +10,7 @@ import {
   getThroughputStats,
   getEventFeed,
 } from '../lib/db/analytics.js';
+import { getRequestLatency, getSlowRoutes } from '../lib/db/request-metrics.js';
 
 export const analyticsRouter = new Hono<{ Bindings: Env; Variables: Variables }>();
 
@@ -103,6 +104,47 @@ analyticsRouter.get('/events', async (c) => {
   const response: AnalyticsEventsResponse = {
     events: parsed,
     total,
+    period: periodHours,
+  };
+
+  return c.json(response);
+});
+
+// GET /api/analytics/requests?period=720
+// API request latency baseline: overall percentiles + slowest routes.
+analyticsRouter.get('/requests', async (c) => {
+  const user = c.get('user');
+  if (!user || user.role !== 'admin') {
+    return c.json({ error: 'Admin access required', code: 'FORBIDDEN' }, 403);
+  }
+
+  const rawPeriod = parseInt(c.req.query('period') || '720', 10);
+  const periodHours = Number.isFinite(rawPeriod) ? Math.min(Math.max(rawPeriod, 1), 8760) : 720;
+  const periodStart = new Date(Date.now() - periodHours * 60 * 60 * 1000).toISOString();
+
+  const db = c.get('db');
+
+  const [latency, routes] = await Promise.all([
+    getRequestLatency(db, periodStart),
+    getSlowRoutes(db, periodStart, 20),
+  ]);
+
+  const response: RequestMetricsResponse = {
+    hero: {
+      p50: latency.p50,
+      p95: latency.p95,
+      p99: latency.p99,
+      count: latency.count,
+      errorRate: latency.errorRate,
+    },
+    routes: routes.map((r) => ({
+      method: r.method,
+      route: r.route,
+      count: r.count,
+      p50: r.p50,
+      p95: r.p95,
+      errorRate: r.errorRate,
+    })),
     period: periodHours,
   };
 

--- a/packages/worker/src/routes/analytics.ts
+++ b/packages/worker/src/routes/analytics.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import type { Env, Variables } from '../env.js';
-import type { AnalyticsPerformanceResponse, AnalyticsEventsResponse, RequestMetricsResponse } from '@valet/shared';
+import type { AnalyticsPerformanceResponse, AnalyticsEventsResponse, RequestMetricsResponse, RequestForensicsResponse } from '@valet/shared';
 import {
   getPercentiles,
   getPerfTrend,
@@ -11,6 +11,7 @@ import {
   getEventFeed,
 } from '../lib/db/analytics.js';
 import { getRequestLatency, getSlowRoutes } from '../lib/db/request-metrics.js';
+import { getAccessDenials, getHeavyRequests, getSlowestRequests } from '../lib/db/request-forensics.js';
 
 export const analyticsRouter = new Hono<{ Bindings: Env; Variables: Variables }>();
 
@@ -145,6 +146,37 @@ analyticsRouter.get('/requests', async (c) => {
       p95: r.p95,
       errorRate: r.errorRate,
     })),
+    period: periodHours,
+  };
+
+  return c.json(response);
+});
+
+// GET /api/analytics/requests/forensics?period=720
+// Security + reliability investigation: authorization failures, heaviest
+// payloads, and slowest requests — each with a request_id to pivot into logs.
+analyticsRouter.get('/requests/forensics', async (c) => {
+  const user = c.get('user');
+  if (!user || user.role !== 'admin') {
+    return c.json({ error: 'Admin access required', code: 'FORBIDDEN' }, 403);
+  }
+
+  const rawPeriod = parseInt(c.req.query('period') || '720', 10);
+  const periodHours = Number.isFinite(rawPeriod) ? Math.min(Math.max(rawPeriod, 1), 8760) : 720;
+  const periodStart = new Date(Date.now() - periodHours * 60 * 60 * 1000).toISOString();
+
+  const db = c.get('db');
+
+  const [accessDenials, heavyRequests, slowestRequests] = await Promise.all([
+    getAccessDenials(db, periodStart, 20),
+    getHeavyRequests(db, periodStart, 10),
+    getSlowestRequests(db, periodStart, 10),
+  ]);
+
+  const response: RequestForensicsResponse = {
+    accessDenials,
+    heavyRequests,
+    slowestRequests,
     period: periodHours,
   };
 


### PR DESCRIPTION
## Problem

Valet instruments the **async agent path** (`turn_complete`, `sandbox_wake`, `llm_response`…) but the **synchronous HTTP API** — the surface real users hit and the front door for both data access and failures — had no queryable telemetry. `hono/logger` prints per-request timing to the console, where it can't be aggregated, percentiled, secured, or pivoted from.

This PR turns that surface into observable, forensic-grade telemetry. Two layers:

1. **Latency baseline** — what users wait on, and which routes are slow.
2. **Security + reliability forensics** — *who* pulled *what*, was it allowed, how big/slow was it, and a pivot into the full request log to see the **cause**.

## Layer 1 — latency baseline (commit 1)

| Layer | Where | What |
|---|---|---|
| Capture | `middleware/request-telemetry.ts` | Times each `/api/*` request; labels by **low-cardinality route pattern** (`c.req.routePath` → `/api/sessions/:id`). Fire-and-forget via `ctx.waitUntil` (**zero** added latency); sampled; fully guarded so telemetry can never break or slow the request it measures. |
| Store | `migrations/0017_request_metrics.sql` | `request_metrics` table, keyed by route (a different grain from the session-scoped `analytics_events`). 90-day nightly retention. |
| Query | `lib/db/request-metrics.ts` | `getRequestLatency` (p50/p95/p99 + 5xx rate), `getSlowRoutes` (per-route, slowest first). |
| API/UI | `routes/analytics.ts`, `api-latency-panel.tsx` | `GET /api/analytics/requests` (admin) → "API Request Latency" panel on the Performance tab. |

## Layer 2 — leakage + reliability forensics (commit 2)

**Information leakage has two surfaces.** This covers the **inbound** one — data pulled out via the API — by enriching each record with what an investigation needs, and adds query lenses + a **request_id pivot** into the full logs. (The **outbound** surface and the agent-path failure taxonomy are mapped under *Paved road* below.)

- **`request_id`** on every row → the *aggregate → pivot* workflow: spot a suspicious row, take its id, grep the Worker logs for the full request (headers/body/downstream calls) — the **cause**. The route stays a pattern (no raw ids), so the table is PII-light; the resource is recoverable via the pivot only when an investigation needs it.
- **`request_bytes`** (inbound `Content-Length`) → large-file / large-payload ingress.
- **Security-aware sampling** → 401/403 and 5xx are **always** recorded, so security signal survives aggressive perf sampling.
- **Lenses** at `GET /api/analytics/requests/forensics` → "Security & Reliability" panel:
  - **Access denials** — repeated 401/403 by actor + route (probing / broken object-level authorization = leakage *attempts*).
  - **Heaviest requests** — largest payloads + status (a 5xx here is the API-side symptom of *"can't parse large files"*).
  - **Slowest requests** — timeout-prone paths, each with a `request_id` to pivot.
- Runbook documented in `CLAUDE.md` → *API request forensics*.

## How this maps to the asks

- **"Understand the cause of information leakage."** Detect the access *pattern* (forbidden access, by actor/route) → pivot the `request_id` into the logs to see exactly what was returned. Auth failures are never sampled away.
- **"Catch why large files fail / sessions time out."** `request_bytes` + the heaviest-requests lens surface large-file ingress and whether it 5xx'd; the slowest-requests lens surfaces timeout-prone calls — each pivotable to the trace.

## Paved road (deliberately deferred, with the approach noted)

- **Egress byte metering** — the data-volume-out anomaly signal. `Content-Length` is absent on the response at middleware time, so this needs a counting `TransformStream` wrapping the response body; out of scope here because mutating the response path conflicts with "telemetry must never break a request."
- **Outbound leakage** — the agent → external integrations/LLM/MCP surface. `action_invocations` already records *which* action/service/actor/risk; enrich it with egress volume + outcome for a destination-level view.
- **Agent-path failure taxonomy** — session timeouts and file-parse failures originate in the DO/runner. Replace the generic `emitEvent('turn_error', { errorCode: 'agent_error' })` with reasons (`timeout`, `file_too_large`, `oom`) + context (file size, duration). The inbound `request_id` then correlates an API symptom to the agent-side root cause.

## Testing

End-to-end via the existing vitest harness (Node + in-memory SQLite), no live deploy required:

- **Units** — sampling (incl. 401/403/5xx always-kept) and percentile/error-rate math.
- **Data layer** — capture→store→query for latency percentiles + slow routes; and the three forensic lenses (access-denial grouping/ordering, heaviest excluding null sizes, slowest ordering).
- **Middleware integration** — real Hono app + in-memory Drizzle + fake `waitUntil`: asserts correct route/method/status, `request_id` + `request_bytes` capture, thrown handlers record 500, non-`/api` skipped, and a 403 recorded even at sample rate 0.

Verification: `tsc --build` clean · **707/707** worker tests (54 files) · client `tsc --noEmit && vite build` clean.
